### PR TITLE
fix(eng/tools/internal/exports): handle SelectorExpr value in typed const

### DIFF
--- a/eng/tools/internal/exports/exports.go
+++ b/eng/tools/internal/exports/exports.go
@@ -119,11 +119,14 @@ func (c *Content) addConst(pkg Package, g *ast.GenDecl) {
 			switch x := vs.Type.(type) {
 			case *ast.Ident:
 				co.Type = x.Name
-				switch vs.Values[0].(type) {
+				switch val := vs.Values[0].(type) {
 				case *ast.Ident:
-					v = vs.Values[0].(*ast.Ident).Name
+					v = val.Name
 				case *ast.BasicLit:
-					v = vs.Values[0].(*ast.BasicLit).Value
+					v = val.Value
+				case *ast.SelectorExpr:
+					// const Foo MyType = pkg.Bar
+					v = pkg.getText(val.Pos(), val.End())
 				default:
 					panic(fmt.Sprintf("wrong type %T", vs.Values[0]))
 				}

--- a/eng/tools/internal/exports/exports_test.go
+++ b/eng/tools/internal/exports/exports_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package exports
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAddConst_SelectorExprValue(t *testing.T) {
+	dir := t.TempDir()
+	src := `package foo
+
+type BlobType string
+
+const (
+	BlobTypeBlockBlob BlobType = generated.BlobTypeBlockBlob
+)
+`
+	if err := os.WriteFile(filepath.Join(dir, "foo.go"), []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+	c, err := Get(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := c.Consts["BlobTypeBlockBlob"]
+	if !ok {
+		t.Fatalf("expected const BlobTypeBlockBlob, got %#v", c.Consts)
+	}
+	if got.Type != "BlobType" {
+		t.Errorf("expected type BlobType, got %q", got.Type)
+	}
+	if got.Value != "generated.BlobTypeBlockBlob" {
+		t.Errorf("expected value generated.BlobTypeBlockBlob, got %q", got.Value)
+	}
+}


### PR DESCRIPTION
## Problem

The generator's changelog step panics with `wrong type *ast.SelectorExpr` when walking the AST of a previous release tag that contains typed const re-exports like:

`go
const BlobTypeBlockBlob BlobType = generated.BlobTypeBlockBlob
`

This pattern is used throughout `sdk/storage/azblob` (blob/blockblob/container/etc.) to surface `internal/generated` constants under public typed aliases. As a result, `generator automation-v2` crashes during `GenChangeLog` for azblob.

Sample failure: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6323656 (log 14)

`
panic: wrong type *ast.SelectorExpr
  ...eng/tools/internal/exports/exports.go:128
`

## Fix

In `addConst`, when the const type is `*ast.Ident`, also accept `*ast.SelectorExpr` values and render them via `pkg.getText` (e.g. `generated.BlobTypeBlockBlob`).

Added a unit test that reproduces the v1.7.0 azblob pattern.

## Follow-up

After this merges and a new `eng/tools/internal` pseudo-version is published, the version pins in `eng/tools/generator/go.mod`, `eng/tools/apidiff/go.mod`, and `eng/tools/profileBuilder/go.mod` need to be bumped so the fix takes effect in CI.