### PR TITLE
[Storage] Add Structured Message CRC64 content validation for blob upload and download

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.8.0-beta.2 (Unreleased)
 
 ### Features Added
+* Added support for Structured Message CRC64 content validation on upload and download operations using `TransferValidationTypeComputeStructuredMessageCRC64`.
 
 ### Breaking Changes
 

--- a/sdk/storage/azblob/appendblob/client.go
+++ b/sdk/storage/azblob/appendblob/client.go
@@ -173,7 +173,11 @@ func (ab *Client) AppendBlock(ctx context.Context, body io.ReadSeekCloser, o *Ap
 	if o != nil && o.TransactionalValidation != nil {
 		body, err = o.TransactionalValidation.Apply(body, appendOptions)
 		if err != nil {
-			return AppendBlockResponse{}, nil
+			return AppendBlockResponse{}, err
+		}
+		count, err = shared.ValidateSeekableStreamAt0AndGetCount(body)
+		if err != nil {
+			return AppendBlockResponse{}, err
 		}
 	}
 

--- a/sdk/storage/azblob/appendblob/client_test.go
+++ b/sdk/storage/azblob/appendblob/client_test.go
@@ -4001,6 +4001,37 @@ func (s *AppendBlobUnrecordedTestsSuite) TestAppendBlockWithStructuredMessageCRC
 	_require.Equal(content, downloadedData)
 }
 
+func (s *AppendBlobUnrecordedTestsSuite) TestAppendBlockUploadDownloadRoundtripWithStructuredMessageCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	abClient := testcommon.CreateNewAppendBlob(context.Background(), _require, testcommon.GenerateBlobName(testName), containerClient)
+
+	_, content := testcommon.GetDataAndReader(testName, 8*1024)
+
+	// Upload with SM CRC64
+	_, err = abClient.AppendBlock(context.Background(), streaming.NopCloser(bytes.NewReader(content)), &appendblob.AppendBlockOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	// Download with SM CRC64 validation
+	downloadResp, err := abClient.BlobClient().DownloadStream(context.Background(), &blob.DownloadStreamOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(content, downloadedData)
+}
+
 func (s *AppendBlobUnrecordedTestsSuite) TestAppendBlockMultipleWithStructuredMessageCRC64() {
 	_require := require.New(s.T())
 	testName := s.T().Name()

--- a/sdk/storage/azblob/appendblob/client_test.go
+++ b/sdk/storage/azblob/appendblob/client_test.go
@@ -16,6 +16,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -4036,6 +4037,6 @@ func (s *AppendBlobUnrecordedTestsSuite) TestAppendBlockMultipleWithStructuredMe
 	downloadedData, err := io.ReadAll(downloadResp.Body)
 	_require.NoError(err)
 
-	expectedData := append(block1, block2...)
+	expectedData := slices.Concat(block1, block2)
 	_require.Equal(expectedData, downloadedData)
 }

--- a/sdk/storage/azblob/appendblob/client_test.go
+++ b/sdk/storage/azblob/appendblob/client_test.go
@@ -3971,3 +3971,71 @@ func (s *AppendBlobUnrecordedTestsSuite) TestUserDelegationSASWithDelegatedUserT
 	enc := qp.Encode()
 	_require.Contains(enc, "skdutid="+skdutid)
 }
+
+func (s *AppendBlobUnrecordedTestsSuite) TestAppendBlockWithStructuredMessageCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	abClient := testcommon.CreateNewAppendBlob(context.Background(), _require, testcommon.GenerateBlobName(testName), containerClient)
+
+	_, content := testcommon.GetDataAndReader(testName, 4*1024)
+
+	_, err = abClient.AppendBlock(context.Background(), streaming.NopCloser(bytes.NewReader(content)), &appendblob.AppendBlockOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	// Download and verify data
+	downloadResp, err := abClient.BlobClient().DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(content, downloadedData)
+}
+
+func (s *AppendBlobUnrecordedTestsSuite) TestAppendBlockMultipleWithStructuredMessageCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	abClient := testcommon.CreateNewAppendBlob(context.Background(), _require, testcommon.GenerateBlobName(testName), containerClient)
+
+	// Append two blocks with SM validation
+	_, block1 := testcommon.GetDataAndReader(testName+"block1", 4*1024)
+	block2 := make([]byte, 4*1024)
+	for i := range block2 {
+		block2[i] = byte((i + 100) % 251)
+	}
+
+	_, err = abClient.AppendBlock(context.Background(), streaming.NopCloser(bytes.NewReader(block1)), &appendblob.AppendBlockOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	_, err = abClient.AppendBlock(context.Background(), streaming.NopCloser(bytes.NewReader(block2)), &appendblob.AppendBlockOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	// Download and verify both blocks
+	downloadResp, err := abClient.BlobClient().DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+
+	expectedData := append(block1, block2...)
+	_require.Equal(expectedData, downloadedData)
+}

--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_57b9218859"
+  "Tag": "go/storage/azblob_5461f135f4"
 }

--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_8c3f6f5553"
+  "Tag": "go/storage/azblob_57b9218859"
 }

--- a/sdk/storage/azblob/blob/client.go
+++ b/sdk/storage/azblob/blob/client.go
@@ -5,6 +5,7 @@ package blob
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"sync"
@@ -389,7 +390,11 @@ func (b *Client) downloadBuffer(ctx context.Context, writer io.WriterAt, o downl
 				return err
 			}
 			if computeReadLength {
-				atomic.AddInt64(&dataDownloaded, *dr.ContentLength)
+				if dr.ContentRange != nil {
+					atomic.AddInt64(&dataDownloaded, parseContentRangeLength(*dr.ContentRange))
+				} else {
+					atomic.AddInt64(&dataDownloaded, *dr.ContentLength)
+				}
 			}
 			err = body.Close()
 			return err
@@ -414,13 +419,20 @@ func (b *Client) DownloadStream(ctx context.Context, o *DownloadStreamOptions) (
 		return DownloadStreamResponse{}, err
 	}
 
+	// If the response contains a structured message body, wrap it with SMDecoder
+	// to validate CRC64 checksums and extract the raw data.
+	if dr.StructuredBodyType != nil && *dr.StructuredBodyType != "" {
+		dr.Body = shared.NewSMDecoder(dr.Body)
+	}
+
 	return DownloadStreamResponse{
-		client:                 b,
-		DownloadResponse:       dr,
-		getInfo:                httpGetterInfo{Range: o.Range, ETag: dr.ETag},
-		ObjectReplicationRules: deserializeORSPolicies(dr.ObjectReplicationRules),
-		cpkInfo:                o.CPKInfo,
-		cpkScope:               o.CPKScopeInfo,
+		client:                  b,
+		DownloadResponse:        dr,
+		getInfo:                 httpGetterInfo{Range: o.Range, ETag: dr.ETag},
+		ObjectReplicationRules:  deserializeORSPolicies(dr.ObjectReplicationRules),
+		cpkInfo:                 o.CPKInfo,
+		cpkScope:                o.CPKScopeInfo,
+		transactionalValidation: o.TransactionalValidation,
 	}, err
 }
 
@@ -473,4 +485,15 @@ func (b *Client) DownloadFile(ctx context.Context, file *os.File, o *DownloadFil
 	} else { // if the blob's size is 0, there is no need in downloading it
 		return 0, nil
 	}
+}
+
+// parseContentRangeLength parses the range length from a Content-Range header value.
+// Format: "bytes start-end/total" → returns end - start + 1.
+// Returns 0 if the header cannot be parsed.
+func parseContentRangeLength(contentRange string) int64 {
+	var start, end int64
+	if _, err := fmt.Sscanf(contentRange, "bytes %d-%d/", &start, &end); err != nil {
+		return 0
+	}
+	return end - start + 1
 }

