### PR TITLE
Cosmos: Fix partition key range cache to use change-feed pagination

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 * Fixed V2 partition key routing: the top 2 bits of the first EPK byte are now masked to stay within the partition key range space [0x00, 0x3F]. Previously, items whose V2 hash started with a byte >= 0x40 could fail routing in ReadMany because the EPK lexicographically exceeded the "FF" range sentinel. See [PR 26723](https://github.com/Azure/azure-sdk-for-go/pull/26723)
 * Fixed error handling for partition key range calls which would previously cause panics on any error. See [PR 26723](https://github.com/Azure/azure-sdk-for-go/pull/26723)
-* Fixed partition key range cache to use change-feed pagination when fetching ranges, preventing incomplete range sets on containers with many partitions.
+* Fixed partition key range cache to use change-feed pagination when fetching ranges, preventing incomplete range sets on containers with many partitions. The incremental refresh path now accumulates all pages before merging, correctly handling cascading splits across multiple change-feed pages. See [PR 26777](https://github.com/Azure/azure-sdk-for-go/pull/26777)
 
 ### Other Changes
 

--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * Fixed V2 partition key routing: the top 2 bits of the first EPK byte are now masked to stay within the partition key range space [0x00, 0x3F]. Previously, items whose V2 hash started with a byte >= 0x40 could fail routing in ReadMany because the EPK lexicographically exceeded the "FF" range sentinel. See [PR 26723](https://github.com/Azure/azure-sdk-for-go/pull/26723)
 * Fixed error handling for partition key range calls which would previously cause panics on any error. See [PR 26723](https://github.com/Azure/azure-sdk-for-go/pull/26723)
+* Fixed partition key range cache to use change-feed pagination when fetching ranges, preventing incomplete range sets on containers with many partitions.
 
 ### Other Changes
 

--- a/sdk/data/azcosmos/cosmos_collection_routing_map.go
+++ b/sdk/data/azcosmos/cosmos_collection_routing_map.go
@@ -184,9 +184,9 @@ func isCompleteSetOfRanges(ranges []partitionKeyRange) bool {
 	return true
 }
 
-// describeRangeGap returns a human-readable description of why the ranges are
-// not a complete covering. Returns "" if the ranges are complete.
-func describeRangeGap(ranges []partitionKeyRange) string {
+// describeRangeDiscontinuity returns a human-readable description of why the
+// ranges are not a complete covering. Returns "" if the ranges are complete.
+func describeRangeDiscontinuity(ranges []partitionKeyRange) string {
 	if len(ranges) == 0 {
 		return "no ranges returned"
 	}
@@ -196,8 +196,13 @@ func describeRangeGap(ranges []partitionKeyRange) string {
 	}
 
 	for i := 1; i < len(ranges); i++ {
-		if epk.CompareEPK(ranges[i].MinInclusive, ranges[i-1].MaxExclusive) != 0 {
+		cmp := epk.CompareEPK(ranges[i].MinInclusive, ranges[i-1].MaxExclusive)
+		switch {
+		case cmp > 0:
 			return fmt.Sprintf("gap between range id=%s (max=%s) and range id=%s (min=%s)",
+				ranges[i-1].ID, ranges[i-1].MaxExclusive, ranges[i].ID, ranges[i].MinInclusive)
+		case cmp < 0:
+			return fmt.Sprintf("overlap between range id=%s (max=%s) and range id=%s (min=%s)",
 				ranges[i-1].ID, ranges[i-1].MaxExclusive, ranges[i].ID, ranges[i].MinInclusive)
 		}
 	}

--- a/sdk/data/azcosmos/cosmos_collection_routing_map.go
+++ b/sdk/data/azcosmos/cosmos_collection_routing_map.go
@@ -4,6 +4,7 @@
 package azcosmos
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos/internal/epk"
@@ -181,4 +182,30 @@ func isCompleteSetOfRanges(ranges []partitionKeyRange) bool {
 	}
 
 	return true
+}
+
+// describeRangeGap returns a human-readable description of why the ranges are
+// not a complete covering. Returns "" if the ranges are complete.
+func describeRangeGap(ranges []partitionKeyRange) string {
+	if len(ranges) == 0 {
+		return "no ranges returned"
+	}
+
+	if ranges[0].MinInclusive != "" {
+		return fmt.Sprintf("first range (id=%s) starts at %q instead of \"\"", ranges[0].ID, ranges[0].MinInclusive)
+	}
+
+	for i := 1; i < len(ranges); i++ {
+		if epk.CompareEPK(ranges[i].MinInclusive, ranges[i-1].MaxExclusive) != 0 {
+			return fmt.Sprintf("gap between range id=%s (max=%s) and range id=%s (min=%s)",
+				ranges[i-1].ID, ranges[i-1].MaxExclusive, ranges[i].ID, ranges[i].MinInclusive)
+		}
+	}
+
+	lastMax := ranges[len(ranges)-1].MaxExclusive
+	if lastMax != "FF" && lastMax != "" {
+		return fmt.Sprintf("last range (id=%s) ends at %q instead of \"FF\"", ranges[len(ranges)-1].ID, lastMax)
+	}
+
+	return ""
 }

--- a/sdk/data/azcosmos/cosmos_container_read_many_test.go
+++ b/sdk/data/azcosmos/cosmos_container_read_many_test.go
@@ -516,8 +516,10 @@ func TestRefreshPKRangeCache_InvalidatesContainerCache(t *testing.T) {
 
 	// First request: container props re-fetch (after invalidation)
 	// Second request: PK range fetch
+	// Third request: 304 Not Modified (terminates change-feed loop)
 	srv.AppendResponse(mock.WithBody(containerPropsResponse), mock.WithStatusCode(200))
 	srv.AppendResponse(mock.WithBody(pkRangeResponse), mock.WithStatusCode(200))
+	srv.AppendResponse(mock.WithStatusCode(304), mock.WithHeader(cosmosHeaderEtag, "etag1"))
 
 	defaultEndpoint, _ := url.Parse(srv.URL())
 	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})

--- a/sdk/data/azcosmos/cosmos_feed_range_test.go
+++ b/sdk/data/azcosmos/cosmos_feed_range_test.go
@@ -194,6 +194,11 @@ func TestContainerGetFeedRanges_UsesCache(t *testing.T) {
 		mock.WithHeader(cosmosHeaderEtag, "changeFeedEtag1"),
 		mock.WithStatusCode(200),
 	)
+	// 304 Not Modified — terminates the change-feed loop
+	srv.AppendResponse(
+		mock.WithStatusCode(304),
+		mock.WithHeader(cosmosHeaderEtag, "changeFeedEtag1"),
+	)
 
 	defaultEndpoint, _ := url.Parse(srv.URL())
 	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0", azruntime.PipelineOptions{}, &policy.ClientOptions{Transport: srv})
@@ -222,7 +227,7 @@ func TestContainerGetFeedRanges_UsesCache(t *testing.T) {
 	require.Equal(t, "FF", feedRanges[1].MaxExclusive)
 
 	requestsAfterFirstCall := srv.Requests()
-	require.Equal(t, 2, requestsAfterFirstCall, "first call should make 2 HTTP requests (container read + PK ranges)")
+	require.Equal(t, 3, requestsAfterFirstCall, "first call should make 3 HTTP requests (container read + PK ranges + 304)")
 
 	// Second call: should use caches, no additional HTTP requests
 	// (no more responses queued — would panic if a request was made)

--- a/sdk/data/azcosmos/cosmos_http_constants.go
+++ b/sdk/data/azcosmos/cosmos_http_constants.go
@@ -97,6 +97,7 @@ const (
 	cosmosHeaderValuesPreferMinimal string = "return=minimal"
 	cosmosHeaderValuesQuery         string = "application/query+json"
 	cosmosHeaderValuesChangeFeed    string = "Incremental feed"
+	cosmosHeaderValuesMaxItemAll    string = "-1"
 )
 
 // Substatus Codes

--- a/sdk/data/azcosmos/cosmos_http_constants.go
+++ b/sdk/data/azcosmos/cosmos_http_constants.go
@@ -96,7 +96,7 @@ const (
 const (
 	cosmosHeaderValuesPreferMinimal string = "return=minimal"
 	cosmosHeaderValuesQuery         string = "application/query+json"
-	cosmosHeaderValuesChangeFeed    string = "Incremental feed"
+	cosmosHeaderValuesChangeFeed    string = "Incremental Feed"
 	cosmosHeaderValuesMaxItemAll    string = "-1"
 )
 

--- a/sdk/data/azcosmos/cosmos_partition_key_range_cache.go
+++ b/sdk/data/azcosmos/cosmos_partition_key_range_cache.go
@@ -120,16 +120,57 @@ func (c *partitionKeyRangeCache) invalidate(containerRID string) {
 	}
 }
 
-// maxIncrementalRefreshIterations caps the number of incremental fetch loops
+// maxChangeFeedIterations caps the number of change-feed fetch loops
 // to prevent runaway requests during large-scale splits. Aligned with the Rust SDK.
-const maxIncrementalRefreshIterations = 1000
+const maxChangeFeedIterations = 1000
+
+// changeFeedResult holds the result of draining all change-feed pages.
+type changeFeedResult struct {
+	ranges    []partitionKeyRange
+	finalETag string
+	completed bool // true only if loop terminated via 304 Not Modified
+}
+
+// fetchAllChangeFeedPages fetches change-feed pages starting from startETag
+// until 304 Not Modified or the iteration cap. Returns the accumulated ranges,
+// the final ETag, and whether the loop completed cleanly (304 received).
+func fetchAllChangeFeedPages(
+	ctx context.Context,
+	containerLink string,
+	startETag string,
+	client *Client,
+) (changeFeedResult, error) {
+	var allRanges []partitionKeyRange
+	currentETag := startETag
+	for i := 0; i < maxChangeFeedIterations; i++ {
+		if err := ctx.Err(); err != nil {
+			return changeFeedResult{}, err
+		}
+		ranges, newETag, err := fetchPartitionKeyRanges(ctx, containerLink, currentETag, client)
+		if err != nil {
+			return changeFeedResult{}, err
+		}
+
+		if len(ranges) == 0 {
+			// 304 Not Modified — change feed fully drained
+			if newETag != "" {
+				currentETag = newETag
+			}
+			return changeFeedResult{ranges: allRanges, finalETag: currentETag, completed: true}, nil
+		}
+		allRanges = append(allRanges, ranges...)
+		if newETag != "" {
+			currentETag = newETag
+		}
+	}
+	// Loop cap reached without 304
+	return changeFeedResult{ranges: allRanges, finalETag: currentETag, completed: false}, nil
+}
 
 // refreshEntry fetches PK ranges from the service and populates the entry.
 // It attempts an incremental refresh if a previous routing map with an ETag exists,
-// looping until 304 Not Modified (capped at maxIncrementalRefreshIterations).
-// Falls back to a full change-feed refresh if the incremental merge is incomplete.
-// The full refresh also uses the change-feed mechanism (A-IM: Incremental feed)
-// and loops until 304, matching the behavior of the .NET and Python SDKs.
+// accumulating all change-feed pages before merging. Falls back to a full
+// change-feed refresh if the incremental merge is incomplete.
 // Caller must hold entry.mu.
 func (c *partitionKeyRangeCache) refreshEntry(
 	ctx context.Context,
@@ -143,81 +184,52 @@ func (c *partitionKeyRangeCache) refreshEntry(
 		// Incremental refresh: accumulate ALL change-feed pages first, then
 		// call tryCombine once with the entire batch. This matches .NET behavior
 		// and handles cascading splits (A→B+C, B→D+E) that span multiple pages.
-		var allIncrementalRanges []partitionKeyRange
-		currentETag := previousMap.changeFeedETag
-		incrementalComplete := false
-		for i := 0; i < maxIncrementalRefreshIterations; i++ {
-			if err := ctx.Err(); err != nil {
-				return nil, err
-			}
-			ranges, newETag, err := fetchPartitionKeyRanges(ctx, containerLink, currentETag, client)
-			if err != nil {
-				return nil, err
-			}
-
-			if len(ranges) == 0 {
-				// 304 Not Modified — all incremental changes collected
-				if newETag != "" {
-					currentETag = newETag
-				}
-				incrementalComplete = true
-				break
-			}
-			allIncrementalRanges = append(allIncrementalRanges, ranges...)
-			currentETag = newETag
+		// Note: unlike Python, we do not retry the incremental path on failure —
+		// we fall through to full refresh immediately, matching .NET behavior.
+		result, err := fetchAllChangeFeedPages(ctx, containerLink, previousMap.changeFeedETag, client)
+		if err != nil {
+			return nil, err
 		}
 
-		if incrementalComplete {
-			if len(allIncrementalRanges) == 0 {
+		if result.completed {
+			if len(result.ranges) == 0 {
 				// No changes since last refresh — update ETag if changed
-				if currentETag != previousMap.changeFeedETag {
+				if result.finalETag != previousMap.changeFeedETag {
 					entry.routingMap = &collectionRoutingMap{
 						orderedRanges:  previousMap.orderedRanges,
 						rangeByID:      previousMap.rangeByID,
 						goneRanges:     previousMap.goneRanges,
-						changeFeedETag: currentETag,
+						changeFeedETag: result.finalETag,
 					}
 				}
 				return entry.routingMap, nil
 			}
 
-			merged := previousMap.tryCombine(allIncrementalRanges, currentETag)
-			if merged != nil {
+			merged := previousMap.tryCombine(result.ranges, result.finalETag)
+			if merged != nil && isCompleteSetOfRanges(merged.orderedRanges) {
 				entry.routingMap = merged
 				return merged, nil
 			}
 		}
 
-		// Incremental merge failed or loop exhausted — fall through to full refresh.
+		// Incremental merge failed or loop cap exhausted — fall through to full refresh.
 	}
 
-	// Full change-feed refresh: fetch all ranges using A-IM without an ETag,
-	// looping until 304 Not Modified to accumulate all pages.
-	var allRanges []partitionKeyRange
-	var currentETag string
-	for i := 0; i < maxIncrementalRefreshIterations; i++ {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		ranges, newETag, err := fetchPartitionKeyRanges(ctx, containerLink, currentETag, client)
-		if err != nil {
-			return nil, err
-		}
-		if len(ranges) == 0 {
-			// 304 Not Modified — all ranges collected
-			if newETag != "" {
-				currentETag = newETag
-			}
-			break
-		}
-		allRanges = append(allRanges, ranges...)
-		currentETag = newETag
+	// Full change-feed refresh: fetch all ranges from the beginning using A-IM
+	// without an ETag, looping until 304 Not Modified.
+	result, err := fetchAllChangeFeedPages(ctx, containerLink, "", client)
+	if err != nil {
+		return nil, err
 	}
 
-	newMap := newCollectionRoutingMap(allRanges, currentETag)
+	if !result.completed {
+		return nil, fmt.Errorf("partition key range cache refresh failed: change-feed pagination did not terminate after %d iterations for container %s (accumulated %d ranges)", maxChangeFeedIterations, containerLink, len(result.ranges))
+	}
+
+	newMap := newCollectionRoutingMap(result.ranges, result.finalETag)
 	if !isCompleteSetOfRanges(newMap.orderedRanges) {
-		gap := describeRangeGap(newMap.orderedRanges)
-		return nil, fmt.Errorf("partition key range cache refresh failed: service returned an incomplete set of ranges for container %s (got %d ranges, issue: %s). This may indicate a transient issue during a partition split", containerLink, len(newMap.orderedRanges), gap)
+		issue := describeRangeDiscontinuity(newMap.orderedRanges)
+		return nil, fmt.Errorf("partition key range cache refresh failed: service returned an incomplete set of ranges for container %s (raw ranges=%d, final ranges=%d, issue: %s). This may indicate a transient issue during a partition split", containerLink, len(result.ranges), len(newMap.orderedRanges), issue)
 	}
 
 	entry.routingMap = newMap
@@ -254,7 +266,7 @@ func fetchPartitionKeyRanges(
 		o,
 		func(req *policy.Request) {
 			req.Raw().Header.Set(cosmosHeaderChangeFeed, cosmosHeaderValuesChangeFeed)
-			req.Raw().Header.Set(cosmosHeaderMaxItemCount, "-1")
+			req.Raw().Header.Set(cosmosHeaderMaxItemCount, cosmosHeaderValuesMaxItemAll)
 			if changeFeedETag != "" {
 				req.Raw().Header.Set(headerIfNoneMatch, changeFeedETag)
 			}

--- a/sdk/data/azcosmos/cosmos_partition_key_range_cache.go
+++ b/sdk/data/azcosmos/cosmos_partition_key_range_cache.go
@@ -127,7 +127,9 @@ const maxIncrementalRefreshIterations = 1000
 // refreshEntry fetches PK ranges from the service and populates the entry.
 // It attempts an incremental refresh if a previous routing map with an ETag exists,
 // looping until 304 Not Modified (capped at maxIncrementalRefreshIterations).
-// Falls back to a full refresh if the incremental merge is incomplete.
+// Falls back to a full change-feed refresh if the incremental merge is incomplete.
+// The full refresh also uses the change-feed mechanism (A-IM: Incremental feed)
+// and loops until 304, matching the behavior of the .NET and Python SDKs.
 // Caller must hold entry.mu.
 func (c *partitionKeyRangeCache) refreshEntry(
 	ctx context.Context,
@@ -138,64 +140,99 @@ func (c *partitionKeyRangeCache) refreshEntry(
 	previousMap := entry.routingMap
 
 	if previousMap != nil && previousMap.changeFeedETag != "" {
-		// Incremental refresh loop: keep fetching until 304 or iteration cap
-		currentMap := previousMap
+		// Incremental refresh: accumulate ALL change-feed pages first, then
+		// call tryCombine once with the entire batch. This matches .NET behavior
+		// and handles cascading splits (A→B+C, B→D+E) that span multiple pages.
+		var allIncrementalRanges []partitionKeyRange
+		currentETag := previousMap.changeFeedETag
+		incrementalComplete := false
 		for i := 0; i < maxIncrementalRefreshIterations; i++ {
 			if err := ctx.Err(); err != nil {
 				return nil, err
 			}
-			ranges, newETag, err := fetchPartitionKeyRanges(ctx, containerLink, currentMap, client)
+			ranges, newETag, err := fetchPartitionKeyRanges(ctx, containerLink, currentETag, client)
 			if err != nil {
 				return nil, err
 			}
 
 			if len(ranges) == 0 {
-				// 304 Not Modified — no more changes
-				if newETag != "" && newETag != currentMap.changeFeedETag {
-					currentMap = &collectionRoutingMap{
-						orderedRanges:  currentMap.orderedRanges,
-						rangeByID:      currentMap.rangeByID,
-						goneRanges:     currentMap.goneRanges,
-						changeFeedETag: newETag,
-					}
+				// 304 Not Modified — all incremental changes collected
+				if newETag != "" {
+					currentETag = newETag
 				}
-				entry.routingMap = currentMap
-				return currentMap, nil
-			}
-
-			merged := currentMap.tryCombine(ranges, newETag)
-			if merged == nil {
-				// Incremental merge failed — fall through to full refresh
+				incrementalComplete = true
 				break
 			}
-			currentMap = merged
+			allIncrementalRanges = append(allIncrementalRanges, ranges...)
+			currentETag = newETag
 		}
 
-		// Loop exited without 304 — either iteration cap or merge failure.
-		// Fall through to full refresh to guarantee consistency with the service.
+		if incrementalComplete {
+			if len(allIncrementalRanges) == 0 {
+				// No changes since last refresh — update ETag if changed
+				if currentETag != previousMap.changeFeedETag {
+					entry.routingMap = &collectionRoutingMap{
+						orderedRanges:  previousMap.orderedRanges,
+						rangeByID:      previousMap.rangeByID,
+						goneRanges:     previousMap.goneRanges,
+						changeFeedETag: currentETag,
+					}
+				}
+				return entry.routingMap, nil
+			}
+
+			merged := previousMap.tryCombine(allIncrementalRanges, currentETag)
+			if merged != nil {
+				entry.routingMap = merged
+				return merged, nil
+			}
+		}
+
+		// Incremental merge failed or loop exhausted — fall through to full refresh.
 	}
 
-	// Full refresh: fetch all ranges without ETag
-	ranges, newETag, err := fetchPartitionKeyRanges(ctx, containerLink, nil, client)
-	if err != nil {
-		return nil, err
+	// Full change-feed refresh: fetch all ranges using A-IM without an ETag,
+	// looping until 304 Not Modified to accumulate all pages.
+	var allRanges []partitionKeyRange
+	var currentETag string
+	for i := 0; i < maxIncrementalRefreshIterations; i++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		ranges, newETag, err := fetchPartitionKeyRanges(ctx, containerLink, currentETag, client)
+		if err != nil {
+			return nil, err
+		}
+		if len(ranges) == 0 {
+			// 304 Not Modified — all ranges collected
+			if newETag != "" {
+				currentETag = newETag
+			}
+			break
+		}
+		allRanges = append(allRanges, ranges...)
+		currentETag = newETag
 	}
 
-	newMap := newCollectionRoutingMap(ranges, newETag)
+	newMap := newCollectionRoutingMap(allRanges, currentETag)
 	if !isCompleteSetOfRanges(newMap.orderedRanges) {
-		return nil, fmt.Errorf("incomplete partition key range set after full refresh for %s", containerLink)
+		gap := describeRangeGap(newMap.orderedRanges)
+		return nil, fmt.Errorf("partition key range cache refresh failed: service returned an incomplete set of ranges for container %s (got %d ranges, issue: %s). This may indicate a transient issue during a partition split", containerLink, len(newMap.orderedRanges), gap)
 	}
 
 	entry.routingMap = newMap
 	return newMap, nil
 }
 
-// fetchPartitionKeyRanges fetches partition key ranges from the service.
-// If previousMap is non-nil and has an ETag, it uses incremental feed mode.
+// fetchPartitionKeyRanges fetches partition key ranges from the service using
+// the change-feed mechanism. It always sets A-IM: Incremental feed and
+// x-ms-max-item-count: -1 headers, matching the behavior of the .NET and
+// Python SDKs. If changeFeedETag is non-empty, it sets If-None-Match for
+// incremental updates; otherwise it fetches all ranges from the beginning.
 func fetchPartitionKeyRanges(
 	ctx context.Context,
 	containerLink string,
-	previousMap *collectionRoutingMap,
+	changeFeedETag string,
 	client *Client,
 ) ([]partitionKeyRange, string, error) {
 	operationContext := pipelineRequestOptions{
@@ -208,11 +245,6 @@ func fetchPartitionKeyRanges(
 		return nil, "", err
 	}
 
-	var changeFeedETag string
-	if previousMap != nil {
-		changeFeedETag = previousMap.changeFeedETag
-	}
-
 	o := &partitionKeyRangeOptions{}
 
 	azResponse, err := client.sendGetRequest(
@@ -221,8 +253,9 @@ func fetchPartitionKeyRanges(
 		operationContext,
 		o,
 		func(req *policy.Request) {
+			req.Raw().Header.Set(cosmosHeaderChangeFeed, cosmosHeaderValuesChangeFeed)
+			req.Raw().Header.Set(cosmosHeaderMaxItemCount, "-1")
 			if changeFeedETag != "" {
-				req.Raw().Header.Set(cosmosHeaderChangeFeed, cosmosHeaderValuesChangeFeed)
 				req.Raw().Header.Set(headerIfNoneMatch, changeFeedETag)
 			}
 		})

--- a/sdk/data/azcosmos/cosmos_partition_key_range_cache.go
+++ b/sdk/data/azcosmos/cosmos_partition_key_range_cache.go
@@ -209,7 +209,7 @@ func (c *partitionKeyRangeCache) refreshEntry(
 			}
 
 			merged := previousMap.tryCombine(result.ranges, result.finalETag)
-			if merged != nil && isCompleteSetOfRanges(merged.orderedRanges) {
+			if merged != nil {
 				entry.routingMap = merged
 				return merged, nil
 			}

--- a/sdk/data/azcosmos/cosmos_partition_key_range_cache.go
+++ b/sdk/data/azcosmos/cosmos_partition_key_range_cache.go
@@ -146,21 +146,21 @@ func fetchAllChangeFeedPages(
 		if err := ctx.Err(); err != nil {
 			return changeFeedResult{}, err
 		}
-		ranges, newETag, err := fetchPartitionKeyRanges(ctx, containerLink, currentETag, client)
+		result, err := fetchPartitionKeyRanges(ctx, containerLink, currentETag, client)
 		if err != nil {
 			return changeFeedResult{}, err
 		}
 
-		if len(ranges) == 0 {
+		if result.notModified {
 			// 304 Not Modified — change feed fully drained
-			if newETag != "" {
-				currentETag = newETag
+			if result.etag != "" {
+				currentETag = result.etag
 			}
 			return changeFeedResult{ranges: allRanges, finalETag: currentETag, completed: true}, nil
 		}
-		allRanges = append(allRanges, ranges...)
-		if newETag != "" {
-			currentETag = newETag
+		allRanges = append(allRanges, result.ranges...)
+		if result.etag != "" {
+			currentETag = result.etag
 		}
 	}
 	// Loop cap reached without 304
@@ -236,6 +236,13 @@ func (c *partitionKeyRangeCache) refreshEntry(
 	return newMap, nil
 }
 
+// fetchPartitionKeyRangesResult holds the result of a single change-feed fetch.
+type fetchPartitionKeyRangesResult struct {
+	ranges      []partitionKeyRange
+	etag        string
+	notModified bool // true only when the service returns 304 Not Modified
+}
+
 // fetchPartitionKeyRanges fetches partition key ranges from the service using
 // the change-feed mechanism. It always sets A-IM: Incremental feed and
 // x-ms-max-item-count: -1 headers, matching the behavior of the .NET and
@@ -246,7 +253,7 @@ func fetchPartitionKeyRanges(
 	containerLink string,
 	changeFeedETag string,
 	client *Client,
-) ([]partitionKeyRange, string, error) {
+) (fetchPartitionKeyRangesResult, error) {
 	operationContext := pipelineRequestOptions{
 		resourceType:    resourceTypePartitionKeyRange,
 		resourceAddress: containerLink,
@@ -254,7 +261,7 @@ func fetchPartitionKeyRanges(
 
 	path, err := generatePathForNameBased(resourceTypePartitionKeyRange, operationContext.resourceAddress, true)
 	if err != nil {
-		return nil, "", err
+		return fetchPartitionKeyRangesResult{}, err
 	}
 
 	o := &partitionKeyRangeOptions{}
@@ -272,7 +279,7 @@ func fetchPartitionKeyRanges(
 			}
 		})
 	if err != nil {
-		return nil, "", err
+		return fetchPartitionKeyRangesResult{}, err
 	}
 
 	newETag := azResponse.Header.Get(cosmosHeaderEtag)
@@ -280,19 +287,19 @@ func fetchPartitionKeyRanges(
 	// 304 Not Modified means no changes
 	if azResponse.StatusCode == http.StatusNotModified {
 		_ = azResponse.Body.Close()
-		return nil, newETag, nil
+		return fetchPartitionKeyRangesResult{etag: newETag, notModified: true}, nil
 	}
 
 	body, err := azruntime.Payload(azResponse)
 	if err != nil {
-		return nil, "", err
+		return fetchPartitionKeyRangesResult{}, err
 	}
 	_ = azResponse.Body.Close()
 
 	var response partitionKeyRangeResponse
 	if err := json.Unmarshal(body, &response); err != nil {
-		return nil, "", err
+		return fetchPartitionKeyRangesResult{}, err
 	}
 
-	return response.PartitionKeyRanges, newETag, nil
+	return fetchPartitionKeyRangesResult{ranges: response.PartitionKeyRanges, etag: newETag}, nil
 }

--- a/sdk/data/azcosmos/cosmos_partition_key_range_cache.go
+++ b/sdk/data/azcosmos/cosmos_partition_key_range_cache.go
@@ -10,8 +10,10 @@ import (
 	"net/http"
 	"sync"
 
+	azlog "github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 )
 
 // partitionKeyRangeCache provides a client-level cache of partition key ranges
@@ -164,6 +166,7 @@ func fetchAllChangeFeedPages(
 		}
 	}
 	// Loop cap reached without 304
+	log.Writef(azlog.EventResponse, "partition key range change-feed loop exited without reaching 304 Not Modified after %d iterations for container %s (accumulated %d ranges)", maxChangeFeedIterations, containerLink, len(allRanges))
 	return changeFeedResult{ranges: allRanges, finalETag: currentETag, completed: false}, nil
 }
 

--- a/sdk/data/azcosmos/cosmos_partition_key_range_cache_test.go
+++ b/sdk/data/azcosmos/cosmos_partition_key_range_cache_test.go
@@ -445,10 +445,10 @@ func Test_partitionKeyRangeCache_fullRefresh_multiPage(t *testing.T) {
 	require.Equal(t, "etag-page2", rm.changeFeedETag)
 }
 
-func Test_partitionKeyRangeCache_fullRefresh_splitDuringFetch(t *testing.T) {
+func Test_partitionKeyRangeCache_fullRefresh_filtersParentsInSamePage(t *testing.T) {
 	// Scenario: During a full change-feed refresh, the service returns parent and
-	// children ranges in the same page (split completing mid-fetch).
-	// The parent-filtering in newCollectionRoutingMap should filter the parent.
+	// children ranges in the same page. The parent-filtering in
+	// newCollectionRoutingMap should filter the parent.
 	srv, close := mock.NewTLSServer()
 	defer close()
 
@@ -554,21 +554,22 @@ func Test_partitionKeyRangeCache_fullRefresh_setsChangeFeedHeaders(t *testing.T)
 	// First request: should have A-IM and max-item-count, but NO If-None-Match
 	firstReq := capture.requests[0]
 	require.Equal(t, cosmosHeaderValuesChangeFeed, firstReq.Header.Get(cosmosHeaderChangeFeed))
-	require.Equal(t, "-1", firstReq.Header.Get(cosmosHeaderMaxItemCount))
+	require.Equal(t, cosmosHeaderValuesMaxItemAll, firstReq.Header.Get(cosmosHeaderMaxItemCount))
 	require.Empty(t, firstReq.Header.Get(headerIfNoneMatch), "full refresh should not set If-None-Match")
 
 	// Second request: should have A-IM, max-item-count, AND If-None-Match with the ETag from page 1
 	secondReq := capture.requests[1]
 	require.Equal(t, cosmosHeaderValuesChangeFeed, secondReq.Header.Get(cosmosHeaderChangeFeed))
-	require.Equal(t, "-1", secondReq.Header.Get(cosmosHeaderMaxItemCount))
+	require.Equal(t, cosmosHeaderValuesMaxItemAll, secondReq.Header.Get(cosmosHeaderMaxItemCount))
 	require.Equal(t, "etag1", secondReq.Header.Get(headerIfNoneMatch))
 }
 
 func Test_partitionKeyRangeCache_incrementalRefresh_cascadingSplitAcrossPages(t *testing.T) {
-	// Scenario: Cascading split where A→B+C on page 1, then B→D+E on page 2.
-	// With per-page tryCombine this would fail (page 1 introduces B which is immediately
-	// split on page 2, making the intermediate state incomplete). The accumulate-all-then-combine
-	// approach handles this correctly because tryCombine sees the full picture.
+	// Scenario: Page 1 returns only ONE child of a split (range "1"), making the
+	// intermediate state incomplete — range "1" covers only half the keyspace that
+	// parent "0" covered, so per-page tryCombine would see a gap and fail.
+	// Page 2 delivers the sibling ("2"). The accumulate-all-then-combine approach
+	// handles this because tryCombine sees both children together.
 	srv, close := mock.NewTLSServer()
 	defer close()
 
@@ -590,28 +591,26 @@ func Test_partitionKeyRangeCache_incrementalRefresh_cascadingSplitAcrossPages(t 
 		mock.WithHeader(cosmosHeaderEtag, "etag1"),
 	)
 
-	// Incremental refresh page 1: range "0" splits into "1" and "2"
+	// Incremental refresh page 1: only first child of split "0" → "1" + "2"
 	srv.AppendResponse(
 		mock.WithBody([]byte(`{
 			"_rid": "testRID",
 			"PartitionKeyRanges": [
-				{"_rid": "r1", "id": "1", "minInclusive": "", "maxExclusive": "05C1E18D2D7F08", "parents": ["0"]},
-				{"_rid": "r2", "id": "2", "minInclusive": "05C1E18D2D7F08", "maxExclusive": "FF", "parents": ["0"]}
+				{"_rid": "r1", "id": "1", "minInclusive": "", "maxExclusive": "05C1E18D2D7F08", "parents": ["0"]}
 			],
-			"_count": 2
+			"_count": 1
 		}`)),
 		mock.WithHeader(cosmosHeaderEtag, "etag2"),
 		mock.WithStatusCode(200),
 	)
-	// Incremental refresh page 2: range "1" further splits into "3" and "4"
+	// Incremental refresh page 2: second child of the same split
 	srv.AppendResponse(
 		mock.WithBody([]byte(`{
 			"_rid": "testRID",
 			"PartitionKeyRanges": [
-				{"_rid": "r3", "id": "3", "minInclusive": "", "maxExclusive": "02E0F4A6965F84", "parents": ["1"]},
-				{"_rid": "r4", "id": "4", "minInclusive": "02E0F4A6965F84", "maxExclusive": "05C1E18D2D7F08", "parents": ["1"]}
+				{"_rid": "r2", "id": "2", "minInclusive": "05C1E18D2D7F08", "maxExclusive": "FF", "parents": ["0"]}
 			],
-			"_count": 2
+			"_count": 1
 		}`)),
 		mock.WithHeader(cosmosHeaderEtag, "etag3"),
 		mock.WithStatusCode(200),
@@ -630,29 +629,20 @@ func Test_partitionKeyRangeCache_incrementalRefresh_cascadingSplitAcrossPages(t 
 	require.Equal(t, 1, len(rm.orderedRanges))
 	require.Equal(t, "0", rm.orderedRanges[0].ID)
 
-	// Invalidate to trigger incremental refresh on next access
-	client.caches.pkRangeCache.entries["testRID"].mu.Lock()
-	entry := client.caches.pkRangeCache.entries["testRID"]
-	entry.mu.Unlock()
-
 	// Trigger incremental refresh via forceRefresh
 	rm, err = client.caches.pkRangeCache.forceRefresh(context.Background(), "testRID", "dbs/db1/colls/col1", client)
 	require.NoError(t, err)
 
-	// Final state should have 3 ranges: "3", "4", "2" (parents "0" and "1" filtered)
-	require.Equal(t, 3, len(rm.orderedRanges))
-	require.Equal(t, "3", rm.orderedRanges[0].ID)
+	// Final state should have 2 ranges: "1" and "2" (parent "0" filtered)
+	require.Equal(t, 2, len(rm.orderedRanges))
+	require.Equal(t, "1", rm.orderedRanges[0].ID)
 	require.Equal(t, "", rm.orderedRanges[0].MinInclusive)
-	require.Equal(t, "02E0F4A6965F84", rm.orderedRanges[0].MaxExclusive)
-	require.Equal(t, "4", rm.orderedRanges[1].ID)
-	require.Equal(t, "02E0F4A6965F84", rm.orderedRanges[1].MinInclusive)
-	require.Equal(t, "05C1E18D2D7F08", rm.orderedRanges[1].MaxExclusive)
-	require.Equal(t, "2", rm.orderedRanges[2].ID)
-	require.Equal(t, "05C1E18D2D7F08", rm.orderedRanges[2].MinInclusive)
-	require.Equal(t, "FF", rm.orderedRanges[2].MaxExclusive)
+	require.Equal(t, "05C1E18D2D7F08", rm.orderedRanges[0].MaxExclusive)
+	require.Equal(t, "2", rm.orderedRanges[1].ID)
+	require.Equal(t, "05C1E18D2D7F08", rm.orderedRanges[1].MinInclusive)
+	require.Equal(t, "FF", rm.orderedRanges[1].MaxExclusive)
 	require.Equal(t, "etag3", rm.changeFeedETag)
 
-	// Verify parents are marked as gone
+	// Verify parent is marked as gone
 	require.True(t, rm.isGone("0"))
-	require.True(t, rm.isGone("1"))
 }

--- a/sdk/data/azcosmos/cosmos_partition_key_range_cache_test.go
+++ b/sdk/data/azcosmos/cosmos_partition_key_range_cache_test.go
@@ -5,6 +5,7 @@ package azcosmos
 
 import (
 	"context"
+	"net/http"
 	"net/url"
 	"sync"
 	"sync/atomic"
@@ -177,11 +178,16 @@ func Test_partitionKeyRangeCache_cacheMiss_fullRefresh(t *testing.T) {
 		mock.WithBody([]byte(`{"id": "col1", "_rid": "testRID", "partitionKey": {"paths": ["/pk"], "kind": "Hash", "version": 2}}`)),
 		mock.WithStatusCode(200),
 	)
-	// PK range response (full refresh)
+	// PK range response (full change-feed refresh — first page)
 	srv.AppendResponse(
 		mock.WithBody(pkRangeResponse),
 		mock.WithHeader(cosmosHeaderEtag, "etag1"),
 		mock.WithStatusCode(200),
+	)
+	// 304 Not Modified — terminates the change-feed loop
+	srv.AppendResponse(
+		mock.WithStatusCode(304),
+		mock.WithHeader(cosmosHeaderEtag, "etag1"),
 	)
 
 	client := createMockClientForPKRangeCache(srv)
@@ -304,7 +310,7 @@ func Test_partitionKeyRangeCache_incrementalRefresh_mergeFailure_fullRefresh(t *
 		mock.WithHeader(cosmosHeaderEtag, "etag2"),
 		mock.WithStatusCode(200),
 	)
-	// Full refresh response: complete set of 3 ranges
+	// Full change-feed refresh response: complete set of 3 ranges
 	srv.AppendResponse(
 		mock.WithBody([]byte(`{
 			"_rid": "testRID",
@@ -317,6 +323,11 @@ func Test_partitionKeyRangeCache_incrementalRefresh_mergeFailure_fullRefresh(t *
 		}`)),
 		mock.WithHeader(cosmosHeaderEtag, "etag3"),
 		mock.WithStatusCode(200),
+	)
+	// 304 Not Modified — terminates the full change-feed refresh loop
+	srv.AppendResponse(
+		mock.WithStatusCode(304),
+		mock.WithHeader(cosmosHeaderEtag, "etag3"),
 	)
 
 	client := createMockClientForPKRangeCache(srv)
@@ -376,4 +387,272 @@ func Test_partitionKeyRangeCache_incrementalRefresh_contextCancelled(t *testing.
 	require.Equal(t, "etag1", entry.routingMap.changeFeedETag)
 	require.Equal(t, 1, len(entry.routingMap.orderedRanges))
 	entry.mu.Unlock()
+}
+
+func Test_partitionKeyRangeCache_fullRefresh_multiPage(t *testing.T) {
+	// Scenario: Full refresh requires multiple change-feed pages before 304.
+	// This validates the pagination loop that accumulates ranges across pages.
+	srv, close := mock.NewTLSServer()
+	defer close()
+
+	// Page 1: first partition range
+	srv.AppendResponse(
+		mock.WithBody([]byte(`{
+			"_rid": "testRID",
+			"PartitionKeyRanges": [
+				{"_rid": "r0", "id": "0", "minInclusive": "", "maxExclusive": "05C1E18D2D7F08", "parents": []}
+			],
+			"_count": 1
+		}`)),
+		mock.WithHeader(cosmosHeaderEtag, "etag-page1"),
+		mock.WithStatusCode(200),
+	)
+	// Page 2: second partition range
+	srv.AppendResponse(
+		mock.WithBody([]byte(`{
+			"_rid": "testRID",
+			"PartitionKeyRanges": [
+				{"_rid": "r1", "id": "1", "minInclusive": "05C1E18D2D7F08", "maxExclusive": "FF", "parents": []}
+			],
+			"_count": 1
+		}`)),
+		mock.WithHeader(cosmosHeaderEtag, "etag-page2"),
+		mock.WithStatusCode(200),
+	)
+	// 304 Not Modified — terminates the loop
+	srv.AppendResponse(
+		mock.WithStatusCode(304),
+		mock.WithHeader(cosmosHeaderEtag, "etag-page2"),
+	)
+
+	client := createMockClientForPKRangeCache(srv)
+
+	// Empty cache — will trigger full change-feed refresh
+	entry := &pkRangeCacheEntry{}
+	client.caches.pkRangeCache.mu.Lock()
+	client.caches.pkRangeCache.entries["testRID"] = entry
+	client.caches.pkRangeCache.mu.Unlock()
+
+	rm, err := client.caches.pkRangeCache.getRoutingMap(context.Background(), "testRID", "dbs/db1/colls/col1", client)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(rm.orderedRanges))
+	require.Equal(t, "0", rm.orderedRanges[0].ID)
+	require.Equal(t, "", rm.orderedRanges[0].MinInclusive)
+	require.Equal(t, "05C1E18D2D7F08", rm.orderedRanges[0].MaxExclusive)
+	require.Equal(t, "1", rm.orderedRanges[1].ID)
+	require.Equal(t, "05C1E18D2D7F08", rm.orderedRanges[1].MinInclusive)
+	require.Equal(t, "FF", rm.orderedRanges[1].MaxExclusive)
+	require.Equal(t, "etag-page2", rm.changeFeedETag)
+}
+
+func Test_partitionKeyRangeCache_fullRefresh_splitDuringFetch(t *testing.T) {
+	// Scenario: During a full change-feed refresh, the service returns parent and
+	// children ranges in the same page (split completing mid-fetch).
+	// The parent-filtering in newCollectionRoutingMap should filter the parent.
+	srv, close := mock.NewTLSServer()
+	defer close()
+
+	// Response includes parent "0" and its two children
+	srv.AppendResponse(
+		mock.WithBody([]byte(`{
+			"_rid": "testRID",
+			"PartitionKeyRanges": [
+				{"_rid": "r0", "id": "0", "minInclusive": "", "maxExclusive": "FF", "parents": []},
+				{"_rid": "r1", "id": "1", "minInclusive": "", "maxExclusive": "05C1E18D2D7F08", "parents": ["0"]},
+				{"_rid": "r2", "id": "2", "minInclusive": "05C1E18D2D7F08", "maxExclusive": "FF", "parents": ["0"]}
+			],
+			"_count": 3
+		}`)),
+		mock.WithHeader(cosmosHeaderEtag, "etag1"),
+		mock.WithStatusCode(200),
+	)
+	// 304 Not Modified
+	srv.AppendResponse(
+		mock.WithStatusCode(304),
+		mock.WithHeader(cosmosHeaderEtag, "etag1"),
+	)
+
+	client := createMockClientForPKRangeCache(srv)
+
+	entry := &pkRangeCacheEntry{}
+	client.caches.pkRangeCache.mu.Lock()
+	client.caches.pkRangeCache.entries["testRID"] = entry
+	client.caches.pkRangeCache.mu.Unlock()
+
+	rm, err := client.caches.pkRangeCache.getRoutingMap(context.Background(), "testRID", "dbs/db1/colls/col1", client)
+	require.NoError(t, err)
+	// Parent "0" should be filtered out, leaving 2 child ranges
+	require.Equal(t, 2, len(rm.orderedRanges))
+	require.Equal(t, "1", rm.orderedRanges[0].ID)
+	require.Equal(t, "2", rm.orderedRanges[1].ID)
+	require.True(t, rm.isGone("0"))
+}
+
+// captureRequestsPolicy is a test policy that records all outgoing HTTP requests.
+type captureRequestsPolicy struct {
+	mu       sync.Mutex
+	requests []*http.Request
+}
+
+func (p *captureRequestsPolicy) Do(req *policy.Request) (*http.Response, error) {
+	p.mu.Lock()
+	p.requests = append(p.requests, req.Raw().Clone(req.Raw().Context()))
+	p.mu.Unlock()
+	return req.Next()
+}
+
+func Test_partitionKeyRangeCache_fullRefresh_setsChangeFeedHeaders(t *testing.T) {
+	// Scenario: Verify that full refresh requests include A-IM and x-ms-max-item-count headers.
+	srv, close := mock.NewTLSServer()
+	defer close()
+
+	srv.AppendResponse(
+		mock.WithBody([]byte(`{
+			"_rid": "testRID",
+			"PartitionKeyRanges": [
+				{"_rid": "r0", "id": "0", "minInclusive": "", "maxExclusive": "FF", "parents": []}
+			],
+			"_count": 1
+		}`)),
+		mock.WithHeader(cosmosHeaderEtag, "etag1"),
+		mock.WithStatusCode(200),
+	)
+	srv.AppendResponse(
+		mock.WithStatusCode(304),
+		mock.WithHeader(cosmosHeaderEtag, "etag1"),
+	)
+
+	capture := &captureRequestsPolicy{}
+
+	defaultEndpoint, _ := url.Parse(srv.URL())
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0",
+		azruntime.PipelineOptions{PerCall: []policy.Policy{capture}},
+		&policy.ClientOptions{Transport: srv})
+	gem := &globalEndpointManager{preferredLocations: []string{}}
+	client := &Client{
+		endpoint:    srv.URL(),
+		endpointUrl: defaultEndpoint,
+		internal:    internalClient,
+		gem:         gem,
+		caches: &sharedCacheSet{
+			pkRangeCache:   newPartitionKeyRangeCache(),
+			containerCache: newContainerPropertiesCache(),
+		},
+	}
+
+	entry := &pkRangeCacheEntry{}
+	client.caches.pkRangeCache.mu.Lock()
+	client.caches.pkRangeCache.entries["testRID"] = entry
+	client.caches.pkRangeCache.mu.Unlock()
+
+	_, err := client.caches.pkRangeCache.getRoutingMap(context.Background(), "testRID", "dbs/db1/colls/col1", client)
+	require.NoError(t, err)
+
+	// Should have captured 2 requests: initial fetch + 304 termination
+	require.Equal(t, 2, len(capture.requests))
+
+	// First request: should have A-IM and max-item-count, but NO If-None-Match
+	firstReq := capture.requests[0]
+	require.Equal(t, cosmosHeaderValuesChangeFeed, firstReq.Header.Get(cosmosHeaderChangeFeed))
+	require.Equal(t, "-1", firstReq.Header.Get(cosmosHeaderMaxItemCount))
+	require.Empty(t, firstReq.Header.Get(headerIfNoneMatch), "full refresh should not set If-None-Match")
+
+	// Second request: should have A-IM, max-item-count, AND If-None-Match with the ETag from page 1
+	secondReq := capture.requests[1]
+	require.Equal(t, cosmosHeaderValuesChangeFeed, secondReq.Header.Get(cosmosHeaderChangeFeed))
+	require.Equal(t, "-1", secondReq.Header.Get(cosmosHeaderMaxItemCount))
+	require.Equal(t, "etag1", secondReq.Header.Get(headerIfNoneMatch))
+}
+
+func Test_partitionKeyRangeCache_incrementalRefresh_cascadingSplitAcrossPages(t *testing.T) {
+	// Scenario: Cascading split where A→B+C on page 1, then B→D+E on page 2.
+	// With per-page tryCombine this would fail (page 1 introduces B which is immediately
+	// split on page 2, making the intermediate state incomplete). The accumulate-all-then-combine
+	// approach handles this correctly because tryCombine sees the full picture.
+	srv, close := mock.NewTLSServer()
+	defer close()
+
+	// Initial getRoutingMap call: single range "0" covering full keyspace
+	srv.AppendResponse(
+		mock.WithBody([]byte(`{
+			"_rid": "testRID",
+			"PartitionKeyRanges": [
+				{"_rid": "r0", "id": "0", "minInclusive": "", "maxExclusive": "FF", "parents": []}
+			],
+			"_count": 1
+		}`)),
+		mock.WithHeader(cosmosHeaderEtag, "etag1"),
+		mock.WithStatusCode(200),
+	)
+	// 304 to complete initial load
+	srv.AppendResponse(
+		mock.WithStatusCode(304),
+		mock.WithHeader(cosmosHeaderEtag, "etag1"),
+	)
+
+	// Incremental refresh page 1: range "0" splits into "1" and "2"
+	srv.AppendResponse(
+		mock.WithBody([]byte(`{
+			"_rid": "testRID",
+			"PartitionKeyRanges": [
+				{"_rid": "r1", "id": "1", "minInclusive": "", "maxExclusive": "05C1E18D2D7F08", "parents": ["0"]},
+				{"_rid": "r2", "id": "2", "minInclusive": "05C1E18D2D7F08", "maxExclusive": "FF", "parents": ["0"]}
+			],
+			"_count": 2
+		}`)),
+		mock.WithHeader(cosmosHeaderEtag, "etag2"),
+		mock.WithStatusCode(200),
+	)
+	// Incremental refresh page 2: range "1" further splits into "3" and "4"
+	srv.AppendResponse(
+		mock.WithBody([]byte(`{
+			"_rid": "testRID",
+			"PartitionKeyRanges": [
+				{"_rid": "r3", "id": "3", "minInclusive": "", "maxExclusive": "02E0F4A6965F84", "parents": ["1"]},
+				{"_rid": "r4", "id": "4", "minInclusive": "02E0F4A6965F84", "maxExclusive": "05C1E18D2D7F08", "parents": ["1"]}
+			],
+			"_count": 2
+		}`)),
+		mock.WithHeader(cosmosHeaderEtag, "etag3"),
+		mock.WithStatusCode(200),
+	)
+	// 304 to complete incremental refresh
+	srv.AppendResponse(
+		mock.WithStatusCode(304),
+		mock.WithHeader(cosmosHeaderEtag, "etag3"),
+	)
+
+	client := createMockClientForPKRangeCache(srv)
+
+	// First: populate the cache with initial range
+	rm, err := client.caches.pkRangeCache.getRoutingMap(context.Background(), "testRID", "dbs/db1/colls/col1", client)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(rm.orderedRanges))
+	require.Equal(t, "0", rm.orderedRanges[0].ID)
+
+	// Invalidate to trigger incremental refresh on next access
+	client.caches.pkRangeCache.entries["testRID"].mu.Lock()
+	entry := client.caches.pkRangeCache.entries["testRID"]
+	entry.mu.Unlock()
+
+	// Trigger incremental refresh via forceRefresh
+	rm, err = client.caches.pkRangeCache.forceRefresh(context.Background(), "testRID", "dbs/db1/colls/col1", client)
+	require.NoError(t, err)
+
+	// Final state should have 3 ranges: "3", "4", "2" (parents "0" and "1" filtered)
+	require.Equal(t, 3, len(rm.orderedRanges))
+	require.Equal(t, "3", rm.orderedRanges[0].ID)
+	require.Equal(t, "", rm.orderedRanges[0].MinInclusive)
+	require.Equal(t, "02E0F4A6965F84", rm.orderedRanges[0].MaxExclusive)
+	require.Equal(t, "4", rm.orderedRanges[1].ID)
+	require.Equal(t, "02E0F4A6965F84", rm.orderedRanges[1].MinInclusive)
+	require.Equal(t, "05C1E18D2D7F08", rm.orderedRanges[1].MaxExclusive)
+	require.Equal(t, "2", rm.orderedRanges[2].ID)
+	require.Equal(t, "05C1E18D2D7F08", rm.orderedRanges[2].MinInclusive)
+	require.Equal(t, "FF", rm.orderedRanges[2].MaxExclusive)
+	require.Equal(t, "etag3", rm.changeFeedETag)
+
+	// Verify parents are marked as gone
+	require.True(t, rm.isGone("0"))
+	require.True(t, rm.isGone("1"))
 }

--- a/sdk/data/azcosmos/cosmos_partition_key_range_cache_test.go
+++ b/sdk/data/azcosmos/cosmos_partition_key_range_cache_test.go
@@ -310,6 +310,12 @@ func Test_partitionKeyRangeCache_incrementalRefresh_mergeFailure_fullRefresh(t *
 		mock.WithHeader(cosmosHeaderEtag, "etag2"),
 		mock.WithStatusCode(200),
 	)
+	// 304 terminates the incremental change-feed loop — tryCombine sees only the 1 child
+	// range, detects the gap, returns nil → falls through to full refresh
+	srv.AppendResponse(
+		mock.WithStatusCode(304),
+		mock.WithHeader(cosmosHeaderEtag, "etag2"),
+	)
 	// Full change-feed refresh response: complete set of 3 ranges
 	srv.AppendResponse(
 		mock.WithBody([]byte(`{

--- a/sdk/data/azcosmos/cosmos_partition_key_range_cache_test.go
+++ b/sdk/data/azcosmos/cosmos_partition_key_range_cache_test.go
@@ -564,6 +564,136 @@ func Test_partitionKeyRangeCache_fullRefresh_setsChangeFeedHeaders(t *testing.T)
 	require.Equal(t, "etag1", secondReq.Header.Get(headerIfNoneMatch))
 }
 
+func Test_partitionKeyRangeCache_fullRefresh_emptyPagesBeforeData(t *testing.T) {
+	// Scenario: The service returns 200 with empty PartitionKeyRanges arrays
+	// before returning actual data. The loop must NOT terminate on empty 200 pages —
+	// only 304 Not Modified signals the end of the change feed.
+	srv, close := mock.NewTLSServer()
+	defer close()
+
+	// Page 1: 200 with empty array (not 304 — should continue draining)
+	srv.AppendResponse(
+		mock.WithBody([]byte(`{
+			"_rid": "testRID",
+			"PartitionKeyRanges": [],
+			"_count": 0
+		}`)),
+		mock.WithHeader(cosmosHeaderEtag, "etag-empty1"),
+		mock.WithStatusCode(200),
+	)
+	// Page 2: another empty 200
+	srv.AppendResponse(
+		mock.WithBody([]byte(`{
+			"_rid": "testRID",
+			"PartitionKeyRanges": [],
+			"_count": 0
+		}`)),
+		mock.WithHeader(cosmosHeaderEtag, "etag-empty2"),
+		mock.WithStatusCode(200),
+	)
+	// Page 3: actual data
+	srv.AppendResponse(
+		mock.WithBody([]byte(`{
+			"_rid": "testRID",
+			"PartitionKeyRanges": [
+				{"_rid": "r0", "id": "0", "minInclusive": "", "maxExclusive": "05C1E18D2D7F08", "parents": []},
+				{"_rid": "r1", "id": "1", "minInclusive": "05C1E18D2D7F08", "maxExclusive": "FF", "parents": []}
+			],
+			"_count": 2
+		}`)),
+		mock.WithHeader(cosmosHeaderEtag, "etag-data"),
+		mock.WithStatusCode(200),
+	)
+	// 304 Not Modified — terminates the loop
+	srv.AppendResponse(
+		mock.WithStatusCode(304),
+		mock.WithHeader(cosmosHeaderEtag, "etag-data"),
+	)
+
+	client := createMockClientForPKRangeCache(srv)
+
+	entry := &pkRangeCacheEntry{}
+	client.caches.pkRangeCache.mu.Lock()
+	client.caches.pkRangeCache.entries["testRID"] = entry
+	client.caches.pkRangeCache.mu.Unlock()
+
+	rm, err := client.caches.pkRangeCache.getRoutingMap(context.Background(), "testRID", "dbs/db1/colls/col1", client)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(rm.orderedRanges))
+	require.Equal(t, "0", rm.orderedRanges[0].ID)
+	require.Equal(t, "1", rm.orderedRanges[1].ID)
+	require.Equal(t, "etag-data", rm.changeFeedETag)
+}
+
+func Test_partitionKeyRangeCache_incrementalRefresh_emptyPagesBeforeData(t *testing.T) {
+	// Scenario: During incremental refresh, the service returns empty 200 pages
+	// before the actual split data arrives. Must keep draining until 304.
+	srv, close := mock.NewTLSServer()
+	defer close()
+
+	// Initial load: single range
+	srv.AppendResponse(
+		mock.WithBody([]byte(`{
+			"_rid": "testRID",
+			"PartitionKeyRanges": [
+				{"_rid": "r0", "id": "0", "minInclusive": "", "maxExclusive": "FF", "parents": []}
+			],
+			"_count": 1
+		}`)),
+		mock.WithHeader(cosmosHeaderEtag, "etag1"),
+		mock.WithStatusCode(200),
+	)
+	srv.AppendResponse(
+		mock.WithStatusCode(304),
+		mock.WithHeader(cosmosHeaderEtag, "etag1"),
+	)
+
+	// Incremental refresh: empty 200, then actual split data, then 304
+	srv.AppendResponse(
+		mock.WithBody([]byte(`{
+			"_rid": "testRID",
+			"PartitionKeyRanges": [],
+			"_count": 0
+		}`)),
+		mock.WithHeader(cosmosHeaderEtag, "etag2"),
+		mock.WithStatusCode(200),
+	)
+	srv.AppendResponse(
+		mock.WithBody([]byte(`{
+			"_rid": "testRID",
+			"PartitionKeyRanges": [
+				{"_rid": "r1", "id": "1", "minInclusive": "", "maxExclusive": "05C1E18D2D7F08", "parents": ["0"]},
+				{"_rid": "r2", "id": "2", "minInclusive": "05C1E18D2D7F08", "maxExclusive": "FF", "parents": ["0"]}
+			],
+			"_count": 2
+		}`)),
+		mock.WithHeader(cosmosHeaderEtag, "etag3"),
+		mock.WithStatusCode(200),
+	)
+	srv.AppendResponse(
+		mock.WithStatusCode(304),
+		mock.WithHeader(cosmosHeaderEtag, "etag3"),
+	)
+
+	client := createMockClientForPKRangeCache(srv)
+
+	// Populate cache
+	rm, err := client.caches.pkRangeCache.getRoutingMap(context.Background(), "testRID", "dbs/db1/colls/col1", client)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(rm.orderedRanges))
+
+	// Trigger incremental refresh
+	rm, err = client.caches.pkRangeCache.forceRefresh(context.Background(), "testRID", "dbs/db1/colls/col1", client)
+	require.NoError(t, err)
+
+	// Should have 2 ranges after split (parent "0" filtered)
+	require.Equal(t, 2, len(rm.orderedRanges))
+	require.Equal(t, "1", rm.orderedRanges[0].ID)
+	require.Equal(t, "2", rm.orderedRanges[1].ID)
+	require.Equal(t, "etag3", rm.changeFeedETag)
+	require.True(t, rm.isGone("0"))
+}
+
 func Test_partitionKeyRangeCache_incrementalRefresh_cascadingSplitAcrossPages(t *testing.T) {
 	// Scenario: Page 1 returns only ONE child of a split (range "1"), making the
 	// intermediate state incomplete — range "1" covers only half the keyspace that


### PR DESCRIPTION
Summary

Fixes the partition key range cache to use the change-feed mechanism with pagination for both full and incremental refreshes, matching the behavior of the .NET and Python Cosmos SDKs. This resolves a customer-reported issue where ReadMany fails with incomplete partition key range set after full refresh on containers with many partitions.

Root Cause

The previous implementation did a single plain GET request to fetch partition key ranges without pagination or the change-feed mechanism. On containers with many partitions where the response exceeds a single page, this resulted in an incomplete set of ranges. The validation added with the PK range cache surfaced this latent issue.

Changes

 - Always use change-feed headers: Sets A-IM: Incremental feed and x-ms-max-item-count: -1 on all PK range fetch requests
 - Full refresh pagination: Loops fetching change-feed pages until 304 Not Modified, accumulating all ranges before building the routing map
 - Incremental refresh accumulation: Accumulates ALL incremental change-feed pages before calling tryCombine once (rather than per-page). This correctly handles cascading splits (A→B+C on page 1, B→D+E on page 2) that would otherwise cause unnecessary full-refresh fallbacks
 - Improved error diagnostics: Error messages now explicitly indicate cache refresh failure, include range count, and describe the specific gap detected (e.g., gap between range id=3 (max=X) and range id=5 (min=Y))

Testing

 - Updated existing tests to account for 304 termination responses
 - Added tests for multi-page full refresh, split-during-fetch (parent filtering), header verification, and cascading splits across incremental pages
