### PR TITLE
fix(azcosmos): remove no-op PopulateCompositeContinuationToken from ChangeFeedResponse

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Breaking Changes
 
+* Removed `ChangeFeedResponse.PopulateCompositeContinuationToken()`. The method is no longer needed: `GetChangeFeed` now populates `ChangeFeedResponse.ContinuationToken` directly with the multi-range composite token. Callers who built single-range tokens manually can use `GetCompositeContinuationToken()` instead.
+
 ### Bugs Fixed
 
 * Fixed `GetChangeFeed` to survive partition splits: customer-supplied `FeedRange`s are now overlap-matched against the routing map, `410/Gone` triggers a cache refresh and bounded retry, split parents expand into per-child queue entries (inheriting the parent's ETag), and the continuation token persists multi-range state across calls. Continuation tokens are guarded against cross-container reuse. See [PR 26768](https://github.com/Azure/azure-sdk-for-go/pull/26768).

--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Breaking Changes
 
-* Removed `ChangeFeedResponse.PopulateCompositeContinuationToken()`. The method is no longer needed: `GetChangeFeed` now populates `ChangeFeedResponse.ContinuationToken` directly with the multi-range composite token. Callers who built single-range tokens manually can use `GetCompositeContinuationToken()` instead.
+* Removed `ChangeFeedResponse.PopulateCompositeContinuationToken()`. The method is no longer needed: `GetChangeFeed` now populates `ChangeFeedResponse.ContinuationToken` directly with the multi-range composite token. Callers who built single-range tokens manually can use `GetCompositeContinuationToken()` instead. See [PR 26792](https://github.com/Azure/azure-sdk-for-go/pull/26792).
 
 ### Bugs Fixed
 

--- a/sdk/data/azcosmos/cosmos_change_feed_response.go
+++ b/sdk/data/azcosmos/cosmos_change_feed_response.go
@@ -59,27 +59,6 @@ func newChangeFeedResponse(resp *http.Response) (ChangeFeedResponse, error) {
 	return response, nil
 }
 
-// PopulateCompositeContinuationToken generates and sets the composite continuation
-// token from response.FeedRange + response.ETag. Retained for back-compat.
-//
-// In the multi-range queue-driven GetChangeFeed path, response.ContinuationToken
-// is already populated with the multi-range composite token by the drain loop
-// itself. This method is therefore a no-op when ContinuationToken is non-empty
-// — overwriting it with a single-range token rebuilt from the per-head
-// FeedRange would lose the multi-range queue state and cause callers that
-// resume with the resulting token to skip subsequent ranges after a split.
-func (response *ChangeFeedResponse) PopulateCompositeContinuationToken() {
-	if response.ContinuationToken != "" {
-		return
-	}
-	if response.FeedRange != nil && response.ETag != "" {
-		compositeToken, err := response.GetCompositeContinuationToken()
-		if err == nil && compositeToken != "" {
-			response.ContinuationToken = compositeToken
-		}
-	}
-}
-
 // GetContinuation from ChangeFeedResponse
 func (c ChangeFeedResponse) GetContinuation() string {
 	return string(c.ETag)

--- a/sdk/data/azcosmos/cosmos_change_feed_response_test.go
+++ b/sdk/data/azcosmos/cosmos_change_feed_response_test.go
@@ -139,14 +139,16 @@ func TestChangeFeedResponseWithFeedRange(t *testing.T) {
 		MaxExclusive: "FF",
 	}
 
-	parsedResponse.PopulateCompositeContinuationToken()
-
-	if parsedResponse.ContinuationToken == "" {
-		t.Fatal("expected CompositeContinuationToken to be populated, but it was empty")
+	tokenStr, err := parsedResponse.GetCompositeContinuationToken()
+	if err != nil {
+		t.Fatalf("GetCompositeContinuationToken returned error: %v", err)
+	}
+	if tokenStr == "" {
+		t.Fatal("expected GetCompositeContinuationToken to return a non-empty token")
 	}
 
 	var compositeToken compositeContinuationToken
-	err = json.Unmarshal([]byte(parsedResponse.ContinuationToken), &compositeToken)
+	err = json.Unmarshal([]byte(tokenStr), &compositeToken)
 	if err != nil {
 		t.Fatalf("failed to unmarshal composite token: %v", err)
 	}
@@ -211,9 +213,11 @@ func TestChangeFeedResponseWithoutFeedRange(t *testing.T) {
 		t.Fatalf("failed to create ChangeFeedResponse: %v", err)
 	}
 
-	parsedResponse.PopulateCompositeContinuationToken()
-
-	if parsedResponse.ContinuationToken != "" {
-		t.Errorf("expected CompositeContinuationToken to be empty, but got: %q", parsedResponse.ContinuationToken)
+	tokenStr, err := parsedResponse.GetCompositeContinuationToken()
+	if err != nil {
+		t.Fatalf("GetCompositeContinuationToken returned error: %v", err)
+	}
+	if tokenStr != "" {
+		t.Errorf("expected GetCompositeContinuationToken to return empty string when FeedRange is nil, got: %q", tokenStr)
 	}
 }

--- a/sdk/data/azcosmos/cosmos_container_change_feed.go
+++ b/sdk/data/azcosmos/cosmos_container_change_feed.go
@@ -383,8 +383,7 @@ func (c *ContainerClient) getChangeFeedForQueue(
 		// Capture the response body's _rid into the token's ResourceID on first
 		// successful response. This keeps the cross-container guard meaningful
 		// across resume — token-issued-by-this-container always carries the
-		// container's RID — and matches pre-F1 PopulateCompositeContinuationToken
-		// semantics that downstream tests rely on.
+		// container's RID.
 		if token.ResourceID == "" && response.ResourceID != "" {
 			token.ResourceID = response.ResourceID
 		}


### PR DESCRIPTION
### Purpose

Removes `ChangeFeedResponse.PopulateCompositeContinuationToken()`, which was made a no-op in [PR #26768](https://github.com/Azure/azure-sdk-for-go/pull/26768). With the queue-driven `GetChangeFeed` rewrite, the response's `ContinuationToken` field is populated by the drain loop itself with a multi-range composite token. Calling `PopulateCompositeContinuationToken()` would either:

- Be a no-op (its current behavior in `main`), or
- If invoked on a hand-constructed `ChangeFeedResponse`, build a stale single-range token that would skip subsequent ranges after a split when used to resume.

There's no remaining valid use case for the method, so this PR removes it outright.

### Public API surface for getting continuation tokens after this change

`ChangeFeedResponse` exposes the following ways to obtain a continuation token, in order of preference:

1. **`ContinuationToken string`** *(struct field — recommended)*  
   Populated automatically by `GetChangeFeed` with the **multi-range composite token** that drives the queue-based drain loop introduced in #26768. This is the only token shape that survives partition splits correctly. Pass it back via `ChangeFeedOptions.Continuation` to resume from where the previous call left off.

2. **`GetCompositeContinuationToken() (string, error)`**  
   Public helper that constructs a **single-range** composite token from the response's `FeedRange` + `ETag`. Useful for advanced callers who hand-construct a `ChangeFeedResponse` outside the normal `GetChangeFeed` flow (e.g., test fixtures or custom adapters). Note: this builds a single-range token, so it will **not** preserve multi-range queue state across partition splits — prefer the `ContinuationToken` field for production code.

3. **`GetContinuation() string`**  
   Low-level accessor returning the raw `ETag` string from the response. Intended for callers that want to perform their own continuation-token construction; not directly usable as a `ChangeFeedOptions.Continuation` value because `GetChangeFeed` only honors composite-token JSON.

4. **`GetContRanges() (min string, max string, ok bool)`**  
   Low-level accessor returning the `FeedRange` bounds of the page that was drained. Pairs with `GetContinuation()` for callers building tokens manually.

### What this PR changes

- Deletes `func (response *ChangeFeedResponse) PopulateCompositeContinuationToken()` from `cosmos_change_feed_response.go`.
- Retargets the two existing tests (`TestChangeFeedResponseWithFeedRange`, `TestChangeFeedResponseWithoutFeedRange`) at `GetCompositeContinuationToken()` so the underlying composite-token construction stays covered.
- Removes a stale comment in `cosmos_container_change_feed.go` that referenced the deleted method.
- Adds a Breaking Changes entry to `CHANGELOG.md`.

### Tests

`go test -race -short -count=1 ./sdk/data/azcosmos/...` — all green.

### Checklist

- [x] The PR does not update generated files.
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.