--- a/sdk/storage/azblob/blob/client.go
+++ b/sdk/storage/azblob/blob/client.go
@@ -390,7 +390,9 @@ func (b *Client) downloadBuffer(ctx context.Context, writer io.WriterAt, o downl
 				return err
 			}
 			if computeReadLength {
-				if dr.ContentRange != nil {
+				if dr.StructuredBodyType != nil && *dr.StructuredBodyType != "" && dr.ContentRange != nil {
+					// For structured message responses, ContentLength reflects the encoded size.
+					// Use ContentRange to get the original data length.
 					atomic.AddInt64(&dataDownloaded, parseContentRangeLength(*dr.ContentRange))
 				} else {
 					atomic.AddInt64(&dataDownloaded, *dr.ContentLength)

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -2068,6 +2068,319 @@ func (s *BlobRecordedTestsSuite) TestBlobDownloadDataIfNoneMatchFalse() {
 	_require.Equal(*resp2.ErrorCode, string(bloberror.ConditionNotMet))
 }
 
+// makeDeterministicContent creates repeatable byte content for recorded tests.
+func makeDeterministicContent(size int) []byte {
+	content := make([]byte, size)
+	for i := range content {
+		content[i] = byte(i % 251)
+	}
+	return content
+}
+
+func (s *BlobRecordedTestsSuite) TestDownloadStreamWithStructuredMessageCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	blobName := testcommon.GenerateBlobName(testName)
+	bbClient := containerClient.NewBlockBlobClient(blobName)
+
+	content := makeDeterministicContent(4 * 1024) // 4 KB
+	_, err = bbClient.Upload(context.Background(), streaming.NopCloser(bytes.NewReader(content)), nil)
+	_require.NoError(err)
+
+	downloadResp, err := bbClient.DownloadStream(context.Background(), &blob.DownloadStreamOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(content, downloadedData)
+}
+
+func (s *BlobRecordedTestsSuite) TestDownloadStreamWithStructuredMessageCRC64RangeDownload() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	blobName := testcommon.GenerateBlobName(testName)
+	bbClient := containerClient.NewBlockBlobClient(blobName)
+
+	content := makeDeterministicContent(8 * 1024) // 8 KB
+	_, err = bbClient.Upload(context.Background(), streaming.NopCloser(bytes.NewReader(content)), nil)
+	_require.NoError(err)
+
+	downloadResp, err := bbClient.DownloadStream(context.Background(), &blob.DownloadStreamOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+		Range:                   blob.HTTPRange{Offset: 1024, Count: 2048},
+	})
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(content[1024:1024+2048], downloadedData)
+}
+
+func (s *BlobRecordedTestsSuite) TestDownloadBufferWithStructuredMessageCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	blobName := testcommon.GenerateBlobName(testName)
+	bbClient := containerClient.NewBlockBlobClient(blobName)
+
+	contentSize := 8 * 1024 // 8 KB
+	content := makeDeterministicContent(contentSize)
+	_, err = bbClient.Upload(context.Background(), streaming.NopCloser(bytes.NewReader(content)), nil)
+	_require.NoError(err)
+
+	blobClient := containerClient.NewBlobClient(blobName)
+	buff := make([]byte, contentSize)
+	n, err := blobClient.DownloadBuffer(context.Background(), buff, &blob.DownloadBufferOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+		BlockSize:               4 * 1024,
+	})
+	_require.NoError(err)
+	_require.Equal(int64(contentSize), n)
+	_require.Equal(content, buff[:n])
+}
+
+func (s *BlobRecordedTestsSuite) TestDownloadStreamSMCRC64EmptyBlob() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	blobName := testcommon.GenerateBlobName(testName)
+	bbClient := containerClient.NewBlockBlobClient(blobName)
+
+	_, err = bbClient.Upload(context.Background(), streaming.NopCloser(bytes.NewReader([]byte{})), nil)
+	_require.NoError(err)
+
+	downloadResp, err := bbClient.DownloadStream(context.Background(), &blob.DownloadStreamOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(0, len(downloadedData))
+}
+
+// Large multi-segment test stays unrecorded (5MB+ recording too large)
+func (s *BlobUnrecordedTestsSuite) TestDownloadStreamSMCRC64LargeMultiSegment() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	blobName := testcommon.GenerateBlobName(testName)
+	bbClient := containerClient.NewBlockBlobClient(blobName)
+
+	contentSize := 5*1024*1024 + 7 // 5MB + 7 bytes (non-aligned)
+	content := makeDeterministicContent(contentSize)
+	_, err = bbClient.Upload(context.Background(), streaming.NopCloser(bytes.NewReader(content)), nil)
+	_require.NoError(err)
+
+	downloadResp, err := bbClient.DownloadStream(context.Background(), &blob.DownloadStreamOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(content, downloadedData)
+}
+
+func (s *BlobRecordedTestsSuite) TestDownloadStreamSMCRC64NonAlignedRange() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	blobName := testcommon.GenerateBlobName(testName)
+	bbClient := containerClient.NewBlockBlobClient(blobName)
+
+	contentSize := 5 * 1024 // 5KB
+	content := makeDeterministicContent(contentSize)
+	_, err = bbClient.Upload(context.Background(), streaming.NopCloser(bytes.NewReader(content)), nil)
+	_require.NoError(err)
+
+	downloadResp, err := bbClient.DownloadStream(context.Background(), &blob.DownloadStreamOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+		Range:                   blob.HTTPRange{Offset: 10, Count: 1000},
+	})
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(content[10:10+1000], downloadedData)
+}
+
+func (s *BlobRecordedTestsSuite) TestDownloadBufferSMCRC64ParallelChunks() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	blobName := testcommon.GenerateBlobName(testName)
+	bbClient := containerClient.NewBlockBlobClient(blobName)
+
+	contentSize := 32 * 1024 // 32 KB
+	content := makeDeterministicContent(contentSize)
+	_, err = bbClient.Upload(context.Background(), streaming.NopCloser(bytes.NewReader(content)), nil)
+	_require.NoError(err)
+
+	blobClient := containerClient.NewBlobClient(blobName)
+	buff := make([]byte, contentSize)
+	n, err := blobClient.DownloadBuffer(context.Background(), buff, &blob.DownloadBufferOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+		BlockSize:               4 * 1024, // 4 KB → 8 parallel chunks
+		Concurrency:             4,
+	})
+	_require.NoError(err)
+	_require.Equal(int64(contentSize), n)
+	_require.Equal(content, buff[:n])
+}
+
+// File download test stays unrecorded (temp file I/O)
+func (s *BlobUnrecordedTestsSuite) TestDownloadFileSMCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	blobName := testcommon.GenerateBlobName(testName)
+	bbClient := containerClient.NewBlockBlobClient(blobName)
+
+	contentSize := 16 * 1024 // 16 KB
+	content := makeDeterministicContent(contentSize)
+	_, err = bbClient.Upload(context.Background(), streaming.NopCloser(bytes.NewReader(content)), nil)
+	_require.NoError(err)
+
+	tmpFile, err := os.CreateTemp("", "sm-download-*.bin")
+	_require.NoError(err)
+	defer func() {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
+	}()
+
+	blobClient := containerClient.NewBlobClient(blobName)
+	n, err := blobClient.DownloadFile(context.Background(), tmpFile, &blob.DownloadFileOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+		BlockSize:               4 * 1024,
+	})
+	_require.NoError(err)
+	_require.Equal(int64(contentSize), n)
+
+	_, err = tmpFile.Seek(0, io.SeekStart)
+	_require.NoError(err)
+	fileContent, err := io.ReadAll(tmpFile)
+	_require.NoError(err)
+	_require.Equal(content, fileContent)
+}
+
+func (s *BlobRecordedTestsSuite) TestDownloadStreamSMCRC64WithRetryReader() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	blobName := testcommon.GenerateBlobName(testName)
+	bbClient := containerClient.NewBlockBlobClient(blobName)
+
+	contentSize := 8 * 1024 // 8 KB
+	content := makeDeterministicContent(contentSize)
+	_, err = bbClient.Upload(context.Background(), streaming.NopCloser(bytes.NewReader(content)), nil)
+	_require.NoError(err)
+
+	downloadResp, err := bbClient.DownloadStream(context.Background(), &blob.DownloadStreamOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	retryReader := downloadResp.NewRetryReader(context.Background(), &blob.RetryReaderOptions{
+		MaxRetries: 3,
+	})
+	defer func() { _ = retryReader.Close() }()
+
+	downloadedData, err := io.ReadAll(retryReader)
+	_require.NoError(err)
+	_require.Equal(content, downloadedData)
+}
+
+func (s *BlobRecordedTestsSuite) TestDownloadStreamSMCRC64UploadDownloadRoundtrip() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	blobName := testcommon.GenerateBlobName(testName)
+	bbClient := containerClient.NewBlockBlobClient(blobName)
+
+	// Test various content sizes including edge cases
+	testSizes := []int{0, 1, 100, 4096, 8*1024 + 37}
+	for _, size := range testSizes {
+		content := makeDeterministicContent(size)
+
+		_, err = bbClient.Upload(context.Background(), streaming.NopCloser(bytes.NewReader(content)), nil)
+		_require.NoError(err)
+
+		downloadResp, err := bbClient.DownloadStream(context.Background(), &blob.DownloadStreamOptions{
+			TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+		})
+		_require.NoError(err)
+
+		downloadedData, err := io.ReadAll(downloadResp.Body)
+		_require.NoError(err)
+		_require.Equal(content, downloadedData, "Mismatch for size %d", size)
+	}
+}
+
 func (s *BlobRecordedTestsSuite) TestBlobDeleteNonExistent() {
 	_require := require.New(s.T())
 	testName := s.T().Name()

--- a/sdk/storage/azblob/blob/constants.go
+++ b/sdk/storage/azblob/blob/constants.go
@@ -204,7 +204,7 @@ type TransferValidationTypeMD5 = exported.TransferValidationTypeMD5
 
 // TransferValidationTypeComputeStructuredMessageCRC64 is a TransferValidationType that computes
 // per-segment CRC64 checksums using the structured message binary format.
-// segmentSize specifies the maximum segment size in bytes (use 0 for default 4MB).
+// segmentSize specifies the maximum segment size in bytes. Values <= 0 use the default (4 MB).
 func TransferValidationTypeComputeStructuredMessageCRC64(segmentSize int) TransferValidationType {
 	return exported.TransferValidationTypeComputeStructuredMessageCRC64(segmentSize)
 }

--- a/sdk/storage/azblob/blob/constants.go
+++ b/sdk/storage/azblob/blob/constants.go
@@ -202,6 +202,13 @@ func TransferValidationTypeComputeCRC64() TransferValidationType {
 // TransferValidationTypeMD5 is a TransferValidationType used to provide a precomputed MD5.
 type TransferValidationTypeMD5 = exported.TransferValidationTypeMD5
 
+// TransferValidationTypeComputeStructuredMessageCRC64 is a TransferValidationType that computes
+// per-segment CRC64 checksums using the structured message binary format.
+// segmentSize specifies the maximum segment size in bytes (use 0 for default 4MB).
+func TransferValidationTypeComputeStructuredMessageCRC64(segmentSize int) TransferValidationType {
+	return exported.TransferValidationTypeComputeStructuredMessageCRC64(segmentSize)
+}
+
 // SourceContentValidationType abstracts the various mechanisms used to validate source content.
 // This interface is not publicly implementable.
 type SourceContentValidationType interface {

--- a/sdk/storage/azblob/blob/examples_test.go
+++ b/sdk/storage/azblob/blob/examples_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -199,6 +200,34 @@ func Example_blob_Client_CreateSnapshot() {
 	// DeleteSnapshotOptionNone produces an error if the base blob has any snapshots.
 	_, err = baseBlobClient.Delete(context.TODO(), &blob.DeleteOptions{DeleteSnapshots: to.Ptr(blob.DeleteSnapshotsOptionTypeInclude)})
 	handleError(err)
+}
+
+// This example shows how to download a blob with Structured Message CRC64 content validation.
+// SM CRC64 validation ensures data integrity during download by verifying CRC64 checksums.
+func Example_blob_DownloadWithContentValidation() {
+	accountName, ok := os.LookupEnv("AZURE_STORAGE_ACCOUNT_NAME")
+	if !ok {
+		panic("AZURE_STORAGE_ACCOUNT_NAME could not be found")
+	}
+	blobURL := fmt.Sprintf("https://%s.blob.core.windows.net/testcontainer/validated-blob.txt", accountName)
+
+	credential, err := blob.NewSharedKeyCredential(accountName, os.Getenv("AZURE_STORAGE_ACCOUNT_KEY"))
+	handleError(err)
+
+	blobClient, err := blob.NewClientWithSharedKeyCredential(blobURL, credential, nil)
+	handleError(err)
+
+	// Download with Structured Message CRC64 validation.
+	// Pass 0 for segmentSize to use the default (4 MB).
+	resp, err := blobClient.DownloadStream(context.TODO(), &blob.DownloadStreamOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	handleError(err)
+
+	downloadedData, err := io.ReadAll(resp.Body)
+	handleError(err)
+
+	fmt.Printf("Downloaded %d bytes with SM CRC64 content validation.\n", len(downloadedData))
 }
 
 // This example shows how to copy a source document on the Internet to a blob.

--- a/sdk/storage/azblob/blob/models.go
+++ b/sdk/storage/azblob/blob/models.go
@@ -69,6 +69,12 @@ type DownloadStreamOptions struct {
 	// Range specifies a range of bytes.  The default value is all bytes.
 	Range HTTPRange
 
+	// TransactionalValidation specifies the transfer validation type to use on download.
+	// When set to TransferValidationTypeComputeStructuredMessageCRC64, the service returns the
+	// blob data wrapped in a structured message with per-segment CRC64 checksums. The SDK
+	// automatically decodes the structured message and validates checksums before returning data.
+	TransactionalValidation TransferValidationType
+
 	AccessConditions *AccessConditions
 	CPKInfo          *CPKInfo
 	CPKScopeInfo     *CPKScopeInfo
@@ -79,9 +85,17 @@ func (o *DownloadStreamOptions) format() (*generated.BlobClientDownloadOptions, 
 		return nil, nil, nil, nil
 	}
 
+	var smHeader *string
+	if o.TransactionalValidation != nil {
+		if h := exported.GetStructuredBodyType(o.TransactionalValidation); h != "" {
+			smHeader = &h
+		}
+	}
+
 	basics := generated.BlobClientDownloadOptions{
 		RangeGetContentMD5: o.RangeGetContentMD5,
 		Range:              exported.FormatHTTPRange(o.Range),
+		StructuredBodyType: smHeader,
 	}
 
 	leaseAccessConditions, modifiedAccessConditions := exported.FormatBlobAccessConditions(o.AccessConditions)
@@ -113,6 +127,9 @@ type downloadOptions struct {
 
 	// RetryReaderOptionsPerBlock is used when downloading each block.
 	RetryReaderOptionsPerBlock RetryReaderOptions
+
+	// TransactionalValidation specifies the transfer validation type to use on download.
+	TransactionalValidation TransferValidationType
 }
 
 func (o *downloadOptions) getBlobPropertiesOptions() *GetPropertiesOptions {
@@ -130,11 +147,12 @@ func (o *downloadOptions) getDownloadBlobOptions(rnge HTTPRange, rangeGetContent
 		return nil
 	}
 	return &DownloadStreamOptions{
-		AccessConditions:   o.AccessConditions,
-		CPKInfo:            o.CPKInfo,
-		CPKScopeInfo:       o.CPKScopeInfo,
-		Range:              rnge,
-		RangeGetContentMD5: rangeGetContentMD5,
+		AccessConditions:        o.AccessConditions,
+		CPKInfo:                 o.CPKInfo,
+		CPKScopeInfo:            o.CPKScopeInfo,
+		Range:                   rnge,
+		RangeGetContentMD5:      rangeGetContentMD5,
+		TransactionalValidation: o.TransactionalValidation,
 	}
 }
 
@@ -163,6 +181,9 @@ type DownloadBufferOptions struct {
 
 	// RetryReaderOptionsPerBlock is used when downloading each block.
 	RetryReaderOptionsPerBlock RetryReaderOptions
+
+	// TransactionalValidation specifies the transfer validation type to use on download.
+	TransactionalValidation TransferValidationType
 }
 
 // DownloadFileOptions contains the optional parameters for the DownloadFile method.
@@ -188,6 +209,9 @@ type DownloadFileOptions struct {
 
 	// RetryReaderOptionsPerBlock is used when downloading each block.
 	RetryReaderOptionsPerBlock RetryReaderOptions
+
+	// TransactionalValidation specifies the transfer validation type to use on download.
+	TransactionalValidation TransferValidationType
 }
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/sdk/storage/azblob/blob/responses.go
+++ b/sdk/storage/azblob/blob/responses.go
@@ -19,10 +19,11 @@ type DownloadStreamResponse struct {
 	DownloadResponse
 	ObjectReplicationRules []ObjectReplicationPolicy
 
-	client   *Client
-	getInfo  httpGetterInfo
-	cpkInfo  *CPKInfo
-	cpkScope *CPKScopeInfo
+	client                  *Client
+	getInfo                 httpGetterInfo
+	cpkInfo                 *CPKInfo
+	cpkScope                *CPKScopeInfo
+	transactionalValidation TransferValidationType
 }
 
 // NewRetryReader constructs new RetryReader stream for reading data. If a connection fails while
@@ -39,10 +40,11 @@ func (r *DownloadStreamResponse) NewRetryReader(ctx context.Context, options *Re
 			ModifiedAccessConditions: &ModifiedAccessConditions{IfMatch: getInfo.ETag},
 		}
 		options := DownloadStreamOptions{
-			Range:            getInfo.Range,
-			AccessConditions: accessConditions,
-			CPKInfo:          r.cpkInfo,
-			CPKScopeInfo:     r.cpkScope,
+			Range:                   getInfo.Range,
+			AccessConditions:        accessConditions,
+			CPKInfo:                 r.cpkInfo,
+			CPKScopeInfo:            r.cpkScope,
+			TransactionalValidation: r.transactionalValidation,
 		}
 		resp, err := r.client.DownloadStream(ctx, &options)
 		if err != nil {

--- a/sdk/storage/azblob/blockblob/client.go
+++ b/sdk/storage/azblob/blockblob/client.go
@@ -178,6 +178,11 @@ func (bb *Client) Upload(ctx context.Context, body io.ReadSeekCloser, options *U
 		if err != nil {
 			return UploadResponse{}, err
 		}
+		// Re-compute count since Apply() may have changed the body size (e.g., structured message encoding).
+		count, err = shared.ValidateSeekableStreamAt0AndGetCount(body)
+		if err != nil {
+			return UploadResponse{}, err
+		}
 	}
 
 	resp, err := bb.generated().Upload(ctx, count, body, opts, httpHeaders, leaseInfo, cpkV, cpkN, accessConditions)
@@ -211,7 +216,11 @@ func (bb *Client) StageBlock(ctx context.Context, base64BlockID string, body io.
 	if options != nil && options.TransactionalValidation != nil {
 		body, err = options.TransactionalValidation.Apply(body, opts)
 		if err != nil {
-			return StageBlockResponse{}, nil
+			return StageBlockResponse{}, err
+		}
+		count, err = shared.ValidateSeekableStreamAt0AndGetCount(body)
+		if err != nil {
+			return StageBlockResponse{}, err
 		}
 	}
 

--- a/sdk/storage/azblob/blockblob/client.go
+++ b/sdk/storage/azblob/blockblob/client.go
@@ -536,8 +536,11 @@ func (bb *Client) UploadBuffer(ctx context.Context, buffer []byte, o *UploadBuff
 		uploadOptions = *o
 	}
 
-	// If user attempts to pass in their own checksum, errors out.
-	if uploadOptions.TransactionalValidation != nil && reflect.TypeOf(uploadOptions.TransactionalValidation).Kind() != reflect.Func {
+	// If user attempts to pass in their own pre-computed checksum, errors out.
+	// Structured message CRC64 is allowed because it computes per-block checksums on-the-fly.
+	if uploadOptions.TransactionalValidation != nil &&
+		reflect.TypeOf(uploadOptions.TransactionalValidation).Kind() != reflect.Func &&
+		exported.GetStructuredBodyType(uploadOptions.TransactionalValidation) == "" {
 		return UploadBufferResponse{}, bloberror.UnsupportedChecksum
 	}
 
@@ -555,8 +558,11 @@ func (bb *Client) UploadFile(ctx context.Context, file *os.File, o *UploadFileOp
 		uploadOptions = *o
 	}
 
-	// If user attempts to pass in their own checksum, errors out.
-	if uploadOptions.TransactionalValidation != nil && reflect.TypeOf(uploadOptions.TransactionalValidation).Kind() != reflect.Func {
+	// If user attempts to pass in their own pre-computed checksum, errors out.
+	// Structured message CRC64 is allowed because it computes per-block checksums on-the-fly.
+	if uploadOptions.TransactionalValidation != nil &&
+		reflect.TypeOf(uploadOptions.TransactionalValidation).Kind() != reflect.Func &&
+		exported.GetStructuredBodyType(uploadOptions.TransactionalValidation) == "" {
 		return UploadFileResponse{}, bloberror.UnsupportedChecksum
 	}
 
@@ -570,8 +576,11 @@ func (bb *Client) UploadStream(ctx context.Context, body io.Reader, o *UploadStr
 		o = &UploadStreamOptions{}
 	}
 
-	// If user attempts to pass in their own checksum, errors out.
-	if o.TransactionalValidation != nil && reflect.TypeOf(o.TransactionalValidation).Kind() != reflect.Func {
+	// If user attempts to pass in their own pre-computed checksum, errors out.
+	// Structured message CRC64 is allowed because it computes per-block checksums on-the-fly.
+	if o.TransactionalValidation != nil &&
+		reflect.TypeOf(o.TransactionalValidation).Kind() != reflect.Func &&
+		exported.GetStructuredBodyType(o.TransactionalValidation) == "" {
 		return UploadStreamResponse{}, bloberror.UnsupportedChecksum
 	}
 

--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -906,6 +906,62 @@ func (s *BlockBlobRecordedTestsSuite) TestStageBlockWithMD5() {
 	_require.Contains(err.Error(), bloberror.MD5Mismatch)
 }
 
+func (s *BlockBlobUnrecordedTestsSuite) TestStageBlockWithStructuredMessageCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	blobName := testcommon.GenerateBlobName(testName)
+	bbClient := containerClient.NewBlockBlobClient(blobName)
+
+	contentSize := 8 * 1024 // 8 KB
+	content := make([]byte, contentSize)
+	body := bytes.NewReader(content)
+	rsc := streaming.NopCloser(body)
+
+	blockID1 := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%6d", 0)))
+	_, err = bbClient.StageBlock(context.Background(), blockID1, rsc, &blockblob.StageBlockOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+}
+
+func (s *BlockBlobUnrecordedTestsSuite) TestUploadWithStructuredMessageCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	blobName := testcommon.GenerateBlobName(testName)
+	bbClient := containerClient.NewBlockBlobClient(blobName)
+
+	contentSize := 4 * 1024 // 4 KB
+	_, content := testcommon.GetDataAndReader(testName, contentSize)
+	rsc := streaming.NopCloser(bytes.NewReader(content))
+
+	_, err = bbClient.Upload(context.Background(), rsc, &blockblob.UploadOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	// Download and verify data was persisted correctly
+	downloadResp, err := bbClient.BlobClient().DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(content, downloadedData)
+}
+
 func (s *BlockBlobRecordedTestsSuite) TestPutBlobWithCRC64() {
 	s.T().Skip("Content CRC64 cannot be validated in Upload()")
 	_require := require.New(s.T())
@@ -6131,6 +6187,36 @@ func (s *BlockBlobRecordedTestsSuite) TestUploadBufferWithCRC64OrMD5() {
 	})
 	_require.Error(err)
 	_require.Error(err, bloberror.UnsupportedChecksum)
+}
+
+func (s *BlockBlobUnrecordedTestsSuite) TestUploadBufferWithStructuredMessageCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	bbClient := testcommon.GetBlockBlobClient(testcommon.GenerateBlobName(testName), containerClient)
+
+	_, content := testcommon.GetDataAndReader(testName, 8*1024)
+
+	_, err = bbClient.UploadBuffer(context.Background(), content, &blockblob.UploadBufferOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+		BlockSize:               4 * 1024,
+		Concurrency:             2,
+	})
+	_require.NoError(err)
+
+	// Download and verify data was persisted correctly
+	downloadResp, err := bbClient.BlobClient().DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(content, downloadedData)
 }
 
 func (s *BlockBlobRecordedTestsSuite) TestBlockGetAccountInfo() {

--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -7269,7 +7270,7 @@ func (s *BlockBlobUnrecordedTestsSuite) TestStageBlockCommitWithStructuredMessag
 	downloadedData, err := io.ReadAll(downloadResp.Body)
 	_require.NoError(err)
 
-	expectedData := append(block1Content, block2Content...)
+	expectedData := slices.Concat(block1Content, block2Content)
 	_require.Equal(expectedData, downloadedData)
 }
 

--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -7390,6 +7390,64 @@ func (s *BlockBlobUnrecordedTestsSuite) TestUploadEmptyBlobWithStructuredMessage
 	_require.Equal([]byte{}, downloadedData)
 }
 
+func (s *BlockBlobUnrecordedTestsSuite) TestUploadExactSegmentBoundaryWithStructuredMessageCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	bbClient := containerClient.NewBlockBlobClient(testcommon.GenerateBlobName(testName))
+
+	// Upload exactly 4 MB (default segment size) to test single-segment boundary
+	_, content := testcommon.GetDataAndReader(testName, 4*1024*1024)
+
+	_, err = bbClient.Upload(context.Background(), streaming.NopCloser(bytes.NewReader(content)), &blockblob.UploadOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	downloadResp, err := bbClient.BlobClient().DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(content, downloadedData)
+}
+
+func (s *BlockBlobUnrecordedTestsSuite) TestUploadSingleByteWithStructuredMessageCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	bbClient := containerClient.NewBlockBlobClient(testcommon.GenerateBlobName(testName))
+
+	// Upload 1-byte blob with SM CRC64
+	content := []byte{0x42}
+	_, err = bbClient.Upload(context.Background(), streaming.NopCloser(bytes.NewReader(content)), &blockblob.UploadOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	// Download with SM CRC64 validation
+	downloadResp, err := bbClient.DownloadStream(context.Background(), &blob.DownloadStreamOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(content, downloadedData)
+}
+
 func (s *BlockBlobUnrecordedTestsSuite) TestUploadBufferWithSMCustomSegmentSize() {
 	_require := require.New(s.T())
 	testName := s.T().Name()

--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -7123,3 +7123,298 @@ func (s *BlockBlobUnrecordedTestsSuite) TestCommitBlockListWithUDSCreatePermissi
 	_require.Error(err)
 	testcommon.ValidateBlobErrorCode(_require, err, bloberror.UnauthorizedBlobOverwrite)
 }
+
+func (s *BlockBlobUnrecordedTestsSuite) TestUploadStreamWithStructuredMessageCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	bbClient := testcommon.GetBlockBlobClient(testcommon.GenerateBlobName(testName), containerClient)
+
+	_, content := testcommon.GetDataAndReader(testName, 8*1024)
+
+	_, err = bbClient.UploadStream(context.Background(), bytes.NewReader(content), &blockblob.UploadStreamOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+		BlockSize:               4 * 1024,
+		Concurrency:             2,
+	})
+	_require.NoError(err)
+
+	// Download and verify data was persisted correctly
+	downloadResp, err := bbClient.BlobClient().DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(content, downloadedData)
+}
+
+func (s *BlockBlobUnrecordedTestsSuite) TestUploadStreamWithStructuredMessageCRC64SingleBlock() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	bbClient := testcommon.GetBlockBlobClient(testcommon.GenerateBlobName(testName), containerClient)
+
+	// Content smaller than block size → single Upload call path
+	_, content := testcommon.GetDataAndReader(testName, 2*1024)
+
+	_, err = bbClient.UploadStream(context.Background(), bytes.NewReader(content), &blockblob.UploadStreamOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+		BlockSize:               4 * 1024,
+		Concurrency:             1,
+	})
+	_require.NoError(err)
+
+	downloadResp, err := bbClient.BlobClient().DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(content, downloadedData)
+}
+
+func (s *BlockBlobUnrecordedTestsSuite) TestUploadFileWithStructuredMessageCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	bbClient := testcommon.GetBlockBlobClient(testcommon.GenerateBlobName(testName), containerClient)
+
+	_, content := testcommon.GetDataAndReader(testName, 8*1024)
+
+	// Write content to a temp file
+	tmpFile, err := os.CreateTemp("", "sm-upload-*.bin")
+	_require.NoError(err)
+	defer func() {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
+	}()
+
+	_, err = tmpFile.Write(content)
+	_require.NoError(err)
+	_, err = tmpFile.Seek(0, io.SeekStart)
+	_require.NoError(err)
+
+	_, err = bbClient.UploadFile(context.Background(), tmpFile, &blockblob.UploadFileOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+		BlockSize:               4 * 1024,
+		Concurrency:             2,
+	})
+	_require.NoError(err)
+
+	// Download and verify
+	downloadResp, err := bbClient.BlobClient().DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(content, downloadedData)
+}
+
+func (s *BlockBlobUnrecordedTestsSuite) TestStageBlockCommitWithStructuredMessageCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	bbClient := containerClient.NewBlockBlobClient(testcommon.GenerateBlobName(testName))
+
+	// Stage two blocks with SM validation, then commit
+	_, block1Content := testcommon.GetDataAndReader(testName+"block1", 4*1024)
+	block2Content := make([]byte, 4*1024)
+	for i := range block2Content {
+		block2Content[i] = byte((i + 100) % 251)
+	}
+
+	blockID1 := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%6d", 0)))
+	blockID2 := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%6d", 1)))
+
+	_, err = bbClient.StageBlock(context.Background(), blockID1, streaming.NopCloser(bytes.NewReader(block1Content)), &blockblob.StageBlockOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	_, err = bbClient.StageBlock(context.Background(), blockID2, streaming.NopCloser(bytes.NewReader(block2Content)), &blockblob.StageBlockOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	_, err = bbClient.CommitBlockList(context.Background(), []string{blockID1, blockID2}, nil)
+	_require.NoError(err)
+
+	// Download and verify the committed blob contains both blocks
+	downloadResp, err := bbClient.BlobClient().DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+
+	expectedData := append(block1Content, block2Content...)
+	_require.Equal(expectedData, downloadedData)
+}
+
+func (s *BlockBlobUnrecordedTestsSuite) TestUploadWithSMThenDownloadWithSMRoundTrip() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	bbClient := containerClient.NewBlockBlobClient(testcommon.GenerateBlobName(testName))
+
+	_, content := testcommon.GetDataAndReader(testName, 4*1024)
+
+	// Upload with SM CRC64
+	_, err = bbClient.Upload(context.Background(), streaming.NopCloser(bytes.NewReader(content)), &blockblob.UploadOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	// Download with SM CRC64 validation
+	downloadResp, err := bbClient.BlobClient().DownloadStream(context.Background(), &blob.DownloadStreamOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(content, downloadedData)
+}
+
+func (s *BlockBlobUnrecordedTestsSuite) TestUploadWithSMThenDownloadWithoutSM() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	bbClient := containerClient.NewBlockBlobClient(testcommon.GenerateBlobName(testName))
+
+	_, content := testcommon.GetDataAndReader(testName, 4*1024)
+
+	// Upload with SM CRC64 validation
+	_, err = bbClient.Upload(context.Background(), streaming.NopCloser(bytes.NewReader(content)), &blockblob.UploadOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	// Download without SM — raw data should still be correct (SM is envelope-only, not stored)
+	downloadResp, err := bbClient.BlobClient().DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(content, downloadedData)
+}
+
+func (s *BlockBlobUnrecordedTestsSuite) TestUploadBufferMultiBlockWithStructuredMessageCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	bbClient := testcommon.GetBlockBlobClient(testcommon.GenerateBlobName(testName), containerClient)
+
+	// 16 KB with 4 KB blocks → 4 blocks (multi-block path)
+	_, content := testcommon.GetDataAndReader(testName, 16*1024)
+
+	_, err = bbClient.UploadBuffer(context.Background(), content, &blockblob.UploadBufferOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+		BlockSize:               4 * 1024,
+		Concurrency:             4,
+	})
+	_require.NoError(err)
+
+	downloadResp, err := bbClient.BlobClient().DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(content, downloadedData)
+}
+
+func (s *BlockBlobUnrecordedTestsSuite) TestUploadEmptyBlobWithStructuredMessageCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	bbClient := containerClient.NewBlockBlobClient(testcommon.GenerateBlobName(testName))
+
+	// Upload empty blob with SM CRC64
+	_, err = bbClient.Upload(context.Background(), streaming.NopCloser(bytes.NewReader([]byte{})), &blockblob.UploadOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	downloadResp, err := bbClient.BlobClient().DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal([]byte{}, downloadedData)
+}
+
+func (s *BlockBlobUnrecordedTestsSuite) TestUploadBufferWithSMCustomSegmentSize() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	bbClient := testcommon.GetBlockBlobClient(testcommon.GenerateBlobName(testName), containerClient)
+
+	_, content := testcommon.GetDataAndReader(testName, 8*1024)
+
+	// Use a custom segment size of 2 KB (smaller than default 4 MB)
+	_, err = bbClient.UploadBuffer(context.Background(), content, &blockblob.UploadBufferOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(2 * 1024),
+		BlockSize:               4 * 1024,
+		Concurrency:             2,
+	})
+	_require.NoError(err)
+
+	downloadResp, err := bbClient.BlobClient().DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(content, downloadedData)
+}

