### PR TITLE
Prepare Key Vault Certificates and Secrets GA release

### DIFF
--- a/sdk/security/keyvault/azcertificates/CHANGELOG.md
+++ b/sdk/security/keyvault/azcertificates/CHANGELOG.md
@@ -3,14 +3,7 @@
 ## 1.5.0 (2026-05-26)
 
 ### Features Added
-
-- Includes all changes from 1.5.0-beta.1.
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+* Includes all changes from 1.5.0-beta.1.
 
 ## 1.5.0-beta.1 (2026-04-08)
 

--- a/sdk/security/keyvault/azcertificates/CHANGELOG.md
+++ b/sdk/security/keyvault/azcertificates/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.5.0-beta.2 (Unreleased)
+## 1.5.0 (2026-05-26)
 
 ### Features Added
+
+- Includes all changes from 1.5.0-beta.1.
 
 ### Breaking Changes
 

--- a/sdk/security/keyvault/azcertificates/version.go
+++ b/sdk/security/keyvault/azcertificates/version.go
@@ -5,5 +5,5 @@ package azcertificates
 
 const (
 	moduleName = "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates"
-	version    = "v1.5.0-beta.2"
+	version    = "v1.5.0"
 )

--- a/sdk/security/keyvault/azsecrets/CHANGELOG.md
+++ b/sdk/security/keyvault/azsecrets/CHANGELOG.md
@@ -3,14 +3,7 @@
 ## 1.5.0 (2026-05-26)
 
 ### Features Added
-
-- Includes all changes from 1.5.0-beta.1.
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+* Includes all changes from 1.5.0-beta.1.
 
 ## 1.5.0-beta.1 (2026-04-08)
 

--- a/sdk/security/keyvault/azsecrets/CHANGELOG.md
+++ b/sdk/security/keyvault/azsecrets/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.5.0-beta.2 (Unreleased)
+## 1.5.0 (2026-05-26)
 
 ### Features Added
+
+- Includes all changes from 1.5.0-beta.1.
 
 ### Breaking Changes
 

--- a/sdk/security/keyvault/azsecrets/version.go
+++ b/sdk/security/keyvault/azsecrets/version.go
@@ -5,5 +5,5 @@ package azsecrets
 
 const (
 	moduleName = "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
-	version    = "v1.5.0-beta.2"
+	version    = "v1.5.0"
 )


### PR DESCRIPTION
## Description
- Updates azcertificates from v1.5.0-beta.2 to v1.5.0.
- Updates azsecrets from v1.5.0-beta.2 to v1.5.0.
- Finalizes changelog entries for the GA release.

## Validation
- `git diff --check`

Build note: `go test ./sdk/security/keyvault/azcertificates/... ./sdk/security/keyvault/azsecrets/...` could not run because `go` is not installed on PATH in this environment.