### PR TITLE
chore(eng/tools): bump eng/tools/internal to pick up SelectorExpr const fix

### DIFF
--- a/eng/tools/apidiff/go.mod
+++ b/eng/tools/apidiff/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
-	github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260323091451-5227f4cb0603
+	github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260521025626-22b44eb319ae
 	github.com/spf13/cobra v1.10.2
 )
 

--- a/eng/tools/apidiff/go.sum
+++ b/eng/tools/apidiff/go.sum
@@ -1,7 +1,7 @@
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
-github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260323091451-5227f4cb0603 h1:iWflo6oJtzVTEg0E9OnRpEESBljaEfphrw6zE7T6IAA=
-github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260323091451-5227f4cb0603/go.mod h1:1wiEmZuPMe5xsZ5BBhoHXpa1Qatbjwp+ETnMY/PbP84=
+github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260521025626-22b44eb319ae h1:bX+jDmV4IoLD8bAbrki3HS4RxBONTOswEHBYxUz7EKA=
+github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260521025626-22b44eb319ae/go.mod h1:1wiEmZuPMe5xsZ5BBhoHXpa1Qatbjwp+ETnMY/PbP84=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/eng/tools/generator/go.mod
+++ b/eng/tools/generator/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/azure-sdk-for-go/eng/tools/generator
 go 1.25.0
 
 require (
-	github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260323091451-5227f4cb0603
+	github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260521025626-22b44eb319ae
 	github.com/Masterminds/semver v1.5.0
 	github.com/ahmetb/go-linq/v3 v3.2.0
 	github.com/go-git/go-git/v5 v5.16.5

--- a/eng/tools/generator/go.sum
+++ b/eng/tools/generator/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
-github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260323091451-5227f4cb0603 h1:iWflo6oJtzVTEg0E9OnRpEESBljaEfphrw6zE7T6IAA=
-github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260323091451-5227f4cb0603/go.mod h1:1wiEmZuPMe5xsZ5BBhoHXpa1Qatbjwp+ETnMY/PbP84=
+github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260521025626-22b44eb319ae h1:bX+jDmV4IoLD8bAbrki3HS4RxBONTOswEHBYxUz7EKA=
+github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260521025626-22b44eb319ae/go.mod h1:1wiEmZuPMe5xsZ5BBhoHXpa1Qatbjwp+ETnMY/PbP84=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=

--- a/eng/tools/profileBuilder/go.mod
+++ b/eng/tools/profileBuilder/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
-	github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260323091451-5227f4cb0603
+	github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260521025626-22b44eb319ae
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/tools v0.43.0
 )

--- a/eng/tools/profileBuilder/go.sum
+++ b/eng/tools/profileBuilder/go.sum
@@ -1,7 +1,7 @@
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
-github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260323091451-5227f4cb0603 h1:iWflo6oJtzVTEg0E9OnRpEESBljaEfphrw6zE7T6IAA=
-github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260323091451-5227f4cb0603/go.mod h1:1wiEmZuPMe5xsZ5BBhoHXpa1Qatbjwp+ETnMY/PbP84=
+github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260521025626-22b44eb319ae h1:bX+jDmV4IoLD8bAbrki3HS4RxBONTOswEHBYxUz7EKA=
+github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260521025626-22b44eb319ae/go.mod h1:1wiEmZuPMe5xsZ5BBhoHXpa1Qatbjwp+ETnMY/PbP84=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=


### PR DESCRIPTION
Bumps `eng/tools/internal` to `v0.0.0-20260521025626-22b44eb319ae` in `generator`, `apidiff`, and `profileBuilder` so the fix from #26853 takes effect when the generator is rebuilt by `eng/scripts/automation_init.sh`.

Without this bump, `generator automation-v2` continues to crash for azblob (and any other package that uses typed const re-exports like `const Foo MyType = pkg.Bar`) during the changelog step.

See sample failure: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6323656