--- a/sdk/storage/azblob/blockblob/examples_test.go
+++ b/sdk/storage/azblob/blockblob/examples_test.go
@@ -200,6 +200,33 @@ func Example_blockblob_SetExpiry() {
 	}
 }
 
+// This example shows how to upload a block blob with Structured Message CRC64 content validation.
+// SM CRC64 validation ensures data integrity during upload by computing and verifying CRC64 checksums.
+func Example_blockblob_UploadWithContentValidation() {
+	accountName, ok := os.LookupEnv("AZURE_STORAGE_ACCOUNT_NAME")
+	if !ok {
+		panic("AZURE_STORAGE_ACCOUNT_NAME could not be found")
+	}
+	blobURL := fmt.Sprintf("https://%s.blob.core.windows.net/testcontainer/validated-blob.txt", accountName)
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	handleError(err)
+
+	blockBlobClient, err := blockblob.NewClient(blobURL, cred, nil)
+	handleError(err)
+
+	data := []byte("Hello, content validation with Structured Message CRC64!")
+
+	// Upload with Structured Message CRC64 validation.
+	// Pass 0 for segmentSize to use the default (4 MB).
+	_, err = blockBlobClient.Upload(context.TODO(), streaming.NopCloser(bytes.NewReader(data)), &blockblob.UploadOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	handleError(err)
+
+	fmt.Println("Blob uploaded with SM CRC64 content validation.")
+}
+
 // This example shows how to set up log callback to dump SDK events
 func Example_blockblob_uploadLogs() {
 	accountName, ok := os.LookupEnv("AZURE_STORAGE_ACCOUNT_NAME")

--- a/sdk/storage/azblob/blockblob/models.go
+++ b/sdk/storage/azblob/blockblob/models.go
@@ -304,13 +304,14 @@ func (o *uploadFromReaderOptions) getStageBlockOptions() *StageBlockOptions {
 
 func (o *uploadFromReaderOptions) getUploadBlockBlobOptions() *UploadOptions {
 	return &UploadOptions{
-		Tags:             o.Tags,
-		Metadata:         o.Metadata,
-		Tier:             o.AccessTier,
-		HTTPHeaders:      o.HTTPHeaders,
-		AccessConditions: o.AccessConditions,
-		CPKInfo:          o.CPKInfo,
-		CPKScopeInfo:     o.CPKScopeInfo,
+		Tags:                    o.Tags,
+		Metadata:                o.Metadata,
+		Tier:                    o.AccessTier,
+		HTTPHeaders:             o.HTTPHeaders,
+		AccessConditions:        o.AccessConditions,
+		CPKInfo:                 o.CPKInfo,
+		CPKScopeInfo:            o.CPKScopeInfo,
+		TransactionalValidation: o.TransactionalValidation,
 	}
 }
 
@@ -393,13 +394,14 @@ func (u *UploadStreamOptions) getUploadOptions() *UploadOptions {
 	}
 
 	return &UploadOptions{
-		Tags:             u.Tags,
-		Metadata:         u.Metadata,
-		Tier:             u.AccessTier,
-		HTTPHeaders:      u.HTTPHeaders,
-		CPKInfo:          u.CPKInfo,
-		CPKScopeInfo:     u.CPKScopeInfo,
-		AccessConditions: u.AccessConditions,
+		Tags:                    u.Tags,
+		Metadata:                u.Metadata,
+		Tier:                    u.AccessTier,
+		HTTPHeaders:             u.HTTPHeaders,
+		CPKInfo:                 u.CPKInfo,
+		CPKScopeInfo:            u.CPKScopeInfo,
+		AccessConditions:        u.AccessConditions,
+		TransactionalValidation: u.TransactionalValidation,
 	}
 }
 

--- a/sdk/storage/azblob/blockblob/structured_message_bench_test.go
+++ b/sdk/storage/azblob/blockblob/structured_message_bench_test.go
@@ -1,0 +1,335 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package blockblob_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
+)
+
+// benchmarkEnv holds pre-created clients for benchmark iterations.
+type benchmarkEnv struct {
+	containerClient *container.Client
+	containerName   string
+	svcClient       *azblob.Client
+}
+
+func setupBenchEnv(b *testing.B) *benchmarkEnv {
+	accountName := os.Getenv("AZURE_STORAGE_ACCOUNT_NAME")
+	accountKey := os.Getenv("AZURE_STORAGE_ACCOUNT_KEY")
+	if accountName == "" || accountKey == "" {
+		b.Skip("Set AZURE_STORAGE_ACCOUNT_NAME and AZURE_STORAGE_ACCOUNT_KEY to run live benchmarks")
+	}
+
+	cred, err := azblob.NewSharedKeyCredential(accountName, accountKey)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	svcClient, err := azblob.NewClientWithSharedKeyCredential(
+		fmt.Sprintf("https://%s.blob.core.windows.net", accountName), cred, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Use timestamp + sanitized test name for unique container names across sub-benchmarks.
+	// Container names must be lowercase, 3-63 chars, only alphanumeric and hyphens.
+	sanitized := strings.ToLower(b.Name())
+	sanitized = strings.ReplaceAll(sanitized, "/", "-")
+	sanitized = strings.ReplaceAll(sanitized, "_", "-")
+	if len(sanitized) > 40 {
+		sanitized = sanitized[:40]
+	}
+	containerName := fmt.Sprintf("%s-%d", sanitized, time.Now().UnixNano()%1000000)
+	_, err = svcClient.CreateContainer(context.Background(), containerName, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	env := &benchmarkEnv{
+		containerClient: svcClient.ServiceClient().NewContainerClient(containerName),
+		containerName:   containerName,
+		svcClient:       svcClient,
+	}
+
+	b.Cleanup(func() {
+		// Delete all blobs then container
+		pager := env.containerClient.NewListBlobsFlatPager(nil)
+		for pager.More() {
+			resp, err := pager.NextPage(context.Background())
+			if err != nil {
+				break
+			}
+			for _, blobItem := range resp.Segment.BlobItems {
+				_, _ = env.containerClient.NewBlobClient(*blobItem.Name).Delete(context.Background(), nil)
+			}
+		}
+		_, _ = svcClient.DeleteContainer(context.Background(), containerName, nil)
+	})
+
+	return env
+}
+
+func makeBenchData(size int) []byte {
+	data := make([]byte, size)
+	_, _ = rand.Read(data)
+	return data
+}
+
+// ── Upload benchmarks: NoValidation vs ComputeCRC64 (2-pass) vs SM CRC64 (single-pass) ──
+
+func BenchmarkUpload(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"1KB", 1 * 1024},
+		{"1MB", 1 * 1024 * 1024},
+		{"4MB", 4 * 1024 * 1024},
+		{"16MB", 16 * 1024 * 1024},
+		{"32MB", 32 * 1024 * 1024},
+	}
+
+	for _, sz := range sizes {
+		data := makeBenchData(sz.size)
+
+		b.Run(fmt.Sprintf("NoValidation/%s", sz.name), func(b *testing.B) {
+			env := setupBenchEnv(b)
+			b.SetBytes(int64(sz.size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				blobName := fmt.Sprintf("noval-%s-%d", sz.name, i)
+				bbClient := env.containerClient.NewBlockBlobClient(blobName)
+				_, err := bbClient.Upload(context.Background(),
+					streaming.NopCloser(bytes.NewReader(data)),
+					&blockblob.UploadOptions{})
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		// ComputeCRC64: reads entire body to compute checksum, then re-reads to send (2-pass)
+		b.Run(fmt.Sprintf("ComputeCRC64/%s", sz.name), func(b *testing.B) {
+			env := setupBenchEnv(b)
+			b.SetBytes(int64(sz.size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				blobName := fmt.Sprintf("crc64-%s-%d", sz.name, i)
+				bbClient := env.containerClient.NewBlockBlobClient(blobName)
+				_, err := bbClient.Upload(context.Background(),
+					streaming.NopCloser(bytes.NewReader(data)),
+					&blockblob.UploadOptions{
+						TransactionalValidation: blob.TransferValidationTypeComputeCRC64(),
+					})
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		// SM CRC64: single-pass streaming CRC computation embedded in the request body
+		b.Run(fmt.Sprintf("SMCRC64/%s", sz.name), func(b *testing.B) {
+			env := setupBenchEnv(b)
+			b.SetBytes(int64(sz.size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				blobName := fmt.Sprintf("sm-%s-%d", sz.name, i)
+				bbClient := env.containerClient.NewBlockBlobClient(blobName)
+				_, err := bbClient.Upload(context.Background(),
+					streaming.NopCloser(bytes.NewReader(data)),
+					&blockblob.UploadOptions{
+						TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+					})
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// ── Download benchmarks: NoValidation vs SM CRC64 ──
+// Note: there is no ComputeCRC64 equivalent for downloads — the service computes CRC.
+// SM adds client-side CRC verification + SM framing overhead on the response body.
+
+func BenchmarkDownload(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"1KB", 1 * 1024},
+		{"1MB", 1 * 1024 * 1024},
+		{"4MB", 4 * 1024 * 1024},
+		{"16MB", 16 * 1024 * 1024},
+		{"64MB", 64 * 1024 * 1024},
+		{"128MB", 128 * 1024 * 1024},
+	}
+
+	for _, sz := range sizes {
+		data := makeBenchData(sz.size)
+
+		b.Run(fmt.Sprintf("NoSM/%s", sz.name), func(b *testing.B) {
+			env := setupBenchEnv(b)
+			// Upload once, then benchmark download
+			blobName := fmt.Sprintf("dl-nosm-%s", sz.name)
+			bbClient := env.containerClient.NewBlockBlobClient(blobName)
+			_, err := bbClient.UploadBuffer(context.Background(), data, nil)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.SetBytes(int64(sz.size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resp, err := bbClient.DownloadStream(context.Background(), nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+				_, _ = io.Copy(io.Discard, resp.Body)
+			}
+		})
+
+		b.Run(fmt.Sprintf("WithSM/%s", sz.name), func(b *testing.B) {
+			env := setupBenchEnv(b)
+			// Upload once, then benchmark download with SM
+			blobName := fmt.Sprintf("dl-sm-%s", sz.name)
+			bbClient := env.containerClient.NewBlockBlobClient(blobName)
+			_, err := bbClient.UploadBuffer(context.Background(), data, nil)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.SetBytes(int64(sz.size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resp, err := bbClient.DownloadStream(context.Background(), &blob.DownloadStreamOptions{
+					TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+				})
+				if err != nil {
+					b.Fatal(err)
+				}
+				_, _ = io.Copy(io.Discard, resp.Body)
+			}
+		})
+	}
+}
+
+// ── UploadBuffer multi-block benchmark: NoValidation vs SM CRC64 ──
+// Note: ComputeCRC64 is not supported for multi-block uploads (UnsupportedChecksum error).
+// SM CRC64 is the only validation option that works with multi-block uploads because it
+// computes per-block checksums on-the-fly.
+
+func BenchmarkUploadBuffer(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"16MB", 16 * 1024 * 1024},
+		{"64MB", 64 * 1024 * 1024},
+		{"128MB", 128 * 1024 * 1024},
+		{"256MB", 256 * 1024 * 1024},
+	}
+
+	for _, sz := range sizes {
+		data := makeBenchData(sz.size)
+
+		b.Run(fmt.Sprintf("NoSM/%s", sz.name), func(b *testing.B) {
+			env := setupBenchEnv(b)
+			b.SetBytes(int64(sz.size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				blobName := fmt.Sprintf("buf-nosm-%s-%d", sz.name, i)
+				bbClient := env.containerClient.NewBlockBlobClient(blobName)
+				_, err := bbClient.UploadBuffer(context.Background(), data, &blockblob.UploadBufferOptions{})
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("WithSM/%s", sz.name), func(b *testing.B) {
+			env := setupBenchEnv(b)
+			b.SetBytes(int64(sz.size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				blobName := fmt.Sprintf("buf-sm-%s-%d", sz.name, i)
+				bbClient := env.containerClient.NewBlockBlobClient(blobName)
+				_, err := bbClient.UploadBuffer(context.Background(), data, &blockblob.UploadBufferOptions{
+					TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+				})
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// ── UploadStream multi-block benchmark: NoValidation vs SM CRC64 ──
+// UploadStream uses a different code path (copyFromReader) than UploadBuffer (uploadFromReader).
+// It reads from a non-seekable stream, buffering into blocks internally.
+
+func BenchmarkUploadStream(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"16MB", 16 * 1024 * 1024},
+		{"64MB", 64 * 1024 * 1024},
+		{"128MB", 128 * 1024 * 1024},
+		{"256MB", 256 * 1024 * 1024},
+	}
+
+	for _, sz := range sizes {
+		data := makeBenchData(sz.size)
+
+		b.Run(fmt.Sprintf("NoSM/%s", sz.name), func(b *testing.B) {
+			env := setupBenchEnv(b)
+			b.SetBytes(int64(sz.size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				blobName := fmt.Sprintf("str-nosm-%s-%d", sz.name, i)
+				bbClient := env.containerClient.NewBlockBlobClient(blobName)
+				_, err := bbClient.UploadStream(context.Background(),
+					bytes.NewReader(data),
+					&blockblob.UploadStreamOptions{})
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("WithSM/%s", sz.name), func(b *testing.B) {
+			env := setupBenchEnv(b)
+			b.SetBytes(int64(sz.size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				blobName := fmt.Sprintf("str-sm-%s-%d", sz.name, i)
+				bbClient := env.containerClient.NewBlockBlobClient(blobName)
+				_, err := bbClient.UploadStream(context.Background(),
+					bytes.NewReader(data),
+					&blockblob.UploadStreamOptions{
+						TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+					})
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/sdk/storage/azblob/client_test.go
+++ b/sdk/storage/azblob/client_test.go
@@ -172,6 +172,42 @@ func (s *AZBlobUnrecordedTestsSuite) TestUploadStreamToBlockBlobInChunksChecksum
 	performUploadStreamToBlockBlobTestWithChecksums(s.T(), _require, testName, blobSize, bufferSize, maxBuffers)
 }
 
+func (s *AZBlobUnrecordedTestsSuite) TestUploadStreamWithStructuredMessageCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+
+	client, err := testcommon.GetClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	_, err = client.CreateContainer(context.Background(), containerName, nil)
+	_require.NoError(err)
+	defer func() {
+		_, err := client.DeleteContainer(context.Background(), containerName, nil)
+		_require.NoError(err)
+	}()
+
+	blobName := testcommon.GenerateBlobName(testName)
+
+	blobContentReader, blobData := testcommon.GenerateData(8 * 1024)
+
+	_, err = client.UploadStream(ctx, containerName, blobName, blobContentReader,
+		&blockblob.UploadStreamOptions{
+			BlockSize:               1024,
+			Concurrency:             3,
+			TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+		})
+	_require.NoError(err)
+
+	// Download and verify data was persisted correctly
+	downloadResp, err := client.DownloadStream(context.Background(), containerName, blobName, nil)
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(blobData, downloadedData)
+}
+
 func performUploadStreamToBlockBlobTest(t *testing.T, _require *require.Assertions, testName string, blobSize, bufferSize, maxBuffers int) {
 	client, err := testcommon.GetClient(t, testcommon.TestAccountDefault, nil)
 	_require.NoError(err)

--- a/sdk/storage/azblob/internal/exported/transfer_validation_option.go
+++ b/sdk/storage/azblob/internal/exported/transfer_validation_option.go
@@ -55,6 +55,23 @@ func (c TransferValidationTypeMD5) Apply(rsc io.ReadSeekCloser, cfg generated.Tr
 
 func (TransferValidationTypeMD5) notPubliclyImplementable() {}
 
+// TransferValidationTypeComputeStructuredMessageCRC64 is a TransferValidationType that computes
+// per-segment CRC64 checksums using the structured message binary format.
+// The body is wrapped in a streaming SMEncoder that produces SM-encoded output on Read().
+// segmentSize specifies the maximum segment size in bytes (use 0 for default 4MB).
+func TransferValidationTypeComputeStructuredMessageCRC64(segmentSize int) TransferValidationType {
+	return transferValidationTypeFn(func(rsc io.ReadSeekCloser, cfg generated.TransactionalContentSetter) (io.ReadSeekCloser, error) {
+		contentLen, err := shared.ValidateSeekableStreamAt0AndGetCount(rsc)
+		if err != nil {
+			return nil, err
+		}
+
+		encoder := shared.NewSMEncoder(rsc, contentLen, segmentSize)
+		cfg.SetStructuredBody(shared.SMHeaderValue, encoder.OriginalContentLength())
+		return encoder, nil
+	})
+}
+
 type transferValidationTypeFn func(io.ReadSeekCloser, generated.TransactionalContentSetter) (io.ReadSeekCloser, error)
 
 func (t transferValidationTypeFn) Apply(rsc io.ReadSeekCloser, cfg generated.TransactionalContentSetter) (io.ReadSeekCloser, error) {

--- a/sdk/storage/azblob/internal/exported/transfer_validation_option.go
+++ b/sdk/storage/azblob/internal/exported/transfer_validation_option.go
@@ -58,7 +58,7 @@ func (TransferValidationTypeMD5) notPubliclyImplementable() {}
 // TransferValidationTypeComputeStructuredMessageCRC64 is a TransferValidationType that computes
 // per-segment CRC64 checksums using the structured message binary format.
 // The body is wrapped in a streaming SMEncoder that produces SM-encoded output on Read().
-// segmentSize specifies the maximum segment size in bytes (use 0 for default 4MB).
+// segmentSize specifies the maximum segment size in bytes. Values <= 0 use the default (4 MB).
 func TransferValidationTypeComputeStructuredMessageCRC64(segmentSize int) TransferValidationType {
 	return &transferValidationTypeSMCRC64{segmentSize: segmentSize}
 }

--- a/sdk/storage/azblob/internal/exported/transfer_validation_option.go
+++ b/sdk/storage/azblob/internal/exported/transfer_validation_option.go
@@ -60,16 +60,38 @@ func (TransferValidationTypeMD5) notPubliclyImplementable() {}
 // The body is wrapped in a streaming SMEncoder that produces SM-encoded output on Read().
 // segmentSize specifies the maximum segment size in bytes (use 0 for default 4MB).
 func TransferValidationTypeComputeStructuredMessageCRC64(segmentSize int) TransferValidationType {
-	return transferValidationTypeFn(func(rsc io.ReadSeekCloser, cfg generated.TransactionalContentSetter) (io.ReadSeekCloser, error) {
-		contentLen, err := shared.ValidateSeekableStreamAt0AndGetCount(rsc)
-		if err != nil {
-			return nil, err
-		}
+	return &transferValidationTypeSMCRC64{segmentSize: segmentSize}
+}
 
-		encoder := shared.NewSMEncoder(rsc, contentLen, segmentSize)
-		cfg.SetStructuredBody(shared.SMHeaderValue, encoder.OriginalContentLength())
-		return encoder, nil
-	})
+type transferValidationTypeSMCRC64 struct {
+	segmentSize int
+}
+
+func (t *transferValidationTypeSMCRC64) Apply(rsc io.ReadSeekCloser, cfg generated.TransactionalContentSetter) (io.ReadSeekCloser, error) {
+	contentLen, err := shared.ValidateSeekableStreamAt0AndGetCount(rsc)
+	if err != nil {
+		return nil, err
+	}
+
+	encoder := shared.NewSMEncoder(rsc, contentLen, t.segmentSize)
+	cfg.SetStructuredBody(shared.SMHeaderValue, encoder.OriginalContentLength())
+	return encoder, nil
+}
+
+func (*transferValidationTypeSMCRC64) notPubliclyImplementable() {}
+
+// StructuredBodyHeaderValue returns the structured body header value for download requests.
+func (t *transferValidationTypeSMCRC64) StructuredBodyHeaderValue() string {
+	return shared.SMHeaderValue
+}
+
+// GetStructuredBodyType returns the structured body header value if the given TransferValidationType
+// is a structured message type, or empty string otherwise.
+func GetStructuredBodyType(tv TransferValidationType) string {
+	if sm, ok := tv.(*transferValidationTypeSMCRC64); ok {
+		return sm.StructuredBodyHeaderValue()
+	}
+	return ""
 }
 
 type transferValidationTypeFn func(io.ReadSeekCloser, generated.TransactionalContentSetter) (io.ReadSeekCloser, error)

--- a/sdk/storage/azblob/internal/generated/models.go
+++ b/sdk/storage/azblob/internal/generated/models.go
@@ -12,6 +12,7 @@ import (
 type TransactionalContentSetter interface {
 	SetCRC64([]byte)
 	SetMD5([]byte)
+	SetStructuredBody(bodyType string, contentLength int64)
 }
 
 func (a *AppendBlobClientAppendBlockOptions) SetCRC64(v []byte) {
@@ -22,12 +23,22 @@ func (a *AppendBlobClientAppendBlockOptions) SetMD5(v []byte) {
 	a.TransactionalContentMD5 = v
 }
 
+func (a *AppendBlobClientAppendBlockOptions) SetStructuredBody(bodyType string, contentLength int64) {
+	a.StructuredBodyType = to.Ptr(bodyType)
+	a.StructuredContentLength = to.Ptr(contentLength)
+}
+
 func (b *BlockBlobClientStageBlockOptions) SetCRC64(v []byte) {
 	b.TransactionalContentCRC64 = v
 }
 
 func (b *BlockBlobClientStageBlockOptions) SetMD5(v []byte) {
 	b.TransactionalContentMD5 = v
+}
+
+func (b *BlockBlobClientStageBlockOptions) SetStructuredBody(bodyType string, contentLength int64) {
+	b.StructuredBodyType = to.Ptr(bodyType)
+	b.StructuredContentLength = to.Ptr(contentLength)
 }
 
 func (p *PageBlobClientUploadPagesOptions) SetCRC64(v []byte) {
@@ -38,12 +49,22 @@ func (p *PageBlobClientUploadPagesOptions) SetMD5(v []byte) {
 	p.TransactionalContentMD5 = v
 }
 
+func (p *PageBlobClientUploadPagesOptions) SetStructuredBody(bodyType string, contentLength int64) {
+	p.StructuredBodyType = to.Ptr(bodyType)
+	p.StructuredContentLength = to.Ptr(contentLength)
+}
+
 func (b *BlockBlobClientUploadOptions) SetCRC64(v []byte) {
 	b.TransactionalContentCRC64 = v
 }
 
 func (b *BlockBlobClientUploadOptions) SetMD5(v []byte) {
 	b.TransactionalContentMD5 = v
+}
+
+func (b *BlockBlobClientUploadOptions) SetStructuredBody(bodyType string, contentLength int64) {
+	b.StructuredBodyType = to.Ptr(bodyType)
+	b.StructuredContentLength = to.Ptr(contentLength)
 }
 
 type SourceContentSetter interface {

--- a/sdk/storage/azblob/internal/shared/structured_message.go
+++ b/sdk/storage/azblob/internal/shared/structured_message.go
@@ -1,0 +1,790 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package shared
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"hash/crc64"
+	"io"
+)
+
+// Structured Message (XSM/1.0) constants
+const (
+	SMVersion   uint8  = 1
+	SMFlagCRC64 uint16 = 0x0001
+
+	SMDefaultSegmentSize = 4 * 1024 * 1024 // 4MB
+
+	SMHeaderSize         = 13 // version(1) + msgLen(8) + flags(2) + numSegments(2)
+	SMSegmentHeaderSize  = 10 // segNum(2) + dataLen(8)
+	SMSegmentFooterSize  = 8  // CRC64
+	SMMessageTrailerSize = 8  // CRC64
+
+	SMHeaderValue = "XSM/1.0; properties=crc64"
+)
+
+// SMEncodeResult holds the result of encoding data into structured message format.
+type SMEncodeResult struct {
+	// EncodedData is the complete structured message binary payload.
+	EncodedData []byte
+	// OriginalContentLength is the length of the original unframed data.
+	OriginalContentLength int64
+}
+
+// SMEncode encodes raw data into structured message format.
+// segmentSize specifies the maximum segment size (use 0 for default 4MB).
+// Returns the full SM binary payload and the original content length.
+func SMEncode(data []byte, segmentSize int) SMEncodeResult {
+	if segmentSize <= 0 {
+		segmentSize = SMDefaultSegmentSize
+	}
+
+	totalDataLen := len(data)
+	numSegments := totalDataLen / segmentSize
+	if totalDataLen%segmentSize != 0 {
+		numSegments++
+	}
+	if numSegments == 0 {
+		numSegments = 1
+	}
+
+	// Calculate total message length
+	msgLen := int64(SMHeaderSize)
+	for i := 0; i < numSegments; i++ {
+		segStart := i * segmentSize
+		segEnd := segStart + segmentSize
+		if segEnd > totalDataLen {
+			segEnd = totalDataLen
+		}
+		segDataLen := segEnd - segStart
+		msgLen += int64(SMSegmentHeaderSize) + int64(segDataLen) + int64(SMSegmentFooterSize)
+	}
+	msgLen += int64(SMMessageTrailerSize)
+
+	var buf bytes.Buffer
+	buf.Grow(int(msgLen))
+
+	// The return values are intentionally discarded.
+	_ = buf.WriteByte(SMVersion)
+	_ = binary.Write(&buf, binary.LittleEndian, msgLen)
+	_ = binary.Write(&buf, binary.LittleEndian, SMFlagCRC64)
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(numSegments))
+
+	// Compute message-level CRC64 over all raw data
+	messageCRC := crc64.Checksum(data, CRC64Table)
+
+	for i := 0; i < numSegments; i++ {
+		segStart := i * segmentSize
+		segEnd := segStart + segmentSize
+		if segEnd > totalDataLen {
+			segEnd = totalDataLen
+		}
+		segData := data[segStart:segEnd]
+
+		// Segment Header (10 bytes)
+		_ = binary.Write(&buf, binary.LittleEndian, uint16(i+1))
+		_ = binary.Write(&buf, binary.LittleEndian, uint64(len(segData)))
+
+		// Segment Data
+		_, _ = buf.Write(segData)
+
+		// Segment Footer - CRC64 of segment data (8 bytes)
+		segCRC := crc64.Checksum(segData, CRC64Table)
+		_ = binary.Write(&buf, binary.LittleEndian, segCRC)
+	}
+
+	// Message Trailer - CRC64 of all raw content (8 bytes)
+	_ = binary.Write(&buf, binary.LittleEndian, messageCRC)
+
+	return SMEncodeResult{
+		EncodedData:           buf.Bytes(),
+		OriginalContentLength: int64(totalDataLen),
+	}
+}
+
+// SMDecodeResult holds the result of decoding a structured message.
+type SMDecodeResult struct {
+	// Data is the extracted raw content.
+	Data []byte
+	// Version is the SM protocol version.
+	Version uint8
+	// Flags are the SM flags (e.g., SMFlagCRC64).
+	Flags uint16
+	// NumSegments is the number of segments in the message.
+	NumSegments uint16
+}
+
+type smDecodedSegment struct {
+	num        uint16
+	data       []byte
+	nextOffset int
+
+	expectedCRC uint64
+	hasCRC      bool
+}
+
+func decodeSMSegment(smData []byte, offset int, expectedSegmentNum uint16, hasCRC bool) (smDecodedSegment, error) {
+	if offset+SMSegmentHeaderSize > len(smData) {
+		return smDecodedSegment{}, fmt.Errorf("segment %d: insufficient data for segment header at offset %d", expectedSegmentNum, offset)
+	}
+
+	segNum := binary.LittleEndian.Uint16(smData[offset : offset+2])
+	segDataLen := binary.LittleEndian.Uint64(smData[offset+2 : offset+10])
+	offset += SMSegmentHeaderSize
+
+	if segNum != expectedSegmentNum {
+		return smDecodedSegment{}, fmt.Errorf("segment number mismatch: expected %d, got %d", expectedSegmentNum, segNum)
+	}
+
+	maxSegmentDataLen := uint64(int(^uint(0) >> 1))
+	if segDataLen > maxSegmentDataLen {
+		return smDecodedSegment{}, fmt.Errorf("segment %d: data length %d exceeds supported size", segNum, segDataLen)
+	}
+
+	remaining := uint64(len(smData) - offset)
+	footerSize := uint64(0)
+	if hasCRC {
+		footerSize = SMSegmentFooterSize
+	}
+
+	if segDataLen > remaining || remaining-segDataLen < footerSize {
+		return smDecodedSegment{}, fmt.Errorf("segment %d: insufficient data for segment content (need %d bytes at offset %d, have %d)", segNum, segDataLen, offset, len(smData))
+	}
+
+	dataEnd := offset + int(segDataLen)
+	segment := smDecodedSegment{
+		num:        segNum,
+		data:       smData[offset:dataEnd],
+		nextOffset: dataEnd,
+		hasCRC:     hasCRC,
+	}
+
+	if hasCRC {
+		segment.expectedCRC = binary.LittleEndian.Uint64(smData[dataEnd : dataEnd+SMSegmentFooterSize])
+		segment.nextOffset += SMSegmentFooterSize
+	}
+
+	return segment, nil
+}
+
+// SMDecode decodes a structured message binary payload and validates CRC64 checksums.
+// Returns the extracted raw data or an error if the SM is malformed or CRC validation fails.
+func SMDecode(smData []byte) (SMDecodeResult, error) {
+	if len(smData) < SMHeaderSize {
+		return SMDecodeResult{}, fmt.Errorf("structured message too short for header: %d bytes (minimum %d)", len(smData), SMHeaderSize)
+	}
+
+	// Parse Message Header
+	version := smData[0]
+	if version != SMVersion {
+		return SMDecodeResult{}, fmt.Errorf("unsupported structured message version: %d (expected %d)", version, SMVersion)
+	}
+
+	msgLen := binary.LittleEndian.Uint64(smData[1:9])
+	if uint64(len(smData)) != msgLen {
+		return SMDecodeResult{}, fmt.Errorf("structured message length mismatch: header says %d, got %d bytes", msgLen, len(smData))
+	}
+
+	flags := binary.LittleEndian.Uint16(smData[9:11])
+	numSegments := binary.LittleEndian.Uint16(smData[11:13])
+	hasCRC := flags&SMFlagCRC64 != 0
+
+	offset := SMHeaderSize
+	var result []byte
+	var msgHasher hash64
+	if hasCRC {
+		msgHasher = crc64.New(CRC64Table)
+	}
+
+	for i := uint16(1); i <= numSegments; i++ {
+		segment, err := decodeSMSegment(smData, offset, i, hasCRC)
+		if err != nil {
+			return SMDecodeResult{}, err
+		}
+
+		result = append(result, segment.data...)
+		offset = segment.nextOffset
+
+		if !segment.hasCRC {
+			continue
+		}
+
+		actualCRC := crc64.Checksum(segment.data, CRC64Table)
+		if segment.expectedCRC != actualCRC {
+			return SMDecodeResult{}, fmt.Errorf("segment %d: CRC64 mismatch (expected 0x%016x, got 0x%016x)", segment.num, segment.expectedCRC, actualCRC)
+		}
+
+		_, _ = msgHasher.Write(segment.data)
+	}
+
+	if hasCRC {
+		if offset+SMMessageTrailerSize > len(smData) {
+			return SMDecodeResult{}, fmt.Errorf("insufficient data for message trailer CRC64 at offset %d", offset)
+		}
+
+		expectedMsgCRC := binary.LittleEndian.Uint64(smData[offset : offset+8])
+		actualMsgCRC := msgHasher.Sum64()
+		if expectedMsgCRC != actualMsgCRC {
+			return SMDecodeResult{}, fmt.Errorf("message trailer CRC64 mismatch (expected 0x%016x, got 0x%016x)", expectedMsgCRC, actualMsgCRC)
+		}
+	}
+
+	return SMDecodeResult{
+		Data:        result,
+		Version:     version,
+		Flags:       flags,
+		NumSegments: numSegments,
+	}, nil
+}
+
+type hash64 interface {
+	Write(p []byte) (n int, err error)
+	Sum64() uint64
+}
+
+// --- Streaming Encoder ---
+
+// encoder state for the state-machine based SMEncoder
+type encoderState int
+
+const (
+	encStateHeader    encoderState = iota // emitting the 13-byte message header
+	encStateSegHeader                     // emitting a 10-byte segment header
+	encStateSegData                       // streaming segment data from inner source
+	encStateSegFooter                     // emitting an 8-byte segment CRC footer
+	encStateTrailer                       // emitting the 8-byte message trailer CRC
+	encStateDone                          // all bytes emitted
+)
+
+// SMEncoder wraps an io.ReadSeeker source and produces SM-encoded output on Read().
+// CRC64 checksums are computed on-the-fly as content is read from the inner source.
+// Supports Seek(0, io.SeekStart) for retry.
+type SMEncoder struct {
+	inner       io.ReadSeeker
+	contentLen  int64 // total original content length
+	segmentSize int
+	numSegments int
+	encodedLen  int64
+
+	state      encoderState
+	segIndex   int    // current segment (0-based)
+	segRemain  int64  // bytes remaining in current segment data
+	segCRC     hash64 // per-segment CRC hasher
+	msgCRC     hash64 // message-level CRC hasher
+	pending    []byte // buffered framing bytes (headers/footers) being drained
+	pendingOff int    // read offset into pending
+	pos        int64  // current read position in the encoded output
+}
+
+// NewSMEncoder creates a streaming encoder that wraps the given content source.
+// contentLen is the total size of the content (must be known upfront for the SM header).
+// segmentSize specifies the max segment size; use 0 for the default (4MB).
+func NewSMEncoder(inner io.ReadSeeker, contentLen int64, segmentSize int) *SMEncoder {
+	if segmentSize <= 0 {
+		segmentSize = SMDefaultSegmentSize
+	}
+
+	numSegments := int(contentLen) / segmentSize
+	if int(contentLen)%segmentSize != 0 {
+		numSegments++
+	}
+	if numSegments == 0 {
+		numSegments = 1
+	}
+
+	// Calculate total encoded length
+	encodedLen := int64(SMHeaderSize)
+	remaining := contentLen
+	for i := 0; i < numSegments; i++ {
+		segDataLen := int64(segmentSize)
+		if segDataLen > remaining {
+			segDataLen = remaining
+		}
+		encodedLen += int64(SMSegmentHeaderSize) + segDataLen + int64(SMSegmentFooterSize)
+		remaining -= segDataLen
+	}
+	encodedLen += int64(SMMessageTrailerSize)
+
+	e := &SMEncoder{
+		inner:       inner,
+		contentLen:  contentLen,
+		segmentSize: segmentSize,
+		numSegments: numSegments,
+		encodedLen:  encodedLen,
+	}
+	e.initState()
+	return e
+}
+
+func (e *SMEncoder) initState() {
+	e.state = encStateHeader
+	e.segIndex = 0
+	e.segRemain = 0
+	e.segCRC = nil
+	e.msgCRC = crc64.New(CRC64Table)
+	e.pending = nil
+	e.pendingOff = 0
+	e.pos = 0
+
+	// Build the 13-byte message header
+	hdr := make([]byte, SMHeaderSize)
+	hdr[0] = SMVersion
+	binary.LittleEndian.PutUint64(hdr[1:9], uint64(e.encodedLen))
+	binary.LittleEndian.PutUint16(hdr[9:11], SMFlagCRC64)
+	binary.LittleEndian.PutUint16(hdr[11:13], uint16(e.numSegments))
+	e.pending = hdr
+	e.pendingOff = 0
+}
+
+func (e *SMEncoder) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	totalRead := 0
+	for totalRead < len(p) {
+		switch e.state {
+		case encStateHeader:
+			n := e.drainPending(p[totalRead:])
+			totalRead += n
+			e.pos += int64(n)
+			if e.pendingOff >= len(e.pending) {
+				e.advanceToNextSegment()
+			}
+
+		case encStateSegHeader:
+			n := e.drainPending(p[totalRead:])
+			totalRead += n
+			e.pos += int64(n)
+			if e.pendingOff >= len(e.pending) {
+				e.state = encStateSegData
+			}
+
+		case encStateSegData:
+			// Read from inner source, up to segment remaining and caller buffer
+			toRead := int64(len(p) - totalRead)
+			if toRead > e.segRemain {
+				toRead = e.segRemain
+			}
+			n, err := e.inner.Read(p[totalRead : totalRead+int(toRead)])
+			if n > 0 {
+				_, _ = e.segCRC.Write(p[totalRead : totalRead+n])
+				_, _ = e.msgCRC.Write(p[totalRead : totalRead+n])
+				totalRead += n
+				e.pos += int64(n)
+				e.segRemain -= int64(n)
+			}
+			if e.segRemain == 0 {
+				// Segment data fully read — emit footer
+				footer := make([]byte, SMSegmentFooterSize)
+				binary.LittleEndian.PutUint64(footer, e.segCRC.Sum64())
+				e.pending = footer
+				e.pendingOff = 0
+				e.state = encStateSegFooter
+			}
+			if err != nil && e.segRemain > 0 {
+				return totalRead, err
+			}
+
+		case encStateSegFooter:
+			n := e.drainPending(p[totalRead:])
+			totalRead += n
+			e.pos += int64(n)
+			if e.pendingOff >= len(e.pending) {
+				e.advanceToNextSegment()
+			}
+
+		case encStateTrailer:
+			n := e.drainPending(p[totalRead:])
+			totalRead += n
+			e.pos += int64(n)
+			if e.pendingOff >= len(e.pending) {
+				e.state = encStateDone
+			}
+
+		case encStateDone:
+			if totalRead > 0 {
+				return totalRead, nil
+			}
+			return 0, io.EOF
+		}
+	}
+	return totalRead, nil
+}
+
+func (e *SMEncoder) advanceToNextSegment() {
+	if e.segIndex >= e.numSegments {
+		// All segments done — emit trailer
+		trailer := make([]byte, SMMessageTrailerSize)
+		binary.LittleEndian.PutUint64(trailer, e.msgCRC.Sum64())
+		e.pending = trailer
+		e.pendingOff = 0
+		e.state = encStateTrailer
+		return
+	}
+
+	// Calculate this segment's data length
+	segDataLen := int64(e.segmentSize)
+	consumed := int64(e.segIndex) * int64(e.segmentSize)
+	if consumed+segDataLen > e.contentLen {
+		segDataLen = e.contentLen - consumed
+	}
+
+	// Build segment header
+	hdr := make([]byte, SMSegmentHeaderSize)
+	binary.LittleEndian.PutUint16(hdr[0:2], uint16(e.segIndex+1))
+	binary.LittleEndian.PutUint64(hdr[2:10], uint64(segDataLen))
+	e.pending = hdr
+	e.pendingOff = 0
+
+	e.segRemain = segDataLen
+	e.segCRC = crc64.New(CRC64Table)
+	e.segIndex++
+	e.state = encStateSegHeader
+}
+
+func (e *SMEncoder) drainPending(dst []byte) int {
+	n := copy(dst, e.pending[e.pendingOff:])
+	e.pendingOff += n
+	return n
+}
+
+func (e *SMEncoder) Seek(offset int64, whence int) (int64, error) {
+	// Support Seek(0, SeekEnd) to report total encoded length.
+	// This is needed by ValidateSeekableStreamAt0AndGetCount to compute Content-Length.
+	if offset == 0 && whence == io.SeekEnd {
+		return e.encodedLen, nil
+	}
+	// Support Seek(0, SeekCurrent) to report current position in the encoded output.
+	if offset == 0 && whence == io.SeekCurrent {
+		return e.pos, nil
+	}
+	if offset != 0 || whence != io.SeekStart {
+		return 0, fmt.Errorf("SMEncoder: unsupported Seek(%d, %d); only Seek(0, SeekStart), Seek(0, SeekEnd), and Seek(0, SeekCurrent) are supported", offset, whence)
+	}
+	// Reset inner source to beginning
+	if _, err := e.inner.Seek(0, io.SeekStart); err != nil {
+		return 0, err
+	}
+	e.initState()
+	return 0, nil
+}
+
+func (e *SMEncoder) Close() error {
+	if closer, ok := e.inner.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+// OriginalContentLength returns the length of the original unframed content.
+func (e *SMEncoder) OriginalContentLength() int64 {
+	return e.contentLen
+}
+
+// EncodedLength returns the total length of the SM-encoded output.
+func (e *SMEncoder) EncodedLength() int64 {
+	return e.encodedLen
+}
+
+// --- Streaming Decoder ---
+
+// decoder state for the state-machine based SMDecoder
+type decoderState int
+
+const (
+	decStateHeader    decoderState = iota // reading the 13-byte message header
+	decStateSegHeader                     // reading a 10-byte segment header
+	decStateSegData                       // streaming segment data to caller
+	decStateSegFooter                     // reading an 8-byte segment CRC footer
+	decStateTrailer                       // reading the 8-byte message trailer CRC
+	decStateDone                          // all data consumed and validated
+	decStateError                         // terminal error state
+)
+
+// SMDecoder wraps an SM-encoded io.ReadCloser and yields raw content on Read().
+// Framing is parsed incrementally and CRC64 checksums are validated per-segment on-the-fly.
+type SMDecoder struct {
+	source io.ReadCloser
+
+	state     decoderState
+	frameBuf  []byte // small buffer for accumulating framing bytes
+	frameNeed int    // how many bytes we need to accumulate
+	frameHave int    // how many bytes accumulated so far
+
+	// Message-level metadata (populated after header is parsed)
+	version     uint8
+	flags       uint16
+	numSegments uint16
+	hasCRC      bool
+	msgLen      uint64
+
+	// Segment tracking
+	segIndex  uint16 // 1-based segment number currently being processed
+	segRemain int64  // bytes remaining in current segment data
+	segCRC    hash64 // per-segment CRC hasher
+	msgCRC    hash64 // message-level CRC hasher
+	bytesRead int64  // total bytes read from source (for length validation)
+
+	err error
+}
+
+// NewSMDecoder creates a streaming decoder that wraps an SM-encoded body.
+// CRC64 checksums are validated per-segment as data flows through.
+func NewSMDecoder(body io.ReadCloser) *SMDecoder {
+	d := &SMDecoder{
+		source:    body,
+		state:     decStateHeader,
+		frameBuf:  make([]byte, SMHeaderSize), // reused for all framing reads
+		frameNeed: SMHeaderSize,
+		frameHave: 0,
+	}
+	return d
+}
+
+func (d *SMDecoder) Read(p []byte) (int, error) {
+	if d.err != nil {
+		return 0, d.err
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	totalOut := 0
+	for totalOut < len(p) {
+		switch d.state {
+		case decStateHeader:
+			done, err := d.fillFrame()
+			if err != nil {
+				d.setError(err)
+				return totalOut, d.err
+			}
+			if !done {
+				return totalOut, nil
+			}
+			if err := d.parseHeader(); err != nil {
+				d.setError(err)
+				return totalOut, d.err
+			}
+
+		case decStateSegHeader:
+			done, err := d.fillFrame()
+			if err != nil {
+				d.setError(err)
+				return totalOut, d.err
+			}
+			if !done {
+				return totalOut, nil
+			}
+			if err := d.parseSegmentHeader(); err != nil {
+				d.setError(err)
+				return totalOut, d.err
+			}
+
+		case decStateSegData:
+			// Read segment data from source, pass through to caller
+			toRead := int64(len(p) - totalOut)
+			if toRead > d.segRemain {
+				toRead = d.segRemain
+			}
+			n, err := d.source.Read(p[totalOut : totalOut+int(toRead)])
+			if n > 0 {
+				d.bytesRead += int64(n)
+				if d.hasCRC {
+					_, _ = d.segCRC.Write(p[totalOut : totalOut+n])
+					_, _ = d.msgCRC.Write(p[totalOut : totalOut+n])
+				}
+				totalOut += n
+				d.segRemain -= int64(n)
+			}
+			if d.segRemain == 0 {
+				// Segment data done
+				if d.hasCRC {
+					d.prepareFrame(SMSegmentFooterSize)
+					d.state = decStateSegFooter
+				} else {
+					d.advanceAfterSegment()
+				}
+			}
+			if err != nil && d.segRemain > 0 {
+				d.setError(fmt.Errorf("segment %d: %s", d.segIndex, err))
+				return totalOut, d.err
+			}
+
+		case decStateSegFooter:
+			done, err := d.fillFrame()
+			if err != nil {
+				d.setError(err)
+				return totalOut, d.err
+			}
+			if !done {
+				return totalOut, nil
+			}
+			if err := d.validateSegmentCRC(); err != nil {
+				d.setError(err)
+				return totalOut, d.err
+			}
+
+		case decStateTrailer:
+			done, err := d.fillFrame()
+			if err != nil {
+				d.setError(err)
+				return totalOut, d.err
+			}
+			if !done {
+				return totalOut, nil
+			}
+			if err := d.validateTrailerCRC(); err != nil {
+				d.setError(err)
+				return totalOut, d.err
+			}
+
+		case decStateDone:
+			if totalOut > 0 {
+				return totalOut, nil
+			}
+			return 0, io.EOF
+
+		case decStateError:
+			return totalOut, d.err
+		}
+	}
+	return totalOut, nil
+}
+
+func (d *SMDecoder) parseHeader() error {
+	buf := d.frameBuf[:SMHeaderSize]
+	d.version = buf[0]
+	if d.version != SMVersion {
+		return fmt.Errorf("unsupported structured message version: %d (expected %d)", d.version, SMVersion)
+	}
+
+	d.msgLen = binary.LittleEndian.Uint64(buf[1:9])
+	d.flags = binary.LittleEndian.Uint16(buf[9:11])
+	d.numSegments = binary.LittleEndian.Uint16(buf[11:13])
+	d.hasCRC = d.flags&SMFlagCRC64 != 0
+
+	if d.hasCRC {
+		d.msgCRC = crc64.New(CRC64Table)
+	}
+
+	d.segIndex = 0
+	d.prepareFrame(SMSegmentHeaderSize)
+	d.state = decStateSegHeader
+	return nil
+}
+
+func (d *SMDecoder) parseSegmentHeader() error {
+	buf := d.frameBuf[:SMSegmentHeaderSize]
+	segNum := binary.LittleEndian.Uint16(buf[0:2])
+	segDataLen := binary.LittleEndian.Uint64(buf[2:10])
+
+	d.segIndex++
+	if segNum != d.segIndex {
+		return fmt.Errorf("segment number mismatch: expected %d, got %d", d.segIndex, segNum)
+	}
+
+	maxSegmentDataLen := uint64(int(^uint(0) >> 1))
+	if segDataLen > maxSegmentDataLen {
+		return fmt.Errorf("segment %d: data length %d exceeds supported size", segNum, segDataLen)
+	}
+
+	d.segRemain = int64(segDataLen)
+	if d.hasCRC {
+		d.segCRC = crc64.New(CRC64Table)
+	}
+	d.state = decStateSegData
+	return nil
+}
+
+func (d *SMDecoder) validateSegmentCRC() error {
+	expected := binary.LittleEndian.Uint64(d.frameBuf[:SMSegmentFooterSize])
+	actual := d.segCRC.Sum64()
+	if expected != actual {
+		return fmt.Errorf("segment %d: CRC64 mismatch (expected 0x%016x, got 0x%016x)", d.segIndex, expected, actual)
+	}
+	d.advanceAfterSegment()
+	return nil
+}
+
+func (d *SMDecoder) advanceAfterSegment() {
+	if d.segIndex >= d.numSegments {
+		if d.hasCRC {
+			d.prepareFrame(SMMessageTrailerSize)
+			d.state = decStateTrailer
+		} else {
+			d.state = decStateDone
+		}
+	} else {
+		d.prepareFrame(SMSegmentHeaderSize)
+		d.state = decStateSegHeader
+	}
+}
+
+func (d *SMDecoder) validateTrailerCRC() error {
+	expected := binary.LittleEndian.Uint64(d.frameBuf[:SMMessageTrailerSize])
+	actual := d.msgCRC.Sum64()
+	if expected != actual {
+		return fmt.Errorf("message trailer CRC64 mismatch (expected 0x%016x, got 0x%016x)", expected, actual)
+	}
+	d.state = decStateDone
+	return nil
+}
+
+// fillFrame reads from source into frameBuf until frameNeed bytes are accumulated.
+// Returns (true, nil) when the full frame is available.
+func (d *SMDecoder) fillFrame() (bool, error) {
+	for d.frameHave < d.frameNeed {
+		n, err := d.source.Read(d.frameBuf[d.frameHave:d.frameNeed])
+		d.frameHave += n
+		d.bytesRead += int64(n)
+		if d.frameHave >= d.frameNeed {
+			return true, nil
+		}
+		if err != nil {
+			if err == io.EOF {
+				return false, fmt.Errorf("unexpected EOF reading structured message framing (have %d of %d bytes)", d.frameHave, d.frameNeed)
+			}
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+func (d *SMDecoder) prepareFrame(size int) {
+	if cap(d.frameBuf) < size {
+		d.frameBuf = make([]byte, size)
+	} else {
+		d.frameBuf = d.frameBuf[:size]
+	}
+	d.frameNeed = size
+	d.frameHave = 0
+}
+
+func (d *SMDecoder) setError(err error) {
+	d.err = err
+	d.state = decStateError
+}
+
+func (d *SMDecoder) Close() error {
+	if d.source != nil {
+		return d.source.Close()
+	}
+	return nil
+}
+
+// DecodeResult returns the decoded message metadata after the header has been parsed.
+// Returns nil if the header has not yet been read.
+func (d *SMDecoder) DecodeResult() *SMDecodeResult {
+	if d.state == decStateHeader {
+		return nil
+	}
+	return &SMDecodeResult{
+		Version:     d.version,
+		Flags:       d.flags,
+		NumSegments: d.numSegments,
+	}
+}

--- a/sdk/storage/azblob/internal/shared/structured_message.go
+++ b/sdk/storage/azblob/internal/shared/structured_message.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"hash/crc64"
 	"io"
+	"math"
 )
 
 // Structured Message (XSM/1.0) constants
@@ -293,6 +294,16 @@ func NewSMEncoder(inner io.ReadSeeker, contentLen int64, segmentSize int) *SMEnc
 	}
 	if numSegments == 0 {
 		numSegments = 1
+	}
+
+	// Segment count is stored as uint16 in the SM header. If the content is too large
+	// for the given segment size, auto-increase segment size to fit within uint16 max.
+	if numSegments > math.MaxUint16 {
+		segmentSize = int(math.Ceil(float64(contentLen) / float64(math.MaxUint16)))
+		numSegments = int(contentLen) / segmentSize
+		if int(contentLen)%segmentSize != 0 {
+			numSegments++
+		}
 	}
 
 	// Calculate total encoded length

--- a/sdk/storage/azblob/internal/shared/structured_message_bench_test.go
+++ b/sdk/storage/azblob/internal/shared/structured_message_bench_test.go
@@ -1,0 +1,305 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package shared
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"hash/crc64"
+	"io"
+	"testing"
+)
+
+// data sizes used across benchmarks
+var benchSizes = []struct {
+	name string
+	size int
+}{
+	{"1KB", 1 * 1024},
+	{"64KB", 64 * 1024},
+	{"1MB", 1 * 1024 * 1024},
+	{"4MB", 4 * 1024 * 1024},
+	{"16MB", 16 * 1024 * 1024},
+	{"100MB", 100 * 1024 * 1024},
+}
+
+func makeBenchData(size int) []byte {
+	data := make([]byte, size)
+	_, _ = rand.Read(data)
+	return data
+}
+
+// ── CRC64 baseline ──
+// Measures raw CRC64 computation cost — the theoretical minimum overhead for any
+// integrity check. SM benchmarks should be compared against this baseline.
+
+func BenchmarkCRC64Checksum(b *testing.B) {
+	for _, sz := range benchSizes {
+		data := makeBenchData(sz.size)
+		b.Run(sz.name, func(b *testing.B) {
+			b.SetBytes(int64(sz.size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				crc64.Checksum(data, CRC64Table)
+			}
+		})
+	}
+}
+
+// ── In-memory encode/decode ──
+
+func BenchmarkSMEncode(b *testing.B) {
+	for _, sz := range benchSizes {
+		data := makeBenchData(sz.size)
+		b.Run(sz.name, func(b *testing.B) {
+			b.SetBytes(int64(sz.size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				SMEncode(data, 0)
+			}
+		})
+	}
+}
+
+func BenchmarkSMDecode(b *testing.B) {
+	for _, sz := range benchSizes {
+		data := makeBenchData(sz.size)
+		encoded := SMEncode(data, 0)
+		b.Run(sz.name, func(b *testing.B) {
+			b.SetBytes(int64(sz.size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = SMDecode(encoded.EncodedData)
+			}
+		})
+	}
+}
+
+// ── Streaming encoder ──
+
+func BenchmarkSMEncoderRead(b *testing.B) {
+	for _, sz := range benchSizes {
+		data := makeBenchData(sz.size)
+		b.Run(sz.name, func(b *testing.B) {
+			b.SetBytes(int64(sz.size))
+			buf := make([]byte, 32*1024) // 32KB read buffer (typical io.Copy size)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				reader := bytes.NewReader(data)
+				encoder := NewSMEncoder(reader, int64(sz.size), 0)
+				for {
+					_, err := encoder.Read(buf)
+					if err == io.EOF {
+						break
+					}
+				}
+			}
+		})
+	}
+}
+
+// ── Streaming decoder ──
+
+func BenchmarkSMDecoderRead(b *testing.B) {
+	for _, sz := range benchSizes {
+		data := makeBenchData(sz.size)
+		encoded := SMEncode(data, 0)
+		b.Run(sz.name, func(b *testing.B) {
+			b.SetBytes(int64(sz.size))
+			buf := make([]byte, 32*1024)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				body := io.NopCloser(bytes.NewReader(encoded.EncodedData))
+				decoder := NewSMDecoder(body)
+				for {
+					_, err := decoder.Read(buf)
+					if err == io.EOF {
+						break
+					}
+				}
+			}
+		})
+	}
+}
+
+// ── Encoder seek/retry ──
+// Measures the cost of seeking back to 0 and re-reading (simulates retry).
+
+func BenchmarkSMEncoderSeekAndReread(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"1KB", 1 * 1024},
+		{"1MB", 1 * 1024 * 1024},
+		{"4MB", 4 * 1024 * 1024},
+	}
+	for _, sz := range sizes {
+		data := makeBenchData(sz.size)
+		b.Run(sz.name, func(b *testing.B) {
+			b.SetBytes(int64(sz.size))
+			buf := make([]byte, 32*1024)
+			reader := bytes.NewReader(data)
+			encoder := NewSMEncoder(reader, int64(sz.size), 0)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = encoder.Seek(0, io.SeekStart)
+				for {
+					_, err := encoder.Read(buf)
+					if err == io.EOF {
+						break
+					}
+				}
+			}
+		})
+	}
+}
+
+// ── Encode + Decode round-trip ──
+
+func BenchmarkSMRoundTrip(b *testing.B) {
+	for _, sz := range benchSizes {
+		data := makeBenchData(sz.size)
+		b.Run(sz.name, func(b *testing.B) {
+			b.SetBytes(int64(sz.size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				result := SMEncode(data, 0)
+				_, _ = SMDecode(result.EncodedData)
+			}
+		})
+	}
+}
+
+// ── Streaming round-trip (encoder → decoder) ──
+
+func BenchmarkSMStreamingRoundTrip(b *testing.B) {
+	for _, sz := range benchSizes {
+		data := makeBenchData(sz.size)
+		b.Run(sz.name, func(b *testing.B) {
+			b.SetBytes(int64(sz.size))
+			buf := make([]byte, 32*1024)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				// Encode: read all from encoder into a buffer
+				reader := bytes.NewReader(data)
+				encoder := NewSMEncoder(reader, int64(sz.size), 0)
+				var encoded bytes.Buffer
+				encoded.Grow(sz.size + sz.size/10) // ~10% overhead estimate
+				for {
+					n, err := encoder.Read(buf)
+					if n > 0 {
+						encoded.Write(buf[:n])
+					}
+					if err == io.EOF {
+						break
+					}
+				}
+				// Decode: stream through decoder
+				body := io.NopCloser(bytes.NewReader(encoded.Bytes()))
+				decoder := NewSMDecoder(body)
+				for {
+					_, err := decoder.Read(buf)
+					if err == io.EOF {
+						break
+					}
+				}
+			}
+		})
+	}
+}
+
+// ── ComputeCRC64 (2-pass) vs SM CRC64 (single-pass) ──
+// ComputeCRC64 reads the entire body to compute CRC, then the body is re-read for the HTTP send.
+// SM CRC64 computes CRC on-the-fly during a single read pass.
+
+func BenchmarkComputeCRC64VsSMEncoder(b *testing.B) {
+	for _, sz := range benchSizes {
+		data := makeBenchData(sz.size)
+
+		// Simulate ComputeCRC64: ReadAll + Checksum + re-read (2-pass)
+		b.Run(fmt.Sprintf("ComputeCRC64_2pass/%s", sz.name), func(b *testing.B) {
+			b.SetBytes(int64(sz.size))
+			buf := make([]byte, 32*1024)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				// Pass 1: read all + compute CRC
+				reader := bytes.NewReader(data)
+				allData, _ := io.ReadAll(reader)
+				crc64.Checksum(allData, CRC64Table)
+
+				// Pass 2: re-read the data (simulates HTTP send)
+				reader2 := bytes.NewReader(allData)
+				for {
+					_, err := reader2.Read(buf)
+					if err == io.EOF {
+						break
+					}
+				}
+			}
+		})
+
+		// SM Encoder: single-pass streaming CRC
+		b.Run(fmt.Sprintf("SMEncoder_1pass/%s", sz.name), func(b *testing.B) {
+			b.SetBytes(int64(sz.size))
+			buf := make([]byte, 32*1024)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				reader := bytes.NewReader(data)
+				encoder := NewSMEncoder(reader, int64(sz.size), 0)
+				for {
+					_, err := encoder.Read(buf)
+					if err == io.EOF {
+						break
+					}
+				}
+			}
+		})
+	}
+}
+
+// ── Segment size impact ──
+// Measures how different segment sizes affect encoding performance for a fixed data size.
+
+func BenchmarkSMEncodeSegmentSizes(b *testing.B) {
+	dataSize := 16 * 1024 * 1024 // 16MB
+	data := makeBenchData(dataSize)
+	segSizes := []struct {
+		name string
+		size int
+	}{
+		{"256KB", 256 * 1024},
+		{"1MB", 1 * 1024 * 1024},
+		{"4MB_default", 4 * 1024 * 1024},
+		{"8MB", 8 * 1024 * 1024},
+		{"16MB", 16 * 1024 * 1024},
+	}
+	for _, seg := range segSizes {
+		b.Run(fmt.Sprintf("data16MB_seg%s", seg.name), func(b *testing.B) {
+			b.SetBytes(int64(dataSize))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				SMEncode(data, seg.size)
+			}
+		})
+	}
+}
+
+// ── Overhead measurement ──
+// Compares raw io.Copy throughput vs SM encoder throughput to quantify framing overhead.
+
+func BenchmarkBaselineIOCopy(b *testing.B) {
+	for _, sz := range benchSizes {
+		data := makeBenchData(sz.size)
+		b.Run(sz.name, func(b *testing.B) {
+			b.SetBytes(int64(sz.size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				reader := bytes.NewReader(data)
+				_, _ = io.Copy(io.Discard, reader)
+			}
+		})
+	}
+}

--- a/sdk/storage/azblob/internal/shared/structured_message_test.go
+++ b/sdk/storage/azblob/internal/shared/structured_message_test.go
@@ -1,0 +1,555 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package shared
+
+import (
+	"bytes"
+	"encoding/binary"
+	"hash/crc64"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecodeRoundTripSmallData(t *testing.T) {
+	data := []byte("Hello, structured message!")
+	result := SMEncode(data, 0)
+
+	require.Equal(t, int64(len(data)), result.OriginalContentLength)
+	require.Greater(t, len(result.EncodedData), len(data))
+
+	decoded, err := SMDecode(result.EncodedData)
+	require.NoError(t, err)
+	require.Equal(t, data, decoded.Data)
+	require.Equal(t, SMVersion, decoded.Version)
+	require.Equal(t, SMFlagCRC64, decoded.Flags)
+	require.Equal(t, uint16(1), decoded.NumSegments)
+}
+
+func TestEncodeDecodeRoundTripEmptyData(t *testing.T) {
+	data := []byte{}
+	result := SMEncode(data, 0)
+
+	require.Equal(t, int64(0), result.OriginalContentLength)
+
+	decoded, err := SMDecode(result.EncodedData)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(decoded.Data))
+	require.Equal(t, uint16(1), decoded.NumSegments)
+}
+
+func TestEncodeDecodeRoundTripExactSegmentSize(t *testing.T) {
+	segSize := 1024
+	data := make([]byte, segSize)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+	result := SMEncode(data, segSize)
+
+	require.Equal(t, int64(segSize), result.OriginalContentLength)
+
+	decoded, err := SMDecode(result.EncodedData)
+	require.NoError(t, err)
+	require.Equal(t, data, decoded.Data)
+	require.Equal(t, uint16(1), decoded.NumSegments)
+}
+
+func TestEncodeDecodeRoundTripMultiSegment(t *testing.T) {
+	segSize := 100
+	data := make([]byte, 350) // 4 segments: 100 + 100 + 100 + 50
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+	result := SMEncode(data, segSize)
+
+	decoded, err := SMDecode(result.EncodedData)
+	require.NoError(t, err)
+	require.Equal(t, data, decoded.Data)
+	require.Equal(t, uint16(4), decoded.NumSegments)
+}
+
+func TestEncodeDecodeRoundTripLargerData(t *testing.T) {
+	data := make([]byte, 1024*1024) // 1MB
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+
+	segSize := 256 * 1024 // 256KB segments => 4 segments
+	result := SMEncode(data, segSize)
+
+	require.Equal(t, int64(len(data)), result.OriginalContentLength)
+
+	decoded, err := SMDecode(result.EncodedData)
+	require.NoError(t, err)
+	require.Equal(t, data, decoded.Data)
+	require.Equal(t, uint16(4), decoded.NumSegments)
+}
+
+func TestEncodeDecodeRoundTripSingleByte(t *testing.T) {
+	data := []byte{0x42}
+	result := SMEncode(data, 0)
+
+	decoded, err := SMDecode(result.EncodedData)
+	require.NoError(t, err)
+	require.Equal(t, data, decoded.Data)
+}
+
+func TestEncodeDecodeRoundTripSegmentSizeOne(t *testing.T) {
+	data := []byte("ABC")
+	result := SMEncode(data, 1)
+
+	decoded, err := SMDecode(result.EncodedData)
+	require.NoError(t, err)
+	require.Equal(t, data, decoded.Data)
+	require.Equal(t, uint16(3), decoded.NumSegments)
+}
+
+func TestEncodeMessageFormat(t *testing.T) {
+	data := []byte("ABCDEFGHIJ") // 10 bytes
+	segSize := 5                 // 2 segments of 5 bytes each
+	result := SMEncode(data, segSize)
+
+	smData := result.EncodedData
+
+	// Verify Message Header
+	require.Equal(t, SMVersion, smData[0])
+
+	msgLen := binary.LittleEndian.Uint64(smData[1:9])
+	require.Equal(t, uint64(len(smData)), msgLen)
+
+	flags := binary.LittleEndian.Uint16(smData[9:11])
+	require.Equal(t, SMFlagCRC64, flags)
+
+	numSegments := binary.LittleEndian.Uint16(smData[11:13])
+	require.Equal(t, uint16(2), numSegments)
+
+	offset := SMHeaderSize
+
+	// Segment 1
+	segNum1 := binary.LittleEndian.Uint16(smData[offset : offset+2])
+	require.Equal(t, uint16(1), segNum1)
+	segLen1 := int64(binary.LittleEndian.Uint64(smData[offset+2 : offset+10]))
+	require.Equal(t, int64(5), segLen1)
+	offset += SMSegmentHeaderSize
+
+	seg1Data := smData[offset : offset+5]
+	require.Equal(t, []byte("ABCDE"), seg1Data)
+	offset += 5
+
+	seg1CRC := binary.LittleEndian.Uint64(smData[offset : offset+8])
+	expectedSeg1CRC := crc64.Checksum([]byte("ABCDE"), CRC64Table)
+	require.Equal(t, expectedSeg1CRC, seg1CRC)
+	offset += 8
+
+	// Segment 2
+	segNum2 := binary.LittleEndian.Uint16(smData[offset : offset+2])
+	require.Equal(t, uint16(2), segNum2)
+	segLen2 := int64(binary.LittleEndian.Uint64(smData[offset+2 : offset+10]))
+	require.Equal(t, int64(5), segLen2)
+	offset += SMSegmentHeaderSize
+
+	seg2Data := smData[offset : offset+5]
+	require.Equal(t, []byte("FGHIJ"), seg2Data)
+	offset += 5
+
+	seg2CRC := binary.LittleEndian.Uint64(smData[offset : offset+8])
+	expectedSeg2CRC := crc64.Checksum([]byte("FGHIJ"), CRC64Table)
+	require.Equal(t, expectedSeg2CRC, seg2CRC)
+	offset += 8
+
+	// Message Trailer CRC64
+	msgCRC := binary.LittleEndian.Uint64(smData[offset : offset+8])
+	expectedMsgCRC := crc64.Checksum(data, CRC64Table)
+	require.Equal(t, expectedMsgCRC, msgCRC)
+	offset += 8
+
+	require.Equal(t, len(smData), offset)
+}
+
+func TestEncodeDefaultSegmentSize(t *testing.T) {
+	data := make([]byte, 100)
+	result := SMEncode(data, 0)
+
+	// With default 4MB segment size, 100 bytes should be 1 segment
+	decoded, err := SMDecode(result.EncodedData)
+	require.NoError(t, err)
+	require.Equal(t, uint16(1), decoded.NumSegments)
+}
+
+func TestEncodeMessageLength(t *testing.T) {
+	data := []byte("ABCDEFGHIJ") // 10 bytes
+	segSize := 5                 // 2 segments
+
+	// Expected length:
+	// Header: 13
+	// Segment 1: 10 (header) + 5 (data) + 8 (CRC) = 23
+	// Segment 2: 10 (header) + 5 (data) + 8 (CRC) = 23
+	// Trailer: 8
+	// Total: 13 + 23 + 23 + 8 = 67
+
+	result := SMEncode(data, segSize)
+	require.Equal(t, 67, len(result.EncodedData))
+}
+
+func TestEncodeCRC64MatchesSharedTable(t *testing.T) {
+	data := []byte("CRC validation test data")
+	expectedCRC := crc64.Checksum(data, CRC64Table)
+
+	result := SMEncode(data, 0)
+	smData := result.EncodedData
+
+	// Trailer CRC is last 8 bytes
+	trailerCRC := binary.LittleEndian.Uint64(smData[len(smData)-8:])
+	require.Equal(t, expectedCRC, trailerCRC)
+}
+
+func TestDecodeInvalid(t *testing.T) {
+	badInputs := []struct {
+		name    string
+		data    []byte
+		errText string
+	}{
+		{
+			name:    "TruncatedHeader",
+			data:    []byte{1, 2, 3},
+			errText: "too short for header",
+		},
+		{
+			name:    "WrongVersion",
+			data:    makeCorruptedSM([]byte("test"), func(d []byte) { d[0] = 99 }),
+			errText: "unsupported structured message version",
+		},
+		{
+			name:    "LengthMismatch",
+			data:    makeCorruptedSM([]byte("test"), func(d []byte) { binary.LittleEndian.PutUint64(d[1:9], 999) }),
+			errText: "length mismatch",
+		},
+		{
+			name:    "CorruptedSegmentCRC",
+			data:    makeCorruptedSM([]byte("Hello, world!"), func(d []byte) { d[36] ^= 0xFF }),
+			errText: "CRC64 mismatch",
+		},
+		{
+			name:    "CorruptedData",
+			data:    makeCorruptedSM([]byte("Hello, world!"), func(d []byte) { d[25] ^= 0xFF }),
+			errText: "CRC64 mismatch",
+		},
+		{
+			name:    "CorruptedTrailerCRC",
+			data:    makeCorruptedSM([]byte("Hello, world!"), func(d []byte) { d[len(d)-1] ^= 0xFF }),
+			errText: "", // could be segment or trailer mismatch
+		},
+	}
+
+	for _, tt := range badInputs {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := SMDecode(tt.data)
+			require.Error(t, err)
+			if tt.errText != "" {
+				require.Contains(t, err.Error(), tt.errText)
+			}
+		})
+	}
+}
+
+func TestDecodeSegmentLengthExceedsSupportedSize(t *testing.T) {
+	data := makeCorruptedSM([]byte("test"), func(d []byte) {
+		binary.LittleEndian.PutUint64(d[15:23], ^uint64(0))
+	})
+
+	_, err := SMDecode(data)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds supported size")
+}
+
+// makeCorruptedSM encodes data then applies a corruption function on the result.
+func makeCorruptedSM(data []byte, corrupt func([]byte)) []byte {
+	result := SMEncode(data, 0)
+	smData := make([]byte, len(result.EncodedData))
+	copy(smData, result.EncodedData)
+	corrupt(smData)
+	return smData
+}
+
+func TestEncoderReadSeekClose(t *testing.T) {
+	data := []byte("encoder test data")
+	enc := NewSMEncoder(bytes.NewReader(data), int64(len(data)), 0)
+
+	require.Equal(t, int64(len(data)), enc.OriginalContentLength())
+	require.Greater(t, enc.EncodedLength(), int64(len(data)))
+
+	// Read all
+	buf := make([]byte, enc.EncodedLength())
+	n, err := io.ReadFull(enc, buf)
+	require.NoError(t, err)
+	require.Equal(t, int(enc.EncodedLength()), n)
+
+	// Seek back to start
+	pos, err := enc.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), pos)
+
+	// Read again and compare
+	buf2 := make([]byte, enc.EncodedLength())
+	n2, err := io.ReadFull(enc, buf2)
+	require.NoError(t, err)
+	require.Equal(t, int(enc.EncodedLength()), n2)
+	require.Equal(t, buf, buf2)
+
+	require.NoError(t, enc.Close())
+
+	// Decode the output to verify correctness
+	decoded, err := SMDecode(buf)
+	require.NoError(t, err)
+	require.Equal(t, data, decoded.Data)
+}
+
+func TestEncoderAsReadSeekCloser(t *testing.T) {
+	data := []byte("interface compliance test")
+	enc := NewSMEncoder(bytes.NewReader(data), int64(len(data)), 0)
+
+	var _ io.ReadSeekCloser = enc
+
+	allData, err := io.ReadAll(enc)
+	require.NoError(t, err)
+	require.Equal(t, int(enc.EncodedLength()), len(allData))
+}
+
+func TestDecoderReadClose(t *testing.T) {
+	data := []byte("decoder test with some content here")
+	result := SMEncode(data, 10)
+
+	body := io.NopCloser(bytes.NewReader(result.EncodedData))
+	dec := NewSMDecoder(body)
+
+	rawData, err := io.ReadAll(dec)
+	require.NoError(t, err)
+	require.Equal(t, data, rawData)
+
+	decResult := dec.DecodeResult()
+	require.NotNil(t, decResult)
+	require.Equal(t, SMVersion, decResult.Version)
+	require.Equal(t, SMFlagCRC64, decResult.Flags)
+
+	require.NoError(t, dec.Close())
+}
+
+func TestDecoderInvalidBody(t *testing.T) {
+	body := io.NopCloser(bytes.NewReader([]byte{0xFF, 0x01, 0x02}))
+	dec := NewSMDecoder(body)
+
+	_, err := io.ReadAll(dec)
+	require.Error(t, err)
+}
+
+func TestDecoderDecodeResultBeforeRead(t *testing.T) {
+	data := []byte("test")
+	result := SMEncode(data, 0)
+	body := io.NopCloser(bytes.NewReader(result.EncodedData))
+	dec := NewSMDecoder(body)
+
+	require.Nil(t, dec.DecodeResult())
+}
+
+func TestStructuredMessageConstants(t *testing.T) {
+	require.Equal(t, uint8(1), SMVersion)
+	require.Equal(t, uint16(0x0001), SMFlagCRC64)
+	require.Equal(t, 4*1024*1024, SMDefaultSegmentSize)
+	require.Equal(t, 13, SMHeaderSize)
+	require.Equal(t, 10, SMSegmentHeaderSize)
+	require.Equal(t, 8, SMSegmentFooterSize)
+	require.Equal(t, 8, SMMessageTrailerSize)
+	require.Equal(t, "XSM/1.0; properties=crc64", SMHeaderValue)
+}
+
+func TestStreamingEncoderMatchesInMemoryEncode(t *testing.T) {
+	data := []byte("ABCDEFGHIJ") // 10 bytes
+	segSize := 5                 // 2 segments
+
+	// In-memory encode
+	inMemResult := SMEncode(data, segSize)
+
+	// Streaming encode
+	enc := NewSMEncoder(bytes.NewReader(data), int64(len(data)), segSize)
+	streamResult, err := io.ReadAll(enc)
+	require.NoError(t, err)
+
+	require.Equal(t, inMemResult.EncodedData, streamResult)
+	require.Equal(t, int64(len(data)), enc.OriginalContentLength())
+	require.Equal(t, int64(len(inMemResult.EncodedData)), enc.EncodedLength())
+}
+
+func TestStreamingEncoderMultiSegment(t *testing.T) {
+	data := make([]byte, 350) // 4 segments with segSize=100
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+	enc := NewSMEncoder(bytes.NewReader(data), int64(len(data)), 100)
+	encoded, err := io.ReadAll(enc)
+	require.NoError(t, err)
+
+	// Verify by decoding
+	decoded, err := SMDecode(encoded)
+	require.NoError(t, err)
+	require.Equal(t, data, decoded.Data)
+	require.Equal(t, uint16(4), decoded.NumSegments)
+}
+
+func TestStreamingEncoderEmpty(t *testing.T) {
+	data := []byte{}
+	enc := NewSMEncoder(bytes.NewReader(data), 0, 0)
+	encoded, err := io.ReadAll(enc)
+	require.NoError(t, err)
+
+	decoded, err := SMDecode(encoded)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(decoded.Data))
+	require.Equal(t, uint16(1), decoded.NumSegments)
+}
+
+func TestStreamingEncoderSmallReads(t *testing.T) {
+	// Test that the encoder works correctly with very small read buffers
+	data := []byte("small buffer test data here!")
+	enc := NewSMEncoder(bytes.NewReader(data), int64(len(data)), 10)
+
+	var result []byte
+	buf := make([]byte, 3) // intentionally small buffer
+	for {
+		n, err := enc.Read(buf)
+		result = append(result, buf[:n]...)
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+	}
+
+	decoded, err := SMDecode(result)
+	require.NoError(t, err)
+	require.Equal(t, data, decoded.Data)
+}
+
+func TestStreamingEncoderToStreamingDecoder(t *testing.T) {
+	data := make([]byte, 1024)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+
+	// Encode with streaming encoder
+	enc := NewSMEncoder(bytes.NewReader(data), int64(len(data)), 256)
+	encoded, err := io.ReadAll(enc)
+	require.NoError(t, err)
+
+	// Decode with streaming decoder
+	dec := NewSMDecoder(io.NopCloser(bytes.NewReader(encoded)))
+	rawData, err := io.ReadAll(dec)
+	require.NoError(t, err)
+	require.Equal(t, data, rawData)
+
+	decResult := dec.DecodeResult()
+	require.NotNil(t, decResult)
+	require.Equal(t, SMVersion, decResult.Version)
+	require.Equal(t, SMFlagCRC64, decResult.Flags)
+	require.Equal(t, uint16(4), decResult.NumSegments)
+}
+
+func TestStreamingDecoderSmallReads(t *testing.T) {
+	data := []byte("streaming decode with tiny buffer")
+	smData := SMEncode(data, 10)
+
+	dec := NewSMDecoder(io.NopCloser(bytes.NewReader(smData.EncodedData)))
+
+	var result []byte
+	buf := make([]byte, 5) // intentionally small buffer
+	for {
+		n, err := dec.Read(buf)
+		result = append(result, buf[:n]...)
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+	}
+	require.Equal(t, data, result)
+}
+
+func TestStreamingDecoderCRCMismatch(t *testing.T) {
+	// Corrupt segment data in an SM payload
+	smData := makeCorruptedSM([]byte("Hello, world!"), func(d []byte) { d[25] ^= 0xFF })
+
+	dec := NewSMDecoder(io.NopCloser(bytes.NewReader(smData)))
+	_, err := io.ReadAll(dec)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CRC64 mismatch")
+}
+
+func TestStreamingDecoderTrailerCRCMismatch(t *testing.T) {
+	// Corrupt trailer CRC
+	smData := makeCorruptedSM([]byte("test"), func(d []byte) { d[len(d)-1] ^= 0xFF })
+
+	dec := NewSMDecoder(io.NopCloser(bytes.NewReader(smData)))
+	_, err := io.ReadAll(dec)
+	require.Error(t, err)
+}
+
+func TestStreamingDecoderBadVersion(t *testing.T) {
+	smData := makeCorruptedSM([]byte("test"), func(d []byte) { d[0] = 99 })
+
+	dec := NewSMDecoder(io.NopCloser(bytes.NewReader(smData)))
+	_, err := io.ReadAll(dec)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported structured message version")
+}
+
+func TestStreamingEncoderSeekSupport(t *testing.T) {
+	data := []byte("seek test")
+	enc := NewSMEncoder(bytes.NewReader(data), int64(len(data)), 0)
+
+	// Seek(0, SeekEnd) returns encoded length
+	pos, err := enc.Seek(0, io.SeekEnd)
+	require.NoError(t, err)
+	require.Equal(t, enc.EncodedLength(), pos)
+
+	// Seek(0, SeekCurrent) at initial position returns 0
+	pos, err = enc.Seek(0, io.SeekCurrent)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), pos)
+
+	// After reading some data, SeekCurrent returns exact position
+	buf := make([]byte, 1)
+	_, _ = enc.Read(buf)
+	pos, err = enc.Seek(0, io.SeekCurrent)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), pos)
+
+	// Non-zero offset should fail
+	_, err = enc.Seek(1, io.SeekStart)
+	require.Error(t, err)
+
+	// Non-zero offset with SeekEnd should fail
+	_, err = enc.Seek(1, io.SeekEnd)
+	require.Error(t, err)
+
+	// Seek(0, SeekStart) resets successfully
+	pos, err = enc.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), pos)
+}
+
+func TestStreamingEncoderWorksWithValidateSeekableStream(t *testing.T) {
+	data := []byte("validate seekable test data")
+	enc := NewSMEncoder(bytes.NewReader(data), int64(len(data)), 0)
+
+	// ValidateSeekableStreamAt0AndGetCount uses Seek(0, SeekCurrent), Seek(0, SeekEnd), Seek(0, SeekStart)
+	count, err := ValidateSeekableStreamAt0AndGetCount(enc)
+	require.NoError(t, err)
+	require.Equal(t, enc.EncodedLength(), count)
+
+	// After validation, encoder should still be at position 0 and readable
+	encoded, err := io.ReadAll(enc)
+	require.NoError(t, err)
+	require.Equal(t, int(count), len(encoded))
+}

--- a/sdk/storage/azblob/internal/shared/structured_message_test.go
+++ b/sdk/storage/azblob/internal/shared/structured_message_test.go
@@ -910,3 +910,77 @@ func TestDecoderMultiSegmentCRCValidation(t *testing.T) {
 	require.Contains(t, err.Error(), "segment 3")
 	require.Contains(t, err.Error(), "CRC64 mismatch")
 }
+
+// Test segment size overflow protection: when content would produce > 65535 segments,
+// NewSMEncoder should auto-increase segment size to keep numSegments within uint16 range.
+func TestSMEncoderSegmentSizeOverflowProtection(t *testing.T) {
+	// With 1-byte segment size and 70000 bytes of content, numSegments would be 70000.
+	// The encoder should auto-increase segment size to ceil(70000/65535) = 2 bytes,
+	// resulting in 35000 segments.
+	contentLen := int64(70000)
+	segmentSize := 1
+	content := make([]byte, contentLen)
+	for i := range content {
+		content[i] = byte(i % 251)
+	}
+
+	enc := NewSMEncoder(bytes.NewReader(content), contentLen, segmentSize)
+
+	// Verify the encoder was created successfully and numSegments <= 65535
+	require.LessOrEqual(t, enc.numSegments, 65535)
+	require.Greater(t, enc.numSegments, 0)
+
+	// Read all encoded data
+	encodedData, err := io.ReadAll(enc)
+	require.NoError(t, err)
+	require.Equal(t, int(enc.EncodedLength()), len(encodedData))
+
+	// Decode and verify round-trip
+	dec := NewSMDecoder(io.NopCloser(bytes.NewReader(encodedData)))
+	decodedData, err := io.ReadAll(dec)
+	require.NoError(t, err)
+	require.Equal(t, content, decodedData)
+}
+
+func TestSMEncoderSegmentSizeExactlyAtLimit(t *testing.T) {
+	// With segment size 1 and exactly 65535 bytes, it should not overflow
+	contentLen := int64(65535)
+	segmentSize := 1
+	content := make([]byte, contentLen)
+	for i := range content {
+		content[i] = byte(i % 199)
+	}
+
+	enc := NewSMEncoder(bytes.NewReader(content), contentLen, segmentSize)
+	require.Equal(t, 65535, enc.numSegments)
+
+	encodedData, err := io.ReadAll(enc)
+	require.NoError(t, err)
+
+	dec := NewSMDecoder(io.NopCloser(bytes.NewReader(encodedData)))
+	decodedData, err := io.ReadAll(dec)
+	require.NoError(t, err)
+	require.Equal(t, content, decodedData)
+}
+
+func TestSMEncoderSegmentSizeJustOverLimit(t *testing.T) {
+	// With segment size 1 and 65536 bytes, it should auto-scale to segment size 2
+	contentLen := int64(65536)
+	segmentSize := 1
+	content := make([]byte, contentLen)
+	for i := range content {
+		content[i] = byte(i % 199)
+	}
+
+	enc := NewSMEncoder(bytes.NewReader(content), contentLen, segmentSize)
+	require.LessOrEqual(t, enc.numSegments, 65535)
+	require.Greater(t, enc.segmentSize, 1)
+
+	encodedData, err := io.ReadAll(enc)
+	require.NoError(t, err)
+
+	dec := NewSMDecoder(io.NopCloser(bytes.NewReader(encodedData)))
+	decodedData, err := io.ReadAll(dec)
+	require.NoError(t, err)
+	require.Equal(t, content, decodedData)
+}

--- a/sdk/storage/azblob/internal/shared/structured_message_test.go
+++ b/sdk/storage/azblob/internal/shared/structured_message_test.go
@@ -9,6 +9,7 @@ package shared
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"hash/crc64"
 	"io"
 	"testing"
@@ -552,4 +553,360 @@ func TestStreamingEncoderWorksWithValidateSeekableStream(t *testing.T) {
 	encoded, err := io.ReadAll(enc)
 	require.NoError(t, err)
 	require.Equal(t, int(count), len(encoded))
+}
+
+// --- Decoder error tests (matching .NET StructuredMessageDecodingStreamTests) ---
+
+func TestDecodeBadVersion(t *testing.T) {
+	smData := makeCorruptedSM([]byte("test data for version check"), func(d []byte) {
+		d[0] = 0xFF
+	})
+	_, err := SMDecode(smData)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported structured message version: 255")
+}
+
+func TestDecodeBadSegmentCRC(t *testing.T) {
+	data := make([]byte, 100)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	smData := makeCorruptedSM(data, func(d []byte) {
+		d[SMHeaderSize+SMSegmentHeaderSize+10] ^= 0xFF
+	})
+	_, err := SMDecode(smData)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CRC64 mismatch")
+	require.Contains(t, err.Error(), "segment 1")
+}
+
+func TestDecodeBadMessageCRC(t *testing.T) {
+	data := make([]byte, 50)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	smData := makeCorruptedSM(data, func(d []byte) {
+		d[len(d)-1] ^= 0xFF
+	})
+	_, err := SMDecode(smData)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CRC64 mismatch")
+}
+
+func TestDecodeWrongMessageLength(t *testing.T) {
+	smData := makeCorruptedSM([]byte("test message length"), func(d []byte) {
+		binary.LittleEndian.PutUint64(d[1:9], 123456789)
+	})
+	_, err := SMDecode(smData)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "length mismatch")
+}
+
+func TestDecodeWrongSegmentCountTooMany(t *testing.T) {
+	data := []byte("test segment count")
+	result := SMEncode(data, 0)
+	smData := make([]byte, len(result.EncodedData))
+	copy(smData, result.EncodedData)
+
+	binary.LittleEndian.PutUint16(smData[11:13], 2)
+	_, err := SMDecode(smData)
+	require.Error(t, err)
+}
+
+func TestDecodeWrongSegmentCountTooFew(t *testing.T) {
+	data := make([]byte, 200)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	result := SMEncode(data, 50) // 4 segments
+	smData := make([]byte, len(result.EncodedData))
+	copy(smData, result.EncodedData)
+
+	binary.LittleEndian.PutUint16(smData[11:13], 3)
+	_, err := SMDecode(smData)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CRC64 mismatch")
+}
+
+func TestDecodeWrongSegmentNumber(t *testing.T) {
+	data := []byte("test segment number check")
+	result := SMEncode(data, 0)
+	smData := make([]byte, len(result.EncodedData))
+	copy(smData, result.EncodedData)
+
+	binary.LittleEndian.PutUint16(smData[SMHeaderSize:SMHeaderSize+2], 123)
+	_, err := SMDecode(smData)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "segment number mismatch")
+	require.Contains(t, err.Error(), "expected 1, got 123")
+}
+
+func TestDecodeTruncatedStream(t *testing.T) {
+	data := []byte("test truncation handling")
+	result := SMEncode(data, 0)
+	truncated := result.EncodedData[:len(result.EncodedData)-4]
+
+	_, err := SMDecode(truncated)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "length mismatch")
+}
+
+func TestDecodeTruncatedSegmentFooter(t *testing.T) {
+	data := []byte("test footer truncation")
+	result := SMEncode(data, 0)
+	smData := make([]byte, len(result.EncodedData))
+	copy(smData, result.EncodedData)
+
+	truncatedLen := len(smData) - 12
+	truncated := smData[:truncatedLen]
+	binary.LittleEndian.PutUint64(truncated[1:9], uint64(truncatedLen))
+	_, err := SMDecode(truncated)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "insufficient data")
+}
+
+func TestDecodeVariousReadSizes(t *testing.T) {
+	testCases := []struct {
+		name    string
+		dataLen int
+		segSize int
+	}{
+		{"Small_DefaultSeg", 100, 0},
+		{"NonAligned_SmallSeg", 2005, 512},
+		{"Aligned_SmallSeg", 2048, 512},
+		{"Large_SmallSeg", 8192, 512},
+		{"SingleByte_SmallSeg", 1, 512},
+		{"ExactSeg", 512, 512},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := make([]byte, tc.dataLen)
+			for i := range data {
+				data[i] = byte(i % 251)
+			}
+
+			result := SMEncode(data, tc.segSize)
+			decoded, err := SMDecode(result.EncodedData)
+			require.NoError(t, err)
+			require.Equal(t, data, decoded.Data)
+		})
+	}
+}
+
+// --- Streaming Encoder -> Decoder Roundtrip Tests (matching .NET StructuredMessageStreamRoundtripTests) ---
+
+func TestStreamingEncoderDecoderRoundtrip(t *testing.T) {
+	testCases := []struct {
+		name    string
+		dataLen int
+		segSize int
+		readLen int
+	}{
+		{"2048_DefaultSeg_8KB", 2048, 0, 8192},
+		{"2005_512Seg_512Read", 2005, 512, 512},
+		{"2048_512Seg_530Read", 2048, 512, 530},
+		{"2005_512Seg_3Read", 2005, 512, 3},
+		{"100_50Seg_7Read", 100, 50, 7},
+		{"1_1Seg_1Read", 1, 1, 1},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := make([]byte, tc.dataLen)
+			for i := range data {
+				data[i] = byte(i % 251)
+			}
+
+			enc := NewSMEncoder(bytes.NewReader(data), int64(len(data)), tc.segSize)
+			encodedData, err := io.ReadAll(enc)
+			require.NoError(t, err)
+			require.Equal(t, int(enc.EncodedLength()), len(encodedData))
+
+			body := io.NopCloser(bytes.NewReader(encodedData))
+			dec := NewSMDecoder(body)
+
+			var decoded []byte
+			buf := make([]byte, tc.readLen)
+			for {
+				n, readErr := dec.Read(buf)
+				if n > 0 {
+					decoded = append(decoded, buf[:n]...)
+				}
+				if readErr == io.EOF {
+					break
+				}
+				require.NoError(t, readErr)
+			}
+
+			require.Equal(t, data, decoded)
+		})
+	}
+}
+
+func TestStreamingEncoderDecoderRoundtripLargeData(t *testing.T) {
+	dataLen := 5 * 1024 * 1024
+	segSize := 1024 * 1024
+
+	data := make([]byte, dataLen)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+
+	enc := NewSMEncoder(bytes.NewReader(data), int64(len(data)), segSize)
+	encodedData, err := io.ReadAll(enc)
+	require.NoError(t, err)
+
+	body := io.NopCloser(bytes.NewReader(encodedData))
+	dec := NewSMDecoder(body)
+
+	decoded, err := io.ReadAll(dec)
+	require.NoError(t, err)
+	require.Equal(t, data, decoded)
+
+	decResult := dec.DecodeResult()
+	require.NotNil(t, decResult)
+	require.Equal(t, uint16(5), decResult.NumSegments)
+}
+
+// --- Encoder Binary Format Tests (matching .NET StructuredMessageTests) ---
+
+func TestEncodeStreamHeaderBinary(t *testing.T) {
+	data := make([]byte, 1024)
+	result := SMEncode(data, 0)
+	smData := result.EncodedData
+
+	require.Equal(t, byte(1), smData[0])
+
+	msgLen := binary.LittleEndian.Uint64(smData[1:9])
+	require.Equal(t, uint64(len(smData)), msgLen)
+
+	flags := binary.LittleEndian.Uint16(smData[9:11])
+	require.Equal(t, uint16(1), flags)
+
+	numSegs := binary.LittleEndian.Uint16(smData[11:13])
+	require.Equal(t, uint16(1), numSegs)
+}
+
+func TestEncodeSegmentHeaderBinary(t *testing.T) {
+	data := make([]byte, 10)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	result := SMEncode(data, 5) // 2 segments of 5 bytes each
+	smData := result.EncodedData
+
+	seg1Num := binary.LittleEndian.Uint16(smData[13:15])
+	require.Equal(t, uint16(1), seg1Num)
+	seg1Len := binary.LittleEndian.Uint64(smData[15:23])
+	require.Equal(t, uint64(5), seg1Len)
+
+	seg2Offset := 13 + 10 + 5 + 8
+	seg2Num := binary.LittleEndian.Uint16(smData[seg2Offset : seg2Offset+2])
+	require.Equal(t, uint16(2), seg2Num)
+	seg2Len := binary.LittleEndian.Uint64(smData[seg2Offset+2 : seg2Offset+10])
+	require.Equal(t, uint64(5), seg2Len)
+}
+
+func TestEncodeNonAlignedDataSize(t *testing.T) {
+	testCases := []struct {
+		dataLen int
+		segSize int
+		expSegs uint16
+	}{
+		{2005, 512, 4},
+		{1, 512, 1},
+		{513, 512, 2},
+		{1023, 512, 2},
+		{10000, 3000, 4},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%d_%d", tc.dataLen, tc.segSize), func(t *testing.T) {
+			data := make([]byte, tc.dataLen)
+			for i := range data {
+				data[i] = byte(i % 251)
+			}
+
+			result := SMEncode(data, tc.segSize)
+			decoded, err := SMDecode(result.EncodedData)
+			require.NoError(t, err)
+			require.Equal(t, data, decoded.Data)
+			require.Equal(t, tc.expSegs, decoded.NumSegments)
+		})
+	}
+}
+
+// --- Decoder via SMDecoder (streaming) error tests ---
+
+func TestDecoderBadVersion(t *testing.T) {
+	smData := makeCorruptedSM([]byte("test"), func(d []byte) {
+		d[0] = 0xFF
+	})
+	body := io.NopCloser(bytes.NewReader(smData))
+	dec := NewSMDecoder(body)
+	_, err := io.ReadAll(dec)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported structured message version")
+}
+
+func TestDecoderBadSegmentCRC(t *testing.T) {
+	data := make([]byte, 100)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	smData := makeCorruptedSM(data, func(d []byte) {
+		d[SMHeaderSize+SMSegmentHeaderSize+5] ^= 0xFF
+	})
+	body := io.NopCloser(bytes.NewReader(smData))
+	dec := NewSMDecoder(body)
+	_, err := io.ReadAll(dec)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CRC64 mismatch")
+}
+
+func TestDecoderBadMessageCRC(t *testing.T) {
+	data := make([]byte, 50)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	smData := makeCorruptedSM(data, func(d []byte) {
+		d[len(d)-1] ^= 0xFF
+	})
+	body := io.NopCloser(bytes.NewReader(smData))
+	dec := NewSMDecoder(body)
+	_, err := io.ReadAll(dec)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CRC64 mismatch")
+}
+
+func TestDecoderWrongSegmentNumber(t *testing.T) {
+	smData := makeCorruptedSM([]byte("seg num test"), func(d []byte) {
+		binary.LittleEndian.PutUint16(d[SMHeaderSize:SMHeaderSize+2], 42)
+	})
+	body := io.NopCloser(bytes.NewReader(smData))
+	dec := NewSMDecoder(body)
+	_, err := io.ReadAll(dec)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "segment number mismatch")
+}
+
+func TestDecoderMultiSegmentCRCValidation(t *testing.T) {
+	data := make([]byte, 200)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	result := SMEncode(data, 50)
+	smData := make([]byte, len(result.EncodedData))
+	copy(smData, result.EncodedData)
+
+	seg3DataStart := SMHeaderSize + 2*(SMSegmentHeaderSize+50+SMSegmentFooterSize) + SMSegmentHeaderSize
+	smData[seg3DataStart+10] ^= 0xFF
+
+	body := io.NopCloser(bytes.NewReader(smData))
+	dec := NewSMDecoder(body)
+	_, err := io.ReadAll(dec)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "segment 3")
+	require.Contains(t, err.Error(), "CRC64 mismatch")
 }

--- a/sdk/storage/azblob/pageblob/client.go
+++ b/sdk/storage/azblob/pageblob/client.go
@@ -172,7 +172,11 @@ func (pb *Client) UploadPages(ctx context.Context, body io.ReadSeekCloser, conte
 	if options != nil && options.TransactionalValidation != nil {
 		body, err = options.TransactionalValidation.Apply(body, uploadPagesOptions)
 		if err != nil {
-			return UploadPagesResponse{}, nil
+			return UploadPagesResponse{}, err
+		}
+		count, err = shared.ValidateSeekableStreamAt0AndGetCount(body)
+		if err != nil {
+			return UploadPagesResponse{}, err
 		}
 	}
 

--- a/sdk/storage/azblob/pageblob/client_test.go
+++ b/sdk/storage/azblob/pageblob/client_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"slices"
 	"testing"
 	"time"
 
@@ -5171,7 +5172,7 @@ func (s *PageBlobUnrecordedTestsSuite) TestUploadPagesMultipleWithStructuredMess
 	downloadedData, err := io.ReadAll(downloadResp.Body)
 	_require.NoError(err)
 
-	expectedData := append(page1, page2...)
+	expectedData := slices.Concat(page1, page2)
 	_require.Equal(expectedData, downloadedData)
 }
 

--- a/sdk/storage/azblob/pageblob/client_test.go
+++ b/sdk/storage/azblob/pageblob/client_test.go
@@ -5130,6 +5130,40 @@ func (s *PageBlobUnrecordedTestsSuite) TestUploadPagesWithStructuredMessageCRC64
 	_require.Equal(content, downloadedData)
 }
 
+func (s *PageBlobUnrecordedTestsSuite) TestUploadPagesDownloadRoundtripWithStructuredMessageCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	// Page blob data must be 512-byte aligned
+	contentSize := int64(1024) // 1 KB (2 pages)
+	pbClient := createNewPageBlobWithSize(context.Background(), _require, testcommon.GenerateBlobName(testName), containerClient, contentSize)
+
+	_, content := testcommon.GetDataAndReader(testName, int(contentSize))
+
+	// Upload with SM CRC64
+	_, err = pbClient.UploadPages(context.Background(), streaming.NopCloser(bytes.NewReader(content)),
+		blob.HTTPRange{Offset: 0, Count: contentSize}, &pageblob.UploadPagesOptions{
+			TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+		})
+	_require.NoError(err)
+
+	// Download with SM CRC64 validation
+	downloadResp, err := pbClient.BlobClient().DownloadStream(context.Background(), &blob.DownloadStreamOptions{
+		TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(content, downloadedData)
+}
+
 func (s *PageBlobUnrecordedTestsSuite) TestUploadPagesMultipleWithStructuredMessageCRC64() {
 	_require := require.New(s.T())
 	testName := s.T().Name()

--- a/sdk/storage/azblob/pageblob/client_test.go
+++ b/sdk/storage/azblob/pageblob/client_test.go
@@ -5098,6 +5098,83 @@ func (s *PageBlobRecordedTestsSuite) TestPageBlobClientDefaultAudience() {
 	_require.NoError(err)
 }
 
+func (s *PageBlobUnrecordedTestsSuite) TestUploadPagesWithStructuredMessageCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	// Page blob data must be 512-byte aligned
+	contentSize := int64(1024) // 1 KB (2 pages)
+	pbClient := createNewPageBlobWithSize(context.Background(), _require, testcommon.GenerateBlobName(testName), containerClient, contentSize)
+
+	_, content := testcommon.GetDataAndReader(testName, int(contentSize))
+
+	_, err = pbClient.UploadPages(context.Background(), streaming.NopCloser(bytes.NewReader(content)),
+		blob.HTTPRange{Offset: 0, Count: contentSize}, &pageblob.UploadPagesOptions{
+			TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+		})
+	_require.NoError(err)
+
+	// Download and verify data
+	downloadResp, err := pbClient.BlobClient().DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(content, downloadedData)
+}
+
+func (s *PageBlobUnrecordedTestsSuite) TestUploadPagesMultipleWithStructuredMessageCRC64() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	contentSize := int64(2048) // 2 KB (4 pages)
+	pbClient := createNewPageBlobWithSize(context.Background(), _require, testcommon.GenerateBlobName(testName), containerClient, contentSize)
+
+	// Upload two 1 KB page ranges with SM validation
+	page1 := make([]byte, 1024)
+	page2 := make([]byte, 1024)
+	for i := range page1 {
+		page1[i] = byte(i % 251)
+	}
+	for i := range page2 {
+		page2[i] = byte((i + 100) % 251)
+	}
+
+	_, err = pbClient.UploadPages(context.Background(), streaming.NopCloser(bytes.NewReader(page1)),
+		blob.HTTPRange{Offset: 0, Count: 1024}, &pageblob.UploadPagesOptions{
+			TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+		})
+	_require.NoError(err)
+
+	_, err = pbClient.UploadPages(context.Background(), streaming.NopCloser(bytes.NewReader(page2)),
+		blob.HTTPRange{Offset: 1024, Count: 1024}, &pageblob.UploadPagesOptions{
+			TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
+		})
+	_require.NoError(err)
+
+	// Download and verify both pages
+	downloadResp, err := pbClient.BlobClient().DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+
+	downloadedData, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+
+	expectedData := append(page1, page2...)
+	_require.Equal(expectedData, downloadedData)
+}
+
 func (s *PageBlobRecordedTestsSuite) TestPageBlobClientCustomAudience() {
 	_require := require.New(s.T())
 	testName := s.T().Name()


### PR DESCRIPTION
This PR includes changes from already approved PRs. 
  
## Summary of this PR 

  - Adds end-to-end support for **Structured Message (SM) CRC64** content validation across all blob types (block, append, page), for both upload and download operations
  - Introduces `TransferValidationTypeComputeStructuredMessageCRC64` — a new `TransferValidationType` that computes per-segment CRC64 checksums using the structured message binary format, providing stronger
  data integrity guarantees than whole-blob MD5/CRC64
  - Implements a streaming SM encoder/decoder in `internal/shared/` that wraps request/response bodies transparently — no changes needed to existing upload/download call patterns

  ### What's included

  1. **Core library** (`internal/shared/structured_message.go`) — SM binary format encoder & decoder with per-segment CRC64 computation and validation
  2. **Upload integration** — SM CRC64 support on `blockblob.Upload`, `UploadBuffer`, `UploadStream`, `UploadFile`, `StageBlock`, `CommitBlockList`, `appendblob.AppendBlock`, and `pageblob.UploadPages`
  3. **Download integration** — SM CRC64 validation on `blob.DownloadStream`, `DownloadBuffer`, and `DownloadFile` with automatic structured message decoding and per-segment integrity checks
  4. **Public API** — `blob.TransferValidationTypeComputeStructuredMessageCRC64(segmentSize)` (use 0 for default 4 MB segments)
  5. **Tests** — Unit tests for encoder/decoder, Integration tests across all blob types covering round-trips, edge cases (empty blob, single byte, exact segment boundary, multi-segment), and error paths
  6. **Benchmarks** — encoder/decoder benchmarks in `internal/shared/` and upload benchmarks in `blockblob/`
  7. **Examples** — `Example_blockblob_UploadWithContentValidation` and `Example_blob_DownloadWithContentValidation`

  ### Usage

  ```go
  // Upload with SM CRC64 (0 = default 4 MB segment size)
  _, err = blockBlobClient.Upload(ctx, body, &blockblob.UploadOptions{
      TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
  })

  // Download with SM CRC64 validation
  resp, err := blobClient.DownloadStream(ctx, &blob.DownloadStreamOptions{
      TransactionalValidation: blob.TransferValidationTypeComputeStructuredMessageCRC64(0),
  })
```
  Test plan

  - unit tests for SM encoder/decoder (internal/shared/structured_message_test.go)
  - integration tests across block blob, append blob, page blob, and blob download
  - Edge cases: empty blob, single byte, exact 4 MB segment boundary, multi-block round-trips
  - Benchmarks for encoder/decoder and upload paths


<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
