### PR TITLE
Update live test to clear access policies

### DIFF
--- a/sdk/storage/azfile/share/client_test.go
+++ b/sdk/storage/azfile/share/client_test.go
@@ -1937,6 +1937,13 @@ func (s *ShareUnrecordedTestsSuite) TestShareSASUsingAccessPolicy() {
 
 	_, err = fileClient.Delete(context.Background(), nil)
 	_require.NoError(err)
+
+	_, err = shareClient.SetAccessPolicy(context.Background(), nil)
+	_require.NoError(err)
+
+	resp2, err := shareClient.GetAccessPolicy(context.Background(), nil)
+	_require.NoError(err)
+	_require.Len(resp2.SignedIdentifiers, 0)
 }
 
 func (s *ShareRecordedTestsSuite) TestPremiumShareBandwidth() {


### PR DESCRIPTION
In response to https://github.com/Azure/azure-sdk-for-go/pull/26601#discussion_r3269860164