### PR TITLE
chore: add @j7nw4r, @SwayGom, and @sagar0207 to messaging CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,10 +60,10 @@
 # ServiceOwners:                                                   @rajeshka @shankarsama
 
 # PRLabel: %Event Hubs
-/sdk/messaging/azeventhubs/                                        @axisc @hmlam @sjkwak
+/sdk/messaging/azeventhubs/                                        @axisc @hmlam @sjkwak @j7nw4r @SwayGom
 
 # ServiceLabel: %Event Hubs
-# ServiceOwners:                                                   @axisc @hmlam @sjkwak
+# ServiceOwners:                                                   @axisc @hmlam @sjkwak @j7nw4r @SwayGom
 
 # PRLabel: %Internal
 /sdk/internal/                                                     @chlowell @jhendrixMSFT @richardpark-msft @rickwinter
@@ -109,13 +109,13 @@
 # ServiceOwners:                                                   @jhendrixMSFT @rickwinter
 
 # PRLabel: %Service Bus
-/sdk/messaging/azservicebus/                                       @EldertGrootenboer @skarri-microsoft
+/sdk/messaging/azservicebus/                                       @EldertGrootenboer @skarri-microsoft @j7nw4r @SwayGom
 
 # PRLabel: %Service Bus
-/sdk/messaging/stress/                                             @EldertGrootenboer @skarri-microsoft
+/sdk/messaging/stress/                                             @EldertGrootenboer @skarri-microsoft @j7nw4r @SwayGom
 
 # ServiceLabel: %Service Bus
-# ServiceOwners:                                                   @EldertGrootenboer @skarri-microsoft
+# ServiceOwners:                                                   @EldertGrootenboer @skarri-microsoft @j7nw4r @SwayGom
 
 # PRLabel: %Storage
 /sdk/storage/                                                      @gapra-msft @jhendrixMSFT @souravgupta-msft @tanyasethi-msft

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,10 +60,10 @@
 # ServiceOwners:                                                   @rajeshka @shankarsama
 
 # PRLabel: %Event Hubs
-/sdk/messaging/azeventhubs/                                        @axisc @hmlam @sjkwak @j7nw4r @SwayGom
+/sdk/messaging/azeventhubs/                                        @axisc @hmlam @sjkwak @j7nw4r @SwayGom @sagar0207
 
 # ServiceLabel: %Event Hubs
-# ServiceOwners:                                                   @axisc @hmlam @sjkwak @j7nw4r @SwayGom
+# ServiceOwners:                                                   @axisc @hmlam @sjkwak @j7nw4r @SwayGom @sagar0207
 
 # PRLabel: %Internal
 /sdk/internal/                                                     @chlowell @jhendrixMSFT @richardpark-msft @rickwinter
@@ -109,13 +109,13 @@
 # ServiceOwners:                                                   @jhendrixMSFT @rickwinter
 
 # PRLabel: %Service Bus
-/sdk/messaging/azservicebus/                                       @EldertGrootenboer @skarri-microsoft @j7nw4r @SwayGom
+/sdk/messaging/azservicebus/                                       @EldertGrootenboer @skarri-microsoft @j7nw4r @SwayGom @sagar0207
 
 # PRLabel: %Service Bus
-/sdk/messaging/stress/                                             @EldertGrootenboer @skarri-microsoft @j7nw4r @SwayGom
+/sdk/messaging/stress/                                             @EldertGrootenboer @skarri-microsoft @j7nw4r @SwayGom @sagar0207
 
 # ServiceLabel: %Service Bus
-# ServiceOwners:                                                   @EldertGrootenboer @skarri-microsoft @j7nw4r @SwayGom
+# ServiceOwners:                                                   @EldertGrootenboer @skarri-microsoft @j7nw4r @SwayGom @sagar0207
 
 # PRLabel: %Storage
 /sdk/storage/                                                      @gapra-msft @jhendrixMSFT @souravgupta-msft @tanyasethi-msft


### PR DESCRIPTION
Adding myself and my coworkers @SwayGom and @sagar0207 to the Event Hubs and Service Bus CODEOWNERS lines (and the matching `# ServiceOwners:` comments that Azure SDK tooling reads). We're on the Microsoft messaging team and already own these surfaces in the other language SDKs.

No other entries changed.
