### PR TITLE
Extend perf run with iterations, rate limiting, CPU/memory sampling, workload configs, and result artifacts

### DIFF
--- a/sdk/internal/perf/README.md
+++ b/sdk/internal/perf/README.md
@@ -3,11 +3,38 @@ The `perf` sub-module provides a framework for writing and running performance t
 
 ## Default Command Options
 
-| Flag | Short Flag | Default Value | Description |
-| -----| ---------- | ------------- | ----------- |
-| `--duration` | `-d` | 10 seconds | How long to run an individual performance test |
-| `--test-proxies` | `-x` | N/A | A semicolon separated list of proxy urls. |
-| `--warmup` | `-w` | 3 seconds| How long to allow the connection to warm up. |
+The flags below match the .NET `Azure.Test.Perf` runner (`PerfOptions.cs`) so
+that perf-automation can drive both languages from a single matrix.
+
+| Flag | Short | Default | Description |
+| ---- | ----- | ------- | ----------- |
+| `--duration` | `-d` | 10 | Measurement-phase duration in seconds. |
+| `--warmup` | `-w` | 5 | Warmup duration in seconds. Zero skips warmup. |
+| `--parallel` | `-p` | 1 | Number of goroutines executing the test concurrently. |
+| `--iterations` | `-i` | 1 | How many times the measurement phase is repeated. |
+| `--rate` | `-r` | 0 | Target throughput in ops/sec aggregated across workers. Zero = unlimited. |
+| `--status-interval` |  | 1 | Seconds between live status lines. |
+| `--latency` | `-l` | false | Track per-operation latency and print a percentile summary. |
+| `--job-statistics` |  | false | Print the `#StartJobStatistics` / `#EndJobStatistics` block parsed by perf-automation. |
+| `--no-cleanup` |  | false | Skip `Cleanup` / `GlobalCleanup` at end of run. |
+| `--sync` |  | false | Accepted for CLI parity; no-op in Go. |
+| `--insecure` |  | false | Accepted for CLI parity; the default transport already skips TLS verification for the test proxy. |
+| `--test-proxies` | `-x` |  | Semicolon-separated list of test-proxy URLs. |
+| `--results-file` |  |  | When combined with `--latency`, writes per-operation results as JSON. |
+| `--output-file-prefix` |  |  | Writes run summary artifacts to `<prefix>.json/.csv/.txt/.md`. |
+| `--resource-telemetry` |  | false | Print a `runtime.MemStats` / goroutine-count delta at end of run. |
+| `--config` |  |  | Path to a workload-config JSON file. |
+| `--workload` |  |  | Workload name to select from the config file. |
+| `--debug` |  | false | Print extra debug output. |
+| `--maxprocs` |  | `runtime.NumCPU()` | Override `GOMAXPROCS` for the run. |
+| `--max-io-completion-threads` |  | 0 | Accepted for CLI parity with .NET ThreadPool tuning; no-op in Go. |
+| `--max-worker-threads` |  | 0 | Accepted for CLI parity with .NET ThreadPool tuning; no-op in Go. |
+| `--min-io-completion-threads` |  | 0 | Accepted for CLI parity with .NET ThreadPool tuning; no-op in Go. |
+| `--min-worker-threads` |  | 0 | Accepted for CLI parity with .NET ThreadPool tuning; no-op in Go. |
+
+The runner always samples process CPU and memory in the background; both are
+shown live in the status line (`CPU`, `Memory(MiB)`) and as
+`averageCpuPercent` / `averageMemoryBytes` in the run-summary artifacts.
 
 
 ## Adding Performance Tests to an SDK

--- a/sdk/internal/perf/call_type_latency.go
+++ b/sdk/internal/perf/call_type_latency.go
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package perf
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type callTypeLatencyCollector struct {
+	mu     sync.Mutex
+	values map[string][]time.Duration
+}
+
+func newCallTypeLatencyCollector() *callTypeLatencyCollector {
+	return &callTypeLatencyCollector{values: map[string][]time.Duration{}}
+}
+
+func (c *callTypeLatencyCollector) Add(callType string, duration time.Duration) {
+	if duration <= 0 {
+		return
+	}
+	if callType == "" {
+		callType = "operation"
+	}
+	c.mu.Lock()
+	c.values[callType] = append(c.values[callType], duration)
+	c.mu.Unlock()
+}
+
+func (c *callTypeLatencyCollector) Summary() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if len(c.values) == 0 {
+		return "Latency by call type: no data"
+	}
+
+	callTypes := make([]string, 0, len(c.values))
+	for key := range c.values {
+		callTypes = append(callTypes, key)
+	}
+	sort.Strings(callTypes)
+
+	lines := make([]string, 0, len(callTypes)+1)
+	lines = append(lines, "Latency by call type (ms):")
+	for _, key := range callTypes {
+		vals := append([]time.Duration(nil), c.values[key]...)
+		sort.Slice(vals, func(i, j int) bool { return vals[i] < vals[j] })
+		line := fmt.Sprintf("  %s: p50=%.2f p95=%.2f p99=%.2f", key, toMS(percentile(vals, 50)), toMS(percentile(vals, 95)), toMS(percentile(vals, 99)))
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
+}

--- a/sdk/internal/perf/implementation.go
+++ b/sdk/internal/perf/implementation.go
@@ -11,6 +11,8 @@ import (
 var (
 	// debug is true if --debug is specified
 	debug bool
+	// syncMode is accepted for compatibility with other language perf runners.
+	syncMode bool
 	// duration is the -d/--duration flag
 	duration int
 	// testProxyURLs is the -x/--test-proxy flag, a semi-colon separated list
@@ -25,6 +27,64 @@ var (
 
 	// number of processes to use, the --maxprocs flag
 	numProcesses int
+
+	// resourceTelemetry prints a runtime.MemStats / goroutine-count diff
+	// at the end of the run when --resource-telemetry is set.
+	resourceTelemetry bool
+
+	// enableOperationLatency is the -l/--latency flag; mirrors PerfOptions.cs
+	// Latency. When set, per-operation latency is tracked and a percentile
+	// summary is printed at the end of the run (and per-operation entries are
+	// written to --results-file).
+	enableOperationLatency bool
+
+	// resultsFilePath points to the file where per-operation results should be written
+	resultsFilePath string
+
+	// workloadConfigPath points to a workload configuration JSON file
+	workloadConfigPath string
+
+	// workloadName is the name of a workload entry in a workload configuration JSON file
+	workloadName string
+
+	// outputFilePrefix writes result artifacts to <prefix>.json/.csv/.txt/.md when set
+	outputFilePrefix string
+
+	// noCleanup skips per-test Cleanup() and GlobalCleanup() at the end of a run.
+	// Mirrors --no-cleanup in other language perf runners; used by perf-automation
+	// to leave server-side state in place between iterations.
+	noCleanup bool
+
+	// insecureSkipVerify is accepted for compatibility with other language perf
+	// runners (--insecure). The Go perf default transport already skips TLS
+	// verification to support the local test proxy, so this flag is a no-op.
+	insecureSkipVerify bool
+
+	// iterations is the -i/--iterations flag; the number of times the measurement
+	// phase is repeated (warmup runs once before the first iteration). Matches the
+	// .NET PerfOptions.Iterations option.
+	iterations int
+
+	// jobStatistics is the --job-statistics flag. When true the runner emits a
+	// `#StartJobStatistics` / `#EndJobStatistics` JSON block consumed by
+	// perf-automation, in the same format as the .NET runner.
+	jobStatistics bool
+
+	// targetRate is the -r/--rate flag, the target throughput in ops/sec aggregated
+	// across all parallel workers. Zero (the default) means "unlimited".
+	targetRate int
+
+	// statusInterval is the --status-interval flag, the number of seconds between
+	// status lines printed to the console. Matches PerfOptions.StatusInterval.
+	statusInterval int
+
+	// The following four flags exist purely for CLI compatibility with the .NET
+	// perf runner's ThreadPool tuning options. The Go runtime has no equivalent
+	// knobs (goroutines are not OS threads), so these flags are parsed and ignored.
+	maxIOCompletionThreads int
+	maxWorkerThreads       int
+	minIOCompletionThreads int
+	minWorkerThreads       int
 )
 
 // parseProxyURLs splits the --test-proxy input with the delimiter ';'

--- a/sdk/internal/perf/latency_stats.go
+++ b/sdk/internal/perf/latency_stats.go
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package perf
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+type latencyCollector struct {
+	mu        sync.Mutex
+	durations []time.Duration
+}
+
+func (l *latencyCollector) Add(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	l.mu.Lock()
+	l.durations = append(l.durations, d)
+	l.mu.Unlock()
+}
+
+func (l *latencyCollector) Summary() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if len(l.durations) == 0 {
+		return "Latency: no data"
+	}
+
+	vals := append([]time.Duration(nil), l.durations...)
+	sort.Slice(vals, func(i, j int) bool { return vals[i] < vals[j] })
+
+	return fmt.Sprintf(
+		"Latency (ms): p50=%.2f p90=%.2f p95=%.2f p99=%.2f max=%.2f",
+		toMS(percentile(vals, 50)),
+		toMS(percentile(vals, 90)),
+		toMS(percentile(vals, 95)),
+		toMS(percentile(vals, 99)),
+		toMS(vals[len(vals)-1]),
+	)
+}
+
+func percentile(vals []time.Duration, p int) time.Duration {
+	if len(vals) == 0 {
+		return 0
+	}
+	if len(vals) == 1 {
+		return vals[0]
+	}
+
+	idx := (float64(p) / 100.0) * float64(len(vals)-1)
+	low := int(idx)
+	high := low + 1
+	if high >= len(vals) {
+		return vals[len(vals)-1]
+	}
+	frac := idx - float64(low)
+	return time.Duration(float64(vals[low])*(1-frac) + float64(vals[high])*frac)
+}
+
+func toMS(d time.Duration) float64 {
+	return float64(d) / float64(time.Millisecond)
+}

--- a/sdk/internal/perf/operation_result.go
+++ b/sdk/internal/perf/operation_result.go
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package perf
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+type operationResult struct {
+	Timestamp time.Time `json:"timestamp"`
+	Operation string    `json:"operation"`
+	LatencyMs float64   `json:"latencyMs"`
+	SizeBytes int64     `json:"sizeBytes"`
+}
+
+type operationResultsCollector struct {
+	mu      sync.Mutex
+	results []operationResult
+}
+
+func (c *operationResultsCollector) Add(operation string, latency time.Duration, sizeBytes int64) {
+	if latency <= 0 {
+		return
+	}
+	if operation == "" {
+		operation = "operation"
+	}
+	c.mu.Lock()
+	c.results = append(c.results, operationResult{
+		Timestamp: time.Now().UTC(),
+		Operation: operation,
+		LatencyMs: toMS(latency),
+		SizeBytes: sizeBytes,
+	})
+	c.mu.Unlock()
+}
+
+func (c *operationResultsCollector) WriteJSON(path string) error {
+	c.mu.Lock()
+	data := append([]operationResult(nil), c.results...)
+	c.mu.Unlock()
+
+	b, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal operation results: %w", err)
+	}
+	if err = os.WriteFile(path, b, 0o600); err != nil {
+		return fmt.Errorf("failed to write operation results file %s: %w", path, err)
+	}
+	return nil
+}

--- a/sdk/internal/perf/perf.go
+++ b/sdk/internal/perf/perf.go
@@ -5,6 +5,7 @@ package perf
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"net/http"
@@ -15,21 +16,55 @@ import (
 )
 
 func init() {
-	flag.IntVar(&duration, "d", 10, "Duration of test in seconds.")
-	flag.IntVar(&duration, "duration", 10, "Duration of test in seconds.")
+	registerFlags(flag.CommandLine)
+}
 
-	flag.StringVar(&testProxyURLs, "test-proxies", "", "test proxy URLs to target. This can be a semi-colon separated list for multiple proxies.")
-	flag.StringVar(&testProxyURLs, "x", "", "test proxy URLs to target. This can be a semi-colon separated list for multiple proxies.")
+// registerFlags binds every perf CLI flag onto the supplied FlagSet. It is
+// extracted from init() so tests can construct their own FlagSet, parse a
+// slice of args, and assert on the resulting global state without disturbing
+// the process-wide flag.CommandLine.
+func registerFlags(fs *flag.FlagSet) {
+	fs.IntVar(&duration, "d", 10, "Duration of test in seconds")
+	fs.IntVar(&duration, "duration", 10, "Duration of test in seconds")
 
-	flag.IntVar(&warmUpDuration, "warmup", 5, "Duration of warmup in seconds.")
-	flag.IntVar(&warmUpDuration, "w", 5, "Duration of warmup in seconds.")
+	fs.StringVar(&testProxyURLs, "test-proxies", "", "URIs of TestProxy Servers (separated by ';')")
+	fs.StringVar(&testProxyURLs, "x", "", "URIs of TestProxy Servers (separated by ';')")
 
-	flag.IntVar(&parallelInstances, "parallel", 1, "Degree of parallelism to run with.")
-	flag.IntVar(&parallelInstances, "p", 1, "Degree of parallelism to run with.")
+	fs.IntVar(&warmUpDuration, "warmup", 5, "Duration of warmup in seconds")
+	fs.IntVar(&warmUpDuration, "w", 5, "Duration of warmup in seconds")
 
-	flag.IntVar(&numProcesses, "maxprocs", runtime.NumCPU(), "Number of CPUs to use.")
+	fs.IntVar(&parallelInstances, "parallel", 1, "Number of operations to execute in parallel")
+	fs.IntVar(&parallelInstances, "p", 1, "Number of operations to execute in parallel")
 
-	flag.BoolVar(&debug, "debug", false, "Print debugging information")
+	fs.IntVar(&iterations, "iterations", 1, "Number of iterations of main test loop")
+	fs.IntVar(&iterations, "i", 1, "Number of iterations of main test loop")
+
+	fs.IntVar(&targetRate, "rate", 0, "Target throughput (ops/sec). 0 means unlimited.")
+	fs.IntVar(&targetRate, "r", 0, "Target throughput (ops/sec). 0 means unlimited.")
+
+	fs.IntVar(&statusInterval, "status-interval", 1, "Interval to write status to console in seconds")
+
+	fs.BoolVar(&jobStatistics, "job-statistics", false, "Print job statistics (used by automation)")
+
+	fs.IntVar(&numProcesses, "maxprocs", runtime.NumCPU(), "Number of CPUs to use.")
+
+	fs.BoolVar(&debug, "debug", false, "Print debugging information")
+	fs.BoolVar(&syncMode, "sync", false, "Runs sync version of test. Accepted for CLI compatibility; no-op for Go perf tests.")
+	fs.BoolVar(&resourceTelemetry, "resource-telemetry", false, "Print process resource telemetry summary (memory, GC, and goroutines).")
+	fs.BoolVar(&enableOperationLatency, "latency", false, "Track and print per-operation latency statistics")
+	fs.BoolVar(&enableOperationLatency, "l", false, "Track and print per-operation latency statistics")
+	fs.BoolVar(&noCleanup, "no-cleanup", false, "Disables test cleanup")
+	fs.BoolVar(&insecureSkipVerify, "insecure", false, "Allow untrusted SSL certs")
+	fs.StringVar(&resultsFilePath, "results-file", "", "File path location to store the results for the test run.")
+	fs.StringVar(&workloadConfigPath, "config", "", "Path to workload config JSON file.")
+	fs.StringVar(&workloadName, "workload", "", "Workload name from config JSON.")
+	fs.StringVar(&outputFilePrefix, "output-file-prefix", "", "Write run artifacts to <prefix>.json/.csv/.txt/.md.")
+
+	// .NET ThreadPool tuning flags — accepted for CLI compatibility, ignored at runtime.
+	fs.IntVar(&maxIOCompletionThreads, "max-io-completion-threads", 0, "Compatibility flag; no-op in Go.")
+	fs.IntVar(&maxWorkerThreads, "max-worker-threads", 0, "Compatibility flag; no-op in Go.")
+	fs.IntVar(&minIOCompletionThreads, "min-io-completion-threads", 0, "Compatibility flag; no-op in Go.")
+	fs.IntVar(&minWorkerThreads, "min-worker-threads", 0, "Compatibility flag; no-op in Go.")
 }
 
 // GlobalPerfTest methods execute once per process
@@ -106,9 +141,26 @@ type PerfMethods struct {
 	New      func(context.Context, PerfTestOptions) (GlobalPerfTest, error)
 }
 
+// Parallel returns the value of the --parallel/-p flag (the number of
+// goroutines running PerfTest instances concurrently). It is safe to call
+// only after flag parsing has occurred (i.e. from inside a registered test's
+// New/Register/Run callbacks). Before flag parsing it returns the default
+// value of 1.
+func Parallel() int {
+	if parallelInstances <= 0 {
+		return 1
+	}
+	return parallelInstances
+}
+
 // Run runs an individual test, registers, and parses command line flags
 func Run(tests map[string]PerfMethods) {
-	if len(os.Args) < 2 {
+	invocation, err := resolveRunInvocation(os.Args[1:])
+	if err != nil {
+		panic(err)
+	}
+
+	if invocation.TestName == "" {
 		// Error out and show available perf tests
 		fmt.Println("Available performance tests:")
 		for name := range tests {
@@ -118,7 +170,7 @@ func Run(tests map[string]PerfMethods) {
 		return
 	}
 
-	testNameToRun := os.Args[1]
+	testNameToRun := invocation.TestName
 	var perfTestToRun PerfMethods
 	var ok bool
 	if perfTestToRun, ok = tests[testNameToRun]; !ok {
@@ -135,10 +187,34 @@ func Run(tests map[string]PerfMethods) {
 		perfTestToRun.Register()
 	}
 
-	// We strip off the first argument because that is used in determining the test
-	os.Args = os.Args[1:]
+	// Parse only config-provided and CLI-provided flags.
+	// CLI arguments are appended last to allow explicit command-line overrides.
+	os.Args = append([]string{os.Args[0]}, invocation.ConfigArgs...)
+	os.Args = append(os.Args, invocation.CLIArgs...)
 
 	flag.Parse()
+
+	// --config / --workload are consumed by resolveRunInvocation before
+	// flag.Parse runs, so the corresponding globals are not populated by
+	// the standard flag machinery. Mirror the resolved invocation onto
+	// the globals so downstream artifacts (run summary, =Options= dump)
+	// reflect the workload that actually drove the run.
+	if invocation.UsesConfig {
+		workloadConfigPath = invocation.ConfigPath
+		workloadName = invocation.Workload
+	}
+
+	// Normalize sentinel defaults for the .NET-compatible Rate/Iterations/
+	// StatusInterval flags.
+	if iterations < 1 {
+		iterations = 1
+	}
+	if statusInterval < 1 {
+		statusInterval = 1
+	}
+	if targetRate < 0 {
+		targetRate = 0
+	}
 
 	if numProcesses > 0 {
 		val := runtime.GOMAXPROCS(numProcesses)
@@ -147,11 +223,78 @@ func Run(tests map[string]PerfMethods) {
 		}
 	}
 
-	fmt.Printf("\tRunning %s\n", testNameToRun)
+	if jobStatistics {
+		// Matches the .NET runner's first-line marker used by perf-automation.
+		fmt.Println("Application started.")
+	}
+
+	// Mirror the .NET runner's "=== Options ===" block so perf-automation
+	// sees the same machine-parseable configuration dump regardless of language.
+	printOptions(testNameToRun)
+
+	if invocation.UsesConfig {
+		fmt.Printf("\tRunning %s (workload: %s, config: %s)\n", testNameToRun, invocation.Workload, invocation.ConfigPath)
+	} else {
+		fmt.Printf("\tRunning %s\n", testNameToRun)
+	}
 
 	runner := newPerfRunner(perfTestToRun, testNameToRun)
-	err := runner.Run()
+	err = runner.Run()
 	if err != nil {
 		panic(err)
 	}
+}
+
+// printOptions writes a "=== Options ===" header followed by a JSON object
+// describing the parsed CLI options. The format mirrors the .NET runner's
+// `JsonSerializer.Serialize(options, ...)` output so a shared parser can
+// extract the run configuration from either language's stdout.
+func printOptions(testName string) {
+	type optionsDump struct {
+		TestName               string `json:"testName"`
+		Duration               int    `json:"duration"`
+		Warmup                 int    `json:"warmup"`
+		Parallel               int    `json:"parallel"`
+		Iterations             int    `json:"iterations"`
+		Rate                   int    `json:"rate"`
+		StatusInterval         int    `json:"statusInterval"`
+		Latency                bool   `json:"latency"`
+		NoCleanup              bool   `json:"noCleanup"`
+		JobStatistics          bool   `json:"jobStatistics"`
+		Sync                   bool   `json:"sync"`
+		Insecure               bool   `json:"insecure"`
+		TestProxies            string `json:"testProxies,omitempty"`
+		ResultsFile            string `json:"resultsFile,omitempty"`
+		MaxIOCompletionThreads int    `json:"maxIOCompletionThreads"`
+		MaxWorkerThreads       int    `json:"maxWorkerThreads"`
+		MinIOCompletionThreads int    `json:"minIOCompletionThreads"`
+		MinWorkerThreads       int    `json:"minWorkerThreads"`
+	}
+	opts := optionsDump{
+		TestName:               testName,
+		Duration:               duration,
+		Warmup:                 warmUpDuration,
+		Parallel:               parallelInstances,
+		Iterations:             iterations,
+		Rate:                   targetRate,
+		StatusInterval:         statusInterval,
+		Latency:                enableOperationLatency,
+		NoCleanup:              noCleanup,
+		JobStatistics:          jobStatistics,
+		Sync:                   syncMode,
+		Insecure:               insecureSkipVerify,
+		TestProxies:            testProxyURLs,
+		ResultsFile:            resultsFilePath,
+		MaxIOCompletionThreads: maxIOCompletionThreads,
+		MaxWorkerThreads:       maxWorkerThreads,
+		MinIOCompletionThreads: minIOCompletionThreads,
+		MinWorkerThreads:       minWorkerThreads,
+	}
+	b, err := json.MarshalIndent(opts, "", "  ")
+	if err != nil {
+		return
+	}
+	fmt.Println("=== Options ===")
+	fmt.Println(string(b))
+	fmt.Println()
 }

--- a/sdk/internal/perf/perf_options_test.go
+++ b/sdk/internal/perf/perf_options_test.go
@@ -1,0 +1,376 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package perf
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// snapshotFlags captures the current values of every flag-backed global so a
+// test can restore them on exit. Each test that calls parseFlagsForTest must
+// defer the returned restore function.
+func snapshotFlags(t *testing.T) func() {
+	t.Helper()
+	saved := struct {
+		duration               int
+		warmUpDuration         int
+		parallelInstances      int
+		iterations             int
+		targetRate             int
+		statusInterval         int
+		jobStatistics          bool
+		numProcesses           int
+		debug                  bool
+		syncMode               bool
+		resourceTelemetry      bool
+		enableOperationLatency bool
+		noCleanup              bool
+		insecureSkipVerify     bool
+		testProxyURLs          string
+		resultsFilePath        string
+		workloadConfigPath     string
+		workloadName           string
+		outputFilePrefix       string
+		maxIOCompletionThreads int
+		maxWorkerThreads       int
+		minIOCompletionThreads int
+		minWorkerThreads       int
+	}{
+		duration, warmUpDuration, parallelInstances, iterations, targetRate, statusInterval,
+		jobStatistics, numProcesses, debug, syncMode, resourceTelemetry,
+		enableOperationLatency, noCleanup, insecureSkipVerify, testProxyURLs,
+		resultsFilePath, workloadConfigPath, workloadName, outputFilePrefix,
+		maxIOCompletionThreads, maxWorkerThreads, minIOCompletionThreads, minWorkerThreads,
+	}
+	return func() {
+		duration = saved.duration
+		warmUpDuration = saved.warmUpDuration
+		parallelInstances = saved.parallelInstances
+		iterations = saved.iterations
+		targetRate = saved.targetRate
+		statusInterval = saved.statusInterval
+		jobStatistics = saved.jobStatistics
+		numProcesses = saved.numProcesses
+		debug = saved.debug
+		syncMode = saved.syncMode
+		resourceTelemetry = saved.resourceTelemetry
+		enableOperationLatency = saved.enableOperationLatency
+		noCleanup = saved.noCleanup
+		insecureSkipVerify = saved.insecureSkipVerify
+		testProxyURLs = saved.testProxyURLs
+		resultsFilePath = saved.resultsFilePath
+		workloadConfigPath = saved.workloadConfigPath
+		workloadName = saved.workloadName
+		outputFilePrefix = saved.outputFilePrefix
+		maxIOCompletionThreads = saved.maxIOCompletionThreads
+		maxWorkerThreads = saved.maxWorkerThreads
+		minIOCompletionThreads = saved.minIOCompletionThreads
+		minWorkerThreads = saved.minWorkerThreads
+	}
+}
+
+// parseFlagsForTest registers every perf flag onto a fresh FlagSet, parses
+// the supplied args, and leaves the package-level globals populated for
+// assertion. Tests must defer the cleanup function returned by snapshotFlags.
+func parseFlagsForTest(t *testing.T, args []string) {
+	t.Helper()
+	fs := flag.NewFlagSet("perf-test", flag.ContinueOnError)
+	registerFlags(fs)
+	require.NoError(t, fs.Parse(args))
+}
+
+// TestDefaults asserts that every flag has the default value documented in
+// PerfOptions.cs (and the Go-only flags retain their existing defaults).
+func TestDefaults(t *testing.T) {
+	defer snapshotFlags(t)()
+	parseFlagsForTest(t, nil)
+
+	require.Equal(t, 10, duration, "--duration default")
+	require.Equal(t, 5, warmUpDuration, "--warmup default")
+	require.Equal(t, 1, parallelInstances, "--parallel default")
+	require.Equal(t, 1, iterations, "--iterations default")
+	require.Equal(t, 0, targetRate, "--rate default (0 = unlimited)")
+	require.Equal(t, 1, statusInterval, "--status-interval default")
+	require.False(t, jobStatistics, "--job-statistics default")
+	require.False(t, syncMode, "--sync default")
+	require.False(t, insecureSkipVerify, "--insecure default")
+	require.False(t, noCleanup, "--no-cleanup default")
+	require.False(t, enableOperationLatency, "--latency default")
+	require.False(t, resourceTelemetry, "--resource-telemetry default")
+	require.Equal(t, "", testProxyURLs, "--test-proxies default")
+	require.Equal(t, "", resultsFilePath, "--results-file default")
+	require.Equal(t, "", outputFilePrefix, "--output-file-prefix default")
+	require.Equal(t, 0, maxIOCompletionThreads, "--max-io-completion-threads default")
+	require.Equal(t, 0, maxWorkerThreads, "--max-worker-threads default")
+	require.Equal(t, 0, minIOCompletionThreads, "--min-io-completion-threads default")
+	require.Equal(t, 0, minWorkerThreads, "--min-worker-threads default")
+	require.Equal(t, runtime.NumCPU(), numProcesses, "--maxprocs default")
+}
+
+// TestFlagLongForms exercises the long-form spelling of every CLI flag. Each
+// table entry sets one flag and asserts it parsed into the expected global.
+func TestFlagLongForms(t *testing.T) {
+	cases := []struct {
+		name   string
+		args   []string
+		assert func(t *testing.T)
+	}{
+		{"duration", []string{"--duration", "42"}, func(t *testing.T) { require.Equal(t, 42, duration) }},
+		{"warmup", []string{"--warmup", "7"}, func(t *testing.T) { require.Equal(t, 7, warmUpDuration) }},
+		{"parallel", []string{"--parallel", "8"}, func(t *testing.T) { require.Equal(t, 8, parallelInstances) }},
+		{"iterations", []string{"--iterations", "3"}, func(t *testing.T) { require.Equal(t, 3, iterations) }},
+		{"rate", []string{"--rate", "100"}, func(t *testing.T) { require.Equal(t, 100, targetRate) }},
+		{"status-interval", []string{"--status-interval", "5"}, func(t *testing.T) { require.Equal(t, 5, statusInterval) }},
+		{"job-statistics", []string{"--job-statistics"}, func(t *testing.T) { require.True(t, jobStatistics) }},
+		{"sync", []string{"--sync"}, func(t *testing.T) { require.True(t, syncMode) }},
+		{"insecure", []string{"--insecure"}, func(t *testing.T) { require.True(t, insecureSkipVerify) }},
+		{"no-cleanup", []string{"--no-cleanup"}, func(t *testing.T) { require.True(t, noCleanup) }},
+		{"latency", []string{"--latency"}, func(t *testing.T) { require.True(t, enableOperationLatency) }},
+		{"resource-telemetry", []string{"--resource-telemetry"}, func(t *testing.T) { require.True(t, resourceTelemetry) }},
+		{"test-proxies", []string{"--test-proxies", "http://a;http://b"}, func(t *testing.T) {
+			require.Equal(t, "http://a;http://b", testProxyURLs)
+			require.Equal(t, []string{"http://a", "http://b"}, parseProxyURLS())
+		}},
+		{"results-file", []string{"--results-file", "/tmp/out.json"}, func(t *testing.T) { require.Equal(t, "/tmp/out.json", resultsFilePath) }},
+		{"output-file-prefix", []string{"--output-file-prefix", "/tmp/run"}, func(t *testing.T) { require.Equal(t, "/tmp/run", outputFilePrefix) }},
+		{"config", []string{"--config", "wl.json"}, func(t *testing.T) { require.Equal(t, "wl.json", workloadConfigPath) }},
+		{"workload", []string{"--workload", "wl-upload"}, func(t *testing.T) { require.Equal(t, "wl-upload", workloadName) }},
+		{"debug", []string{"--debug"}, func(t *testing.T) { require.True(t, debug) }},
+		{"maxprocs", []string{"--maxprocs", "2"}, func(t *testing.T) { require.Equal(t, 2, numProcesses) }},
+		{"max-io-completion-threads", []string{"--max-io-completion-threads", "16"}, func(t *testing.T) { require.Equal(t, 16, maxIOCompletionThreads) }},
+		{"max-worker-threads", []string{"--max-worker-threads", "16"}, func(t *testing.T) { require.Equal(t, 16, maxWorkerThreads) }},
+		{"min-io-completion-threads", []string{"--min-io-completion-threads", "2"}, func(t *testing.T) { require.Equal(t, 2, minIOCompletionThreads) }},
+		{"min-worker-threads", []string{"--min-worker-threads", "2"}, func(t *testing.T) { require.Equal(t, 2, minWorkerThreads) }},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			defer snapshotFlags(t)()
+			parseFlagsForTest(t, tc.args)
+			tc.assert(t)
+		})
+	}
+}
+
+// TestFlagShortForms exercises the short alias of every flag that defines one
+// (-d, -w, -p, -i, -r, -l, -x). They must produce the same effect as the
+// long form.
+func TestFlagShortForms(t *testing.T) {
+	cases := []struct {
+		name   string
+		args   []string
+		assert func(t *testing.T)
+	}{
+		{"d", []string{"-d", "20"}, func(t *testing.T) { require.Equal(t, 20, duration) }},
+		{"w", []string{"-w", "3"}, func(t *testing.T) { require.Equal(t, 3, warmUpDuration) }},
+		{"p", []string{"-p", "16"}, func(t *testing.T) { require.Equal(t, 16, parallelInstances) }},
+		{"i", []string{"-i", "5"}, func(t *testing.T) { require.Equal(t, 5, iterations) }},
+		{"r", []string{"-r", "50"}, func(t *testing.T) { require.Equal(t, 50, targetRate) }},
+		{"l", []string{"-l"}, func(t *testing.T) { require.True(t, enableOperationLatency) }},
+		{"x", []string{"-x", "http://proxy"}, func(t *testing.T) { require.Equal(t, "http://proxy", testProxyURLs) }},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			defer snapshotFlags(t)()
+			parseFlagsForTest(t, tc.args)
+			tc.assert(t)
+		})
+	}
+}
+
+// TestRateLimiter verifies that newRateLimiter emits tokens at approximately
+// the requested rate. The test uses a coarse window (200 ms) and asserts the
+// observed count is within [floor(expected*0.5), ceil(expected*2)] to avoid
+// flakiness on slow CI runners.
+func TestRateLimiter(t *testing.T) {
+	const rate = 100
+	tokens, stop := newRateLimiter(rate)
+	defer close(stop)
+
+	deadline := time.After(200 * time.Millisecond)
+	count := 0
+loop:
+	for {
+		select {
+		case _, ok := <-tokens:
+			if !ok {
+				break loop
+			}
+			count++
+		case <-deadline:
+			break loop
+		}
+	}
+
+	// At 100 ops/s for ~200 ms we expect ~20 tokens. Allow a wide tolerance
+	// to keep the test reliable under load.
+	require.GreaterOrEqual(t, count, 5, "rate limiter produced too few tokens")
+	require.LessOrEqual(t, count, 60, "rate limiter produced too many tokens")
+}
+
+// TestLatencyCollector verifies that --latency accumulators record samples
+// and report percentile summaries containing the expected markers.
+func TestLatencyCollector(t *testing.T) {
+	c := &latencyCollector{}
+	c.Add(time.Millisecond)
+	c.Add(2 * time.Millisecond)
+	c.Add(3 * time.Millisecond)
+
+	summary := c.Summary()
+	for _, marker := range []string{"p50", "p90", "p95", "p99", "max"} {
+		require.Contains(t, summary, marker)
+	}
+}
+
+// TestCallTypeCollector verifies the call-type latency buckets that drive
+// the per-call summary printed alongside --latency.
+func TestCallTypeCollector(t *testing.T) {
+	c := newCallTypeLatencyCollector()
+	c.Add("operation", time.Millisecond)
+	c.Add("operation", 2*time.Millisecond)
+	c.Add("proxy-live", 5*time.Millisecond)
+
+	summary := c.Summary()
+	require.Contains(t, summary, "operation")
+	require.Contains(t, summary, "proxy-live")
+}
+
+// TestOperationResultsWriteJSON drives the --results-file output path and
+// asserts the on-disk shape matches what perf-automation consumes.
+func TestOperationResultsWriteJSON(t *testing.T) {
+	c := &operationResultsCollector{}
+	c.Add("UploadBlobTest", 12*time.Millisecond, 1024)
+	c.Add("UploadBlobTest", 7*time.Millisecond, 1024)
+
+	path := filepath.Join(t.TempDir(), "results.json")
+	require.NoError(t, c.WriteJSON(path))
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var rows []operationResult
+	require.NoError(t, json.Unmarshal(raw, &rows))
+	require.Len(t, rows, 2)
+	require.Equal(t, "UploadBlobTest", rows[0].Operation)
+	require.InDelta(t, 12.0, rows[0].LatencyMs, 0.001)
+	require.Equal(t, int64(1024), rows[0].SizeBytes)
+}
+
+// TestOutputFilePrefixWritesAllArtifacts drives the --output-file-prefix
+// writer and asserts that all four artifact files are produced and the JSON
+// shape includes the fields populated by the runner.
+func TestOutputFilePrefixWritesAllArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	prefix := filepath.Join(dir, "run")
+
+	summary := newRunSummary("TestX", 100, 50.0, "lat", "ct", "res")
+	summary.AverageCPUPercent = 25.5
+	summary.AverageMemoryBytes = 1024 * 1024
+	summary.ProcessStatsSummary = "Process stats: ..."
+	require.NoError(t, writeRunArtifacts(prefix, summary))
+
+	for _, ext := range []string{".json", ".csv", ".txt", ".md"} {
+		_, err := os.Stat(prefix + ext)
+		require.NoError(t, err, "expected %s artifact", ext)
+	}
+
+	raw, err := os.ReadFile(prefix + ".json")
+	require.NoError(t, err)
+	var got runSummary
+	require.NoError(t, json.Unmarshal(raw, &got))
+	require.Equal(t, "TestX", got.TestName)
+	require.Equal(t, int64(100), got.TotalOperations)
+	require.InDelta(t, 50.0, got.OpsPerSecond, 0.001)
+	require.InDelta(t, 25.5, got.AverageCPUPercent, 0.001)
+}
+
+// TestStatusColumnFormatters covers the helpers used to render the
+// CPU / Memory columns on the live status line.
+func TestStatusColumnFormatters(t *testing.T) {
+	require.Equal(t, "n/a", formatCPUColumn(-1))
+	require.Equal(t, "12.34%", formatCPUColumn(12.34))
+
+	require.Equal(t, "n/a", formatMemoryColumn(0))
+	require.Equal(t, "1.00", formatMemoryColumn(1024*1024))
+}
+
+// TestProcessStatsSamplerProducesSamples starts the sampler, waits long
+// enough to produce at least one sample, and asserts the recorded CPU% is
+// finite and non-negative. This protects against regressions in the
+// /cpu/classes/total - /cpu/classes/idle math.
+func TestProcessStatsSamplerProducesSamples(t *testing.T) {
+	s := newProcessStatsSampler(50 * time.Millisecond)
+	s.Start()
+
+	// Give the sampler enough wall time to collect at least 2 ticks so
+	// AverageCPU has a usable delta to work with.
+	time.Sleep(250 * time.Millisecond)
+	s.Stop()
+
+	require.Greater(t, s.SampleCount(), 0, "expected at least one sample")
+	require.GreaterOrEqual(t, s.AverageCPU(), 0.0, "averageCpuPercent should not be negative")
+	require.GreaterOrEqual(t, s.AverageMemory(), int64(0), "averageMemoryBytes should not be negative")
+
+	last, mem := s.LastSample()
+	require.GreaterOrEqual(t, last, 0.0)
+	require.GreaterOrEqual(t, mem, uint64(0))
+}
+
+// TestPrintVersionsIncludesGoRuntime captures stdout while printVersions
+// runs and asserts the Go runtime version line is present in the expected
+// format (matches the .NET adapter's `Informational: (\S*)` regex).
+func TestPrintVersionsIncludesGoRuntime(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	origStdout := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	printVersions()
+	require.NoError(t, w.Close())
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	out := string(buf[:n])
+
+	require.Contains(t, out, "=== Versions ===")
+	require.Contains(t, out, "go:")
+	require.Contains(t, out, "Informational:")
+	require.Contains(t, out, runtime.Version())
+}
+
+// TestPrintJobStatisticsBlock captures stdout while printJobStatistics runs
+// and asserts the #StartJobStatistics / payload / #EndJobStatistics markers
+// match the .NET runner's output that perf-automation parses.
+func TestPrintJobStatisticsBlock(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	origStdout := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	printJobStatistics(123.45)
+	require.NoError(t, w.Close())
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	out := string(buf[:n])
+
+	require.True(t, strings.HasPrefix(strings.TrimSpace(out), "#StartJobStatistics"))
+	require.Contains(t, out, "#EndJobStatistics")
+	require.Contains(t, out, "perfstress/throughput")
+	require.Contains(t, out, "123.45")
+}

--- a/sdk/internal/perf/perf_runner.go
+++ b/sdk/internal/perf/perf_runner.go
@@ -5,9 +5,9 @@ package perf
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -23,8 +23,15 @@ type optionsSlice struct {
 	mu   sync.Mutex
 }
 
+// perfRunner is the per-process orchestrator that drives setup, warmup, one or
+// more measurement iterations, and cleanup. The control-flow is modeled after
+// the .NET runner (common/Perf/Azure.Test.Perf/PerfProgram.cs):
+//
+//	GlobalSetup -> Setup -> Warmup (if --warmup > 0)
+//	            -> for i in 1..Iterations: RunTests
+//	            -> Cleanup -> GlobalCleanup
 type perfRunner struct {
-	// ticker is the runner for giving updates every second
+	// ticker is the runner for giving updates every status-interval seconds
 	ticker *time.Ticker
 	done   chan bool
 
@@ -53,6 +60,14 @@ type perfRunner struct {
 	// tracker for whether the warmup has finished
 	warmupFinished int32
 	warmupPrinted  bool
+
+	latencyCollector      *latencyCollector
+	callTypeCollector     *callTypeLatencyCollector
+	operationResults      *operationResultsCollector
+	resourceBeforeRun     resourceTelemetrySnapshot
+	resourceAfterRun      resourceTelemetrySnapshot
+	resourceTelemetryDone bool
+	processStats          *processStatsSampler
 }
 
 func newPerfRunner(p PerfMethods, name string) *perfRunner {
@@ -60,8 +75,11 @@ func newPerfRunner(p PerfMethods, name string) *perfRunner {
 	if warmUpDuration == 0 {
 		warmupFinished, warmupPrinted = parallelInstances, true
 	}
+	// The status ticker is created lazily inside Run() once the runner is
+	// about to start emitting status lines. Allocating it here as well would
+	// leak the original *time.Ticker (it is never Stop'd before being
+	// overwritten by Run).
 	return &perfRunner{
-		ticker:                       time.NewTicker(time.Second),
 		done:                         make(chan bool),
 		name:                         name,
 		proxyTransports:              map[string]*RecordingHTTPClient{},
@@ -72,6 +90,9 @@ func newPerfRunner(p PerfMethods, name string) *perfRunner {
 		messagePrinter:               message.NewPrinter(message.MatchLanguage("en")),
 		warmupFinished:               int32(warmupFinished),
 		warmupPrinted:                warmupPrinted,
+		latencyCollector:             &latencyCollector{},
+		callTypeCollector:            newCallTypeLatencyCollector(),
+		operationResults:             &operationResultsCollector{},
 	}
 }
 
@@ -81,18 +102,31 @@ func (r *perfRunner) Run() error {
 		return err
 	}
 	defer func() {
+		if noCleanup {
+			return
+		}
 		err = r.globalInstance.GlobalCleanup(context.Background())
 		if err != nil {
 			panic(err)
 		}
 	}()
 
-	err = r.createPerfTests()
-	if err != nil {
+	if err = r.createPerfTests(); err != nil {
 		return err
 	}
 
-	r.ticker = time.NewTicker(time.Second)
+	// The process-stats sampler runs for the lifetime of every perf run.
+	// Its output drives the CPU%/WorkingSet/PrivateMemory columns in the
+	// status line and the final =Process stats= summary, mirroring the
+	// .NET runner where the same data is always collected.
+	r.processStats = newProcessStatsSampler(time.Second)
+	r.processStats.Start()
+
+	statusTick := time.Duration(statusInterval) * time.Second
+	if statusTick <= 0 {
+		statusTick = time.Second
+	}
+	r.ticker = time.NewTicker(statusTick)
 
 	// Poller for printing
 	go func() {
@@ -110,15 +144,193 @@ func (r *perfRunner) Run() error {
 			}
 		}
 	}()
-	wg.Wait()
+
+	// Run any test-proxy bootstrap (live -> record -> playback) once per worker.
+	if testProxyURLs != "" {
+		if err = r.bootstrapProxies(); err != nil {
+			return err
+		}
+	}
+
+	if resourceTelemetry {
+		r.resourceBeforeRun = captureResourceTelemetry()
+	}
+
+	// Warmup runs once before the first measurement iteration.
+	if warmUpDuration > 0 {
+		r.runPhase(true, nil)
+	}
+
+	// Run the measurement phase `iterations` times. The Go --iterations /
+	// -i flag mirrors the .NET PerfOptions.Iterations option.
+	loopCount := iterations
+	if loopCount < 1 {
+		loopCount = 1
+	}
+	for iter := 1; iter <= loopCount; iter++ {
+		title := "Test"
+		if loopCount > 1 {
+			title = fmt.Sprintf("Test %d", iter)
+			fmt.Printf("\n=== %s ===\n", title)
+		}
+		// Reset per-iteration measurement counters/state on each worker
+		// and on the runner so each iteration produces independent stats.
+		r.resetMeasurementState()
+
+		var rateStop chan struct{}
+		var rateCh <-chan struct{}
+		if targetRate > 0 {
+			rateCh, rateStop = newRateLimiter(targetRate)
+		}
+		r.runPhase(false, rateCh)
+		if rateStop != nil {
+			close(rateStop)
+		}
+	}
+
+	if r.processStats != nil {
+		r.processStats.Stop()
+	}
 
 	r.done <- true
 
-	err = r.printFinalUpdate(false)
-	if err != nil {
+	if err = r.printFinalUpdate(false); err != nil {
 		return err
 	}
+
+	if resultsFilePath != "" && enableOperationLatency {
+		if err = r.operationResults.WriteJSON(resultsFilePath); err != nil {
+			return err
+		}
+	}
+
+	if jobStatistics {
+		printJobStatistics(r.opsPerSecond(false))
+	}
+
+	if err = r.writeArtifacts(); err != nil {
+		return err
+	}
+
+	printVersions()
+
+	if noCleanup {
+		return nil
+	}
 	return r.cleanup()
+}
+
+// runPhase spawns one goroutine per parallel worker that runs a single
+// warmup or measurement pass, then waits for them all to complete.
+func (r *perfRunner) runPhase(warmup bool, rateCh <-chan struct{}) {
+	for idx, test := range r.tests {
+		wg.Add(1)
+		go r.runWorkerPhase(test, idx, warmup, rateCh)
+	}
+	wg.Wait()
+}
+
+// runWorkerPhase executes a single warmup or measurement pass for one worker.
+func (r *perfRunner) runWorkerPhase(p PerfTest, index int, warmup bool, rateCh <-chan struct{}) {
+	defer wg.Done()
+
+	r.allOptions.mu.Lock()
+	opts := r.allOptions.opts[index]
+	r.allOptions.mu.Unlock()
+
+	if err := r.runTestForDuration(p, opts, warmup, rateCh); err != nil {
+		panic(err)
+	}
+
+	if warmup {
+		val := atomic.AddInt32(&r.warmupFinished, 1)
+		if debug {
+			fmt.Printf("finished %d warmups\n", val)
+		}
+	}
+}
+
+// resetMeasurementState clears per-worker measurement counters and the
+// shared latency/operation-result collectors so a fresh iteration starts
+// with empty stats.
+func (r *perfRunner) resetMeasurementState() {
+	r.allOptions.mu.Lock()
+	for _, opt := range r.allOptions.opts {
+		atomic.StoreInt64(&opt.runCount, 0)
+		atomic.StoreInt64((*int64)(&opt.runElapsed), 0)
+		t := time.Time{}
+		opt.runStart = &t
+		opt.finished = false
+	}
+	r.allOptions.mu.Unlock()
+	r.operationStatusTracker = -1
+	r.latencyCollector = &latencyCollector{}
+	r.callTypeCollector = newCallTypeLatencyCollector()
+	r.operationResults = &operationResultsCollector{}
+}
+
+// bootstrapProxies performs the one-time live -> record -> playback dance
+// against the test proxy for each worker so subsequent iterations replay
+// from the in-memory recording.
+func (r *perfRunner) bootstrapProxies() error {
+	for idx := range r.tests {
+		id := fmt.Sprintf("%s-%d", r.name, idx)
+		p := r.tests[idx]
+
+		r.proxyTransports[id].SetMode("live")
+		start := time.Now()
+		if err := p.Run(context.Background()); err != nil {
+			return err
+		}
+		r.callTypeCollector.Add("proxy-live", time.Since(start))
+
+		r.proxyTransports[id].SetMode("record")
+		if err := r.proxyTransports[id].start(); err != nil {
+			return err
+		}
+		start = time.Now()
+		if err := p.Run(context.Background()); err != nil {
+			return err
+		}
+		r.callTypeCollector.Add("proxy-record", time.Since(start))
+		if err := r.proxyTransports[id].stop(); err != nil {
+			return err
+		}
+
+		r.proxyTransports[id].SetMode("playback")
+		if err := r.proxyTransports[id].start(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// newRateLimiter starts a producer goroutine that emits one token every
+// 1/rate seconds across a buffered channel shared by all workers. Workers
+// receive one token before invoking each operation, throttling the
+// aggregate throughput to approximately `rate` ops/sec. Closing the
+// returned stop channel terminates the producer.
+func newRateLimiter(rate int) (<-chan struct{}, chan struct{}) {
+	tokens := make(chan struct{}, rate)
+	stop := make(chan struct{})
+	interval := time.Second / time.Duration(rate)
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				close(tokens)
+				return
+			case <-ticker.C:
+				select {
+				case tokens <- struct{}{}:
+				default:
+				}
+			}
+		}
+	}()
+	return tokens, stop
 }
 
 // global setup by instantiating a single global instance
@@ -131,15 +343,14 @@ func (r *perfRunner) globalSetup() error {
 	return nil
 }
 
-// createPerfTests spins up `parallelInstances` (specified by --parallel flag) goroutines
+// createPerfTests spins up `parallelInstances` (specified by --parallel flag) PerfTest instances.
+// The goroutines that drive them are spawned later, once per phase, by runPhase.
 func (r *perfRunner) createPerfTests() error {
-	var IDs []string
 	proxyURLS := parseProxyURLS()
 
 	for idx := 0; idx < parallelInstances; idx++ {
 		ID := fmt.Sprintf("%s-%d", r.name, idx)
 		options := newPerfTestOptions(ID)
-		IDs = append(IDs, ID)
 
 		if testProxyURLs != "" {
 			proxyURL := proxyURLS[idx%len(proxyURLS)]
@@ -162,11 +373,6 @@ func (r *perfRunner) createPerfTests() error {
 		r.allOptions.mu.Lock()
 		r.allOptions.opts = append(r.allOptions.opts, &options)
 		r.allOptions.mu.Unlock()
-	}
-
-	for idx, test := range r.tests {
-		wg.Add(1)
-		go r.runTest(test, idx, IDs[idx])
 	}
 	return nil
 }
@@ -198,18 +404,21 @@ func (r *perfRunner) printStatus() error {
 			return err
 		}
 		r.operationStatusTracker = 0
-		if _, err := fmt.Fprintln(r.w, "\nCurrent\tTotal\tAverage\t"); err != nil {
+		if _, err := fmt.Fprintln(r.w, "\nCurrent\tTotal\tAverage\tCPU\tMemory(MiB)\t"); err != nil {
 			return err
 		}
 	}
 	totalOperations := r.totalOperations(false)
+	cpuPct, memBytes := r.lastProcessSample()
 
 	_, err := fmt.Fprintf(
 		r.w,
-		"%s\t%s\t%s\t\n",
+		"%s\t%s\t%s\t%s\t%s\t\n",
 		r.messagePrinter.Sprintf("%d", totalOperations-r.operationStatusTracker),
 		r.messagePrinter.Sprintf("%d", totalOperations),
 		r.messagePrinter.Sprintf("%.2f", r.opsPerSecond(false)),
+		formatCPUColumn(cpuPct),
+		formatMemoryColumn(memBytes),
 	)
 	if err != nil {
 		return err
@@ -223,22 +432,52 @@ func (r *perfRunner) printWarmupStatus() (bool, error) {
 	if r.warmupOperationStatusTracker == -1 {
 		r.warmupOperationStatusTracker = 0
 		fmt.Println("===== WARMUP =====")
-		if _, err := fmt.Fprintln(r.w, "\nCurrent\tTotal\tAverage\t"); err != nil {
+		if _, err := fmt.Fprintln(r.w, "\nCurrent\tTotal\tAverage\tCPU\tMemory(MiB)\t"); err != nil {
 			return false, err
 		}
 	}
 	totalOperations := r.totalOperations(true)
+	cpuPct, memBytes := r.lastProcessSample()
 
-	if r.warmupOperationStatusTracker == totalOperations {
+	// Warmup is finished only when every goroutine has returned from its
+	// warmup loop (runTest increments warmupFinished on completion). The
+	// previous heuristic — "no new operations in the last status tick" —
+	// fires spuriously for long-running iterations (e.g. multi-GiB blob
+	// transfers) where a single op exceeds the 1s status interval and
+	// would cause the warmup phase to terminate after only one second with
+	// zero recorded operations.
+	if atomic.LoadInt32(&r.warmupFinished) >= int32(parallelInstances) {
+		// Drain one last status line so the user sees the final counters
+		// before "=== Warm Up Results ===" is printed.
+		if totalOperations != r.warmupOperationStatusTracker {
+			_, err := fmt.Fprintf(
+				r.w,
+				"%s\t%s\t%s\t%s\t%s\t\n",
+				r.messagePrinter.Sprintf("%d", totalOperations-r.warmupOperationStatusTracker),
+				r.messagePrinter.Sprintf("%d", totalOperations),
+				r.messagePrinter.Sprintf("%.2f", r.opsPerSecond(true)),
+				formatCPUColumn(cpuPct),
+				formatMemoryColumn(memBytes),
+			)
+			if err != nil {
+				return false, err
+			}
+			r.warmupOperationStatusTracker = totalOperations
+			if err := r.w.Flush(); err != nil {
+				return false, err
+			}
+		}
 		return true, nil
 	}
 
 	_, err := fmt.Fprintf(
 		r.w,
-		"%s\t%s\t%s\t\n",
+		"%s\t%s\t%s\t%s\t%s\t\n",
 		r.messagePrinter.Sprintf("%d", totalOperations-r.warmupOperationStatusTracker),
 		r.messagePrinter.Sprintf("%d", totalOperations),
 		r.messagePrinter.Sprintf("%.2f", r.opsPerSecond(true)),
+		formatCPUColumn(cpuPct),
+		formatMemoryColumn(memBytes),
 	)
 	if err != nil {
 		return false, err
@@ -298,7 +537,28 @@ func (r *perfRunner) printFinalUpdate(warmup bool) error {
 	totalOperations := r.totalOperations(warmup)
 	opsPerSecond := r.opsPerSecond(warmup)
 	if opsPerSecond == 0.0 {
-		return fmt.Errorf("completed without generating operation statistics")
+		// Zero completed operations means the elapsed window was too short
+		// to fit even one iteration (e.g. uploading a multi-GiB blob with a
+		// 60 s --warmup). For the warmup phase this is a soft condition —
+		// warn and continue so the measurement phase still has a chance to
+		// run (with a longer --duration, or after retries succeed). For the
+		// run phase it is a real failure: nothing useful can be reported.
+		if warmup {
+			fmt.Println("\n=== Warm Up Results ===")
+			fmt.Printf(
+				"warning: warmup completed without generating operation statistics. "+
+					"Consider increasing --warmup beyond the per-iteration latency "+
+					"(--warmup is currently %d s).\n",
+				warmUpDuration,
+			)
+			r.warmupPrinted = true
+			return nil
+		}
+		return fmt.Errorf(
+			"completed without generating operation statistics: no iteration finished in --duration %d s. "+
+				"Increase --duration, reduce --size, or use a chunked method (--upload-method buffer|stream, --download-method buffer)",
+			duration,
+		)
 	}
 
 	secondsPerOp := 1.0 / opsPerSecond
@@ -316,85 +576,32 @@ func (r *perfRunner) printFinalUpdate(warmup bool) error {
 		r.messagePrinter.Sprintf("%.3f", opsPerSecond),
 		r.messagePrinter.Sprintf("%.3f", secondsPerOp),
 	)
+
+	if !warmup {
+		if enableOperationLatency {
+			fmt.Println(r.latencyCollector.Summary())
+			fmt.Println(r.callTypeCollector.Summary())
+		}
+		if resourceTelemetry {
+			if !r.resourceTelemetryDone {
+				r.resourceAfterRun = captureResourceTelemetry()
+				r.resourceTelemetryDone = true
+			}
+			fmt.Println(r.resourceBeforeRun.DiffSummary(r.resourceAfterRun))
+		}
+		if r.processStats != nil && r.processStats.SampleCount() > 0 {
+			fmt.Println(r.processStats.Summary())
+		}
+	}
+
 	return nil
 }
 
-// runTest takes care of the semantics of running a single iteration.
-// It changes configuration on the proxy, increments counters, and
-// updates the running-time.
-func (r *perfRunner) runTest(p PerfTest, index int, id string) {
-	defer wg.Done()
-	if debug {
-		log.Printf("number of proxies %d", len(r.proxyTransports))
-	}
-
-	r.allOptions.mu.Lock()
-	opts := r.allOptions.opts[index]
-	r.allOptions.mu.Unlock()
-
-	// If we are using the test proxy need to set up the in-memory recording.
-	if testProxyURLs != "" {
-		// First request goes through in Live mode
-		r.proxyTransports[id].SetMode("live")
-		err := p.Run(context.Background())
-		if err != nil {
-			panic(err)
-		}
-
-		// 2nd request goes through in Record mode
-		r.proxyTransports[id].SetMode("record")
-		err = r.proxyTransports[id].start()
-		if err != nil {
-			panic(err)
-
-		}
-
-		err = p.Run(context.Background())
-		if err != nil {
-			panic(err)
-		}
-		err = r.proxyTransports[id].stop()
-		if err != nil {
-			panic(err)
-		}
-
-		// All ensuing requests go through in Playback mode
-		r.proxyTransports[id].SetMode("playback")
-		err = r.proxyTransports[id].start()
-		if err != nil {
-			panic(err)
-		}
-	}
-
-	// true parameter indicates were running the warmup here
-	err := r.runTestForDuration(p, opts, true)
-	if err != nil {
-		panic(err)
-	}
-
-	// increment the warmupFinished counter that one goroutine has finished warmup
-	val := atomic.AddInt32(&r.warmupFinished, 1)
-	if debug {
-		fmt.Printf("finished %d warmups\n", val)
-	}
-
-	// run the actual test
-	err = r.runTestForDuration(p, opts, false)
-	if err != nil {
-		panic(err)
-	}
-
-	if testProxyURLs != "" {
-		// Stop the proxy now
-		if err := proxyTransportsSuite[id].stop(); err != nil {
-			panic(err)
-		}
-		proxyTransportsSuite[id].SetMode("live")
-	}
-	opts.finished = true
-}
-
-func (r *perfRunner) runTestForDuration(p PerfTest, opts *PerfTestOptions, warmup bool) error {
+// runTestForDuration runs a single warmup or measurement pass for one worker
+// for the configured duration. When rateCh is non-nil each iteration waits to
+// receive a token from it before invoking p.Run, throttling the aggregate
+// throughput to the value of --rate.
+func (r *perfRunner) runTestForDuration(p PerfTest, opts *PerfTestOptions, warmup bool, rateCh <-chan struct{}) error {
 	if warmup && warmUpDuration <= 0 {
 		return nil
 	}
@@ -425,7 +632,19 @@ func (r *perfRunner) runTestForDuration(p PerfTest, opts *PerfTestOptions, warmu
 
 	lastSavedTime := time.Now()
 	for time.Since(*startPtr).Seconds() < float64(runDuration) {
+		if rateCh != nil {
+			select {
+			case _, ok := <-rateCh:
+				if !ok {
+					return nil
+				}
+			case <-ctx.Done():
+				return nil
+			}
+		}
+		operationStart := time.Now()
 		err := p.Run(ctx)
+		operationDuration := time.Since(operationStart)
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
 				break
@@ -435,23 +654,150 @@ func (r *perfRunner) runTestForDuration(p PerfTest, opts *PerfTestOptions, warmu
 		}
 		opts.increment(warmup)
 
+		if !warmup {
+			r.latencyCollector.Add(operationDuration)
+			r.callTypeCollector.Add("operation", operationDuration)
+			if resultsFilePath != "" && enableOperationLatency {
+				r.operationResults.Add(r.name, operationDuration, 0)
+			}
+		}
+
 		if time.Since(lastSavedTime).Seconds() > 0.3 {
-			duration := time.Since(*startPtr)
+			elapsed := time.Since(*startPtr)
 			if warmup {
-				atomic.StoreInt64((*int64)(&opts.warmupElapsed), int64(duration))
+				atomic.StoreInt64((*int64)(&opts.warmupElapsed), int64(elapsed))
 			} else {
-				atomic.StoreInt64((*int64)(&opts.runElapsed), int64(duration))
+				atomic.StoreInt64((*int64)(&opts.runElapsed), int64(elapsed))
 			}
 			lastSavedTime = time.Now()
 		}
 	}
 
-	duration := time.Since(*startPtr)
+	elapsed := time.Since(*startPtr)
 	if warmup {
-		atomic.StoreInt64((*int64)(&opts.warmupElapsed), int64(duration))
+		atomic.StoreInt64((*int64)(&opts.warmupElapsed), int64(elapsed))
 	} else {
-		atomic.StoreInt64((*int64)(&opts.runElapsed), int64(duration))
+		atomic.StoreInt64((*int64)(&opts.runElapsed), int64(elapsed))
 	}
 
+	opts.finished = true
 	return nil
+}
+
+func (r *perfRunner) writeArtifacts() error {
+	if outputFilePrefix == "" {
+		return nil
+	}
+
+	totalOperations := r.totalOperations(false)
+	opsPerSecond := r.opsPerSecond(false)
+
+	latencySummary := ""
+	callTypeSummary := ""
+	resourceSummary := ""
+
+	if enableOperationLatency {
+		latencySummary = r.latencyCollector.Summary()
+		callTypeSummary = r.callTypeCollector.Summary()
+	}
+	if resourceTelemetry {
+		if !r.resourceTelemetryDone {
+			r.resourceAfterRun = captureResourceTelemetry()
+			r.resourceTelemetryDone = true
+		}
+		resourceSummary = r.resourceBeforeRun.DiffSummary(r.resourceAfterRun)
+	}
+
+	avgCPU := -1.0
+	avgMem := int64(-1)
+	processStatsSummary := ""
+	if r.processStats != nil && r.processStats.SampleCount() > 0 {
+		avgCPU = r.processStats.AverageCPU()
+		avgMem = r.processStats.AverageMemory()
+		processStatsSummary = r.processStats.Summary()
+	}
+
+	summary := newRunSummary(r.name, totalOperations, opsPerSecond, latencySummary, callTypeSummary, resourceSummary)
+	summary.AverageCPUPercent = avgCPU
+	summary.AverageMemoryBytes = avgMem
+	summary.ProcessStatsSummary = processStatsSummary
+	if err := writeRunArtifacts(outputFilePrefix, summary); err != nil {
+		return err
+	}
+
+	fmt.Printf("Wrote result artifacts: %s.json/.csv/.txt/.md\n", outputFilePrefix)
+	return nil
+}
+
+// printJobStatistics writes the `#StartJobStatistics` / `#EndJobStatistics`
+// block consumed by perf-automation. The JSON shape mirrors the .NET
+// runner's BenchmarkOutput payload (Source, Name, ShortDescription,
+// LongDescription, Format, Measurements[]) so a single parser can read
+// throughput from either language's stdout.
+func printJobStatistics(opsPerSecond float64) {
+	type metadata struct {
+		Source           string `json:"Source"`
+		Name             string `json:"Name"`
+		ShortDescription string `json:"ShortDescription"`
+		LongDescription  string `json:"LongDescription"`
+		Format           string `json:"Format"`
+	}
+	type measurement struct {
+		Timestamp string  `json:"Timestamp"`
+		Name      string  `json:"Name"`
+		Value     float64 `json:"Value"`
+	}
+	type output struct {
+		Metadata     []metadata    `json:"Metadata"`
+		Measurements []measurement `json:"Measurements"`
+	}
+	out := output{
+		Metadata: []metadata{{
+			Source:           "PerfStress",
+			Name:             "perfstress/throughput",
+			ShortDescription: "Throughput (ops/sec)",
+			LongDescription:  "Throughput (ops/sec)",
+			Format:           "n2",
+		}},
+		Measurements: []measurement{{
+			Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+			Name:      "perfstress/throughput",
+			Value:     opsPerSecond,
+		}},
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		return
+	}
+	fmt.Println("#StartJobStatistics")
+	fmt.Println(string(b))
+	fmt.Println("#EndJobStatistics")
+}
+
+// lastProcessSample returns the most recent CPU% and memory-in-bytes from the
+// process-stats sampler, or sentinel values when the sampler is disabled or
+// has not yet produced a sample.
+func (r *perfRunner) lastProcessSample() (float64, uint64) {
+	if r.processStats == nil {
+		return -1, 0
+	}
+	return r.processStats.LastSample()
+}
+
+// formatCPUColumn renders the CPU% column for the status line. A negative
+// value (no sample yet) is displayed as "n/a".
+func formatCPUColumn(cpuPercent float64) string {
+	if cpuPercent < 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.2f%%", cpuPercent)
+}
+
+// formatMemoryColumn renders the Memory(MiB) column for the status line.
+// Zero bytes (no sample yet) is displayed as "n/a".
+func formatMemoryColumn(memoryBytes uint64) string {
+	if memoryBytes == 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.2f", float64(memoryBytes)/(1024*1024))
 }

--- a/sdk/internal/perf/process_stats.go
+++ b/sdk/internal/perf/process_stats.go
@@ -1,0 +1,218 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package perf
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/metrics"
+	"sync"
+	"time"
+)
+
+const (
+	// cpuTotalMetric is the cumulative CPU budget for the Go runtime, i.e.
+	// GOMAXPROCS * wallTime. It INCLUDES /cpu/classes/idle (time the scheduler
+	// had a P available but no goroutine was runnable), so it must not be used
+	// directly to compute CPU utilization. We subtract cpuIdleMetric from it to
+	// obtain CPU-seconds actually consumed by user code, the GC, and the
+	// scavenger.
+	cpuTotalMetric    = "/cpu/classes/total:cpu-seconds"
+	cpuIdleMetric     = "/cpu/classes/idle:cpu-seconds"
+	memoryTotalMetric = "/memory/classes/total:bytes"
+)
+
+// processStatsSampler periodically samples the process CPU usage (in percent of all
+// available cores) and total memory obtained from the OS. It is intended to mirror
+// the CPU/memory tracking added to the .NET/Python perf-automation runners.
+type processStatsSampler struct {
+	interval      time.Duration
+	done          chan struct{}
+	wg            sync.WaitGroup
+	mu            sync.Mutex
+	cpuSamples    []float64
+	memorySamples []uint64
+	started       bool
+}
+
+func newProcessStatsSampler(interval time.Duration) *processStatsSampler {
+	return &processStatsSampler{
+		interval: interval,
+		done:     make(chan struct{}),
+	}
+}
+
+// Start begins periodic sampling in a background goroutine.
+func (s *processStatsSampler) Start() {
+	if s.started {
+		return
+	}
+	s.started = true
+	s.wg.Add(1)
+	go s.run()
+}
+
+// Stop halts sampling and waits for the sampler goroutine to exit. Safe to call
+// multiple times.
+func (s *processStatsSampler) Stop() {
+	if !s.started {
+		return
+	}
+	select {
+	case <-s.done:
+		// already stopped
+		return
+	default:
+		close(s.done)
+	}
+	s.wg.Wait()
+}
+
+func (s *processStatsSampler) run() {
+	defer s.wg.Done()
+
+	samples := []metrics.Sample{
+		{Name: cpuTotalMetric},
+		{Name: cpuIdleMetric},
+		{Name: memoryTotalMetric},
+	}
+	metrics.Read(samples)
+	lastCPU, cpuOK := readBusyCPUSeconds(samples[0], samples[1])
+	lastTime := time.Now()
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.done:
+			return
+		case now := <-ticker.C:
+			metrics.Read(samples)
+			cpu, ok := readBusyCPUSeconds(samples[0], samples[1])
+			mem, memOK := readMemoryBytes(samples[2])
+			elapsed := now.Sub(lastTime).Seconds()
+			if cpuOK && ok && elapsed > 0 {
+				cpuPct := (cpu - lastCPU) / (elapsed * float64(runtime.NumCPU())) * 100.0
+				s.mu.Lock()
+				s.cpuSamples = append(s.cpuSamples, cpuPct)
+				s.mu.Unlock()
+			}
+			if memOK {
+				s.mu.Lock()
+				s.memorySamples = append(s.memorySamples, mem)
+				s.mu.Unlock()
+			}
+			lastCPU, cpuOK = cpu, ok
+			lastTime = now
+		}
+	}
+}
+
+// AverageCPU returns the average sampled CPU percent across all available cores,
+// or -1 if no samples were collected.
+func (s *processStatsSampler) AverageCPU() float64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.cpuSamples) == 0 {
+		return -1
+	}
+	var sum float64
+	for _, v := range s.cpuSamples {
+		sum += v
+	}
+	return sum / float64(len(s.cpuSamples))
+}
+
+// AverageMemory returns the average sampled memory in bytes, or -1 if no samples
+// were collected.
+func (s *processStatsSampler) AverageMemory() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.memorySamples) == 0 {
+		return -1
+	}
+	var sum uint64
+	for _, v := range s.memorySamples {
+		sum += v
+	}
+	return int64(sum / uint64(len(s.memorySamples)))
+}
+
+// SampleCount returns the number of samples collected so far.
+func (s *processStatsSampler) SampleCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.cpuSamples)
+}
+
+// LastSample returns the most recently observed CPU% and memory in bytes
+// suitable for emitting on the live status line. Returns (-1, 0) when no
+// samples have been collected yet.
+func (s *processStatsSampler) LastSample() (cpuPercent float64, memoryBytes uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.cpuSamples) == 0 {
+		return -1, 0
+	}
+	cpuPercent = s.cpuSamples[len(s.cpuSamples)-1]
+	if len(s.memorySamples) > 0 {
+		memoryBytes = s.memorySamples[len(s.memorySamples)-1]
+	}
+	return cpuPercent, memoryBytes
+}
+
+// Summary returns a single-line human-readable summary of the collected stats.
+func (s *processStatsSampler) Summary() string {
+	cpu := s.AverageCPU()
+	mem := s.AverageMemory()
+	memMiB := -1.0
+	if mem >= 0 {
+		memMiB = float64(mem) / (1024.0 * 1024.0)
+	}
+	return fmt.Sprintf(
+		"Process stats: averageCpu=%.2f%% averageMemory(MiB)=%.2f samples=%d",
+		cpu, memMiB, s.SampleCount(),
+	)
+}
+
+func readCPUSeconds(s metrics.Sample) (float64, bool) {
+	switch s.Value.Kind() {
+	case metrics.KindFloat64:
+		return s.Value.Float64(), true
+	case metrics.KindUint64:
+		return float64(s.Value.Uint64()), true
+	}
+	return 0, false
+}
+
+// readBusyCPUSeconds returns total - idle, i.e. the CPU-seconds actually
+// consumed by Go code (user goroutines + GC + scavenger), excluding the
+// scheduler-idle time that /cpu/classes/total includes. This matches what
+// the .NET runner reports via Process.TotalProcessorTime, which counts only
+// busy CPU time.
+func readBusyCPUSeconds(total, idle metrics.Sample) (float64, bool) {
+	totalSec, ok := readCPUSeconds(total)
+	if !ok {
+		return 0, false
+	}
+	idleSec, ok := readCPUSeconds(idle)
+	if !ok {
+		// If the idle class isn't available on this Go version, fall back to
+		// the total so the metric at least remains monotonic (even though the
+		// resulting percentage will be inflated).
+		return totalSec, true
+	}
+	return totalSec - idleSec, true
+}
+
+func readMemoryBytes(s metrics.Sample) (uint64, bool) {
+	switch s.Value.Kind() {
+	case metrics.KindUint64:
+		return s.Value.Uint64(), true
+	case metrics.KindFloat64:
+		return uint64(s.Value.Float64()), true
+	}
+	return 0, false
+}

--- a/sdk/internal/perf/resource_telemetry.go
+++ b/sdk/internal/perf/resource_telemetry.go
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package perf
+
+import (
+	"fmt"
+	"runtime"
+)
+
+type resourceTelemetrySnapshot struct {
+	allocMiB      float64
+	totalAllocMiB float64
+	sysMiB        float64
+	numGC         uint32
+	goroutines    int
+}
+
+func captureResourceTelemetry() resourceTelemetrySnapshot {
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	return resourceTelemetrySnapshot{
+		allocMiB:      bytesToMiB(mem.Alloc),
+		totalAllocMiB: bytesToMiB(mem.TotalAlloc),
+		sysMiB:        bytesToMiB(mem.Sys),
+		numGC:         mem.NumGC,
+		goroutines:    runtime.NumGoroutine(),
+	}
+}
+
+func (s resourceTelemetrySnapshot) DiffSummary(after resourceTelemetrySnapshot) string {
+	return fmt.Sprintf(
+		"Resource telemetry: alloc(MiB)=%.2f totalAlloc(MiB)=%.2f sys(MiB)=%.2f gc=%d goroutines=%d",
+		after.allocMiB-s.allocMiB,
+		after.totalAllocMiB-s.totalAllocMiB,
+		after.sysMiB-s.sysMiB,
+		after.numGC-s.numGC,
+		after.goroutines,
+	)
+}
+
+func bytesToMiB(v uint64) float64 {
+	return float64(v) / (1024.0 * 1024.0)
+}

--- a/sdk/internal/perf/result_output.go
+++ b/sdk/internal/perf/result_output.go
@@ -1,0 +1,219 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package perf
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+type runSummary struct {
+	TestName         string  `json:"testName"`
+	DurationSeconds  int     `json:"durationSeconds"`
+	WarmupSeconds    int     `json:"warmupSeconds"`
+	Parallel         int     `json:"parallel"`
+	TotalOperations  int64   `json:"totalOperations"`
+	OpsPerSecond     float64 `json:"opsPerSecond"`
+	SecondsPerOp     float64 `json:"secondsPerOp"`
+	WeightedAvgSec   float64 `json:"weightedAverageSeconds"`
+	TimestampUTC     string  `json:"timestampUtc"`
+	LatencySummary   string  `json:"latencySummary,omitempty"`
+	CallTypeSummary  string  `json:"callTypeSummary,omitempty"`
+	ResourceSummary  string  `json:"resourceSummary,omitempty"`
+	WorkloadConfig   string  `json:"workloadConfig,omitempty"`
+	SelectedWorkload string  `json:"selectedWorkload,omitempty"`
+
+	AverageCPUPercent   float64 `json:"averageCpuPercent"`
+	AverageMemoryBytes  int64   `json:"averageMemoryBytes"`
+	ProcessStatsSummary string  `json:"processStatsSummary,omitempty"`
+}
+
+func writeRunArtifacts(prefix string, summary runSummary) error {
+	if prefix == "" {
+		return nil
+	}
+
+	if err := writeJSON(prefix+".json", summary); err != nil {
+		return err
+	}
+	if err := writeCSV(prefix+".csv", summary); err != nil {
+		return err
+	}
+	if err := writeText(prefix+".txt", summary); err != nil {
+		return err
+	}
+	if err := writeMarkdown(prefix+".md", summary); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func writeJSON(path string, summary runSummary) error {
+	b, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON artifact: %w", err)
+	}
+	return os.WriteFile(path, b, 0o600)
+}
+
+func writeCSV(path string, summary runSummary) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create CSV artifact %s: %w", path, err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	w := csv.NewWriter(f)
+	rows := [][]string{
+		{"testName", summary.TestName},
+		{"durationSeconds", fmt.Sprintf("%d", summary.DurationSeconds)},
+		{"warmupSeconds", fmt.Sprintf("%d", summary.WarmupSeconds)},
+		{"parallel", fmt.Sprintf("%d", summary.Parallel)},
+		{"totalOperations", fmt.Sprintf("%d", summary.TotalOperations)},
+		{"opsPerSecond", fmt.Sprintf("%.6f", summary.OpsPerSecond)},
+		{"secondsPerOp", fmt.Sprintf("%.6f", summary.SecondsPerOp)},
+		{"weightedAverageSeconds", fmt.Sprintf("%.6f", summary.WeightedAvgSec)},
+		{"timestampUtc", summary.TimestampUTC},
+		{"latencySummary", summary.LatencySummary},
+		{"callTypeSummary", summary.CallTypeSummary},
+		{"resourceSummary", summary.ResourceSummary},
+		{"workloadConfig", summary.WorkloadConfig},
+		{"selectedWorkload", summary.SelectedWorkload},
+		{"averageCpuPercent", fmt.Sprintf("%.6f", summary.AverageCPUPercent)},
+		{"averageMemoryBytes", fmt.Sprintf("%d", summary.AverageMemoryBytes)},
+		{"processStatsSummary", summary.ProcessStatsSummary},
+	}
+	for _, row := range rows {
+		if err = w.Write(row); err != nil {
+			return fmt.Errorf("failed writing CSV artifact %s: %w", path, err)
+		}
+	}
+	w.Flush()
+	if err = w.Error(); err != nil {
+		return fmt.Errorf("failed flushing CSV artifact %s: %w", path, err)
+	}
+	return nil
+}
+
+func writeText(path string, summary runSummary) error {
+	content := renderText(summary)
+	return os.WriteFile(path, []byte(content), 0o600)
+}
+
+func writeMarkdown(path string, summary runSummary) error {
+	content := renderMarkdown(summary)
+	return os.WriteFile(path, []byte(content), 0o600)
+}
+
+func renderText(summary runSummary) string {
+	lines := []string{
+		fmt.Sprintf("Test: %s", summary.TestName),
+		fmt.Sprintf("Duration(s): %d", summary.DurationSeconds),
+		fmt.Sprintf("Warmup(s): %d", summary.WarmupSeconds),
+		fmt.Sprintf("Parallel: %d", summary.Parallel),
+		fmt.Sprintf("TotalOperations: %d", summary.TotalOperations),
+		fmt.Sprintf("OpsPerSecond: %.6f", summary.OpsPerSecond),
+		fmt.Sprintf("SecondsPerOp: %.6f", summary.SecondsPerOp),
+		fmt.Sprintf("WeightedAverageSeconds: %.6f", summary.WeightedAvgSec),
+		fmt.Sprintf("TimestampUTC: %s", summary.TimestampUTC),
+	}
+	if summary.LatencySummary != "" {
+		lines = append(lines, summary.LatencySummary)
+	}
+	if summary.CallTypeSummary != "" {
+		lines = append(lines, summary.CallTypeSummary)
+	}
+	if summary.ResourceSummary != "" {
+		lines = append(lines, summary.ResourceSummary)
+	}
+	if summary.WorkloadConfig != "" {
+		lines = append(lines, fmt.Sprintf("WorkloadConfig: %s", summary.WorkloadConfig))
+	}
+	if summary.SelectedWorkload != "" {
+		lines = append(lines, fmt.Sprintf("SelectedWorkload: %s", summary.SelectedWorkload))
+	}
+	lines = append(lines,
+		fmt.Sprintf("AverageCpuPercent: %.2f", summary.AverageCPUPercent),
+		fmt.Sprintf("AverageMemoryBytes: %d", summary.AverageMemoryBytes),
+	)
+	if summary.ProcessStatsSummary != "" {
+		lines = append(lines, summary.ProcessStatsSummary)
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func renderMarkdown(summary runSummary) string {
+	lines := []string{
+		"# Perf Run Summary",
+		"",
+		"| Field | Value |",
+		"| --- | --- |",
+		fmt.Sprintf("| Test | %s |", summary.TestName),
+		fmt.Sprintf("| Duration (s) | %d |", summary.DurationSeconds),
+		fmt.Sprintf("| Warmup (s) | %d |", summary.WarmupSeconds),
+		fmt.Sprintf("| Parallel | %d |", summary.Parallel),
+		fmt.Sprintf("| Total Operations | %d |", summary.TotalOperations),
+		fmt.Sprintf("| Ops/s | %.6f |", summary.OpsPerSecond),
+		fmt.Sprintf("| Seconds/op | %.6f |", summary.SecondsPerOp),
+		fmt.Sprintf("| Weighted Avg (s) | %.6f |", summary.WeightedAvgSec),
+		fmt.Sprintf("| Timestamp (UTC) | %s |", summary.TimestampUTC),
+		fmt.Sprintf("| Average CPU (%%) | %.2f |", summary.AverageCPUPercent),
+		fmt.Sprintf("| Average Memory (bytes) | %d |", summary.AverageMemoryBytes),
+	}
+	if summary.WorkloadConfig != "" {
+		lines = append(lines, fmt.Sprintf("| Workload Config | %s |", summary.WorkloadConfig))
+	}
+	if summary.SelectedWorkload != "" {
+		lines = append(lines, fmt.Sprintf("| Selected Workload | %s |", summary.SelectedWorkload))
+	}
+	if summary.LatencySummary != "" {
+		lines = append(lines, "", "## Latency", "", summary.LatencySummary)
+	}
+	if summary.CallTypeSummary != "" {
+		lines = append(lines, "", "## By Call Type", "", summary.CallTypeSummary)
+	}
+	if summary.ResourceSummary != "" {
+		lines = append(lines, "", "## Resource Telemetry", "", summary.ResourceSummary)
+	}
+	if summary.ProcessStatsSummary != "" {
+		lines = append(lines, "", "## Process Stats", "", summary.ProcessStatsSummary)
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func newRunSummary(testName string, totalOperations int64, opsPerSecond float64, latencySummary string, callTypeSummary string, resourceSummary string) runSummary {
+	secondsPerOp := 0.0
+	weightedAvg := 0.0
+	if opsPerSecond > 0 {
+		secondsPerOp = 1.0 / opsPerSecond
+		weightedAvg = float64(totalOperations) / opsPerSecond
+	}
+
+	return runSummary{
+		TestName:         testName,
+		DurationSeconds:  duration,
+		WarmupSeconds:    warmUpDuration,
+		Parallel:         parallelInstances,
+		TotalOperations:  totalOperations,
+		OpsPerSecond:     opsPerSecond,
+		SecondsPerOp:     secondsPerOp,
+		WeightedAvgSec:   weightedAvg,
+		TimestampUTC:     time.Now().UTC().Format(time.RFC3339),
+		LatencySummary:   latencySummary,
+		CallTypeSummary:  callTypeSummary,
+		ResourceSummary:  resourceSummary,
+		WorkloadConfig:   workloadConfigPath,
+		SelectedWorkload: workloadName,
+
+		AverageCPUPercent:  -1,
+		AverageMemoryBytes: -1,
+	}
+}

--- a/sdk/internal/perf/versions.go
+++ b/sdk/internal/perf/versions.go
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package perf
+
+import (
+	"fmt"
+	"runtime"
+	debugpkg "runtime/debug"
+	"sort"
+	"strings"
+)
+
+// printVersions writes a "=== Versions ===" block to stdout that lists the Go
+// runtime version and the versions of every Azure SDK module compiled into the
+// running perf binary. The format mirrors what perf-automation's other
+// language adapters (e.g. Net.cs) parse from stdout to populate the
+// IterationResult.PackageVersions dictionary:
+//
+//	=== Versions ===
+//	go:                          1.22.3
+//	github.com/Azure/azure-sdk-for-go/sdk/azcore:        Informational: v1.14.0
+//	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob: Informational: v1.4.0
+//
+// The "Informational:" prefix matches the .NET adapter's
+// `Informational: (\S*)` capture group so a future Go.cs adapter that
+// reuses the .NET parsing pattern works without modification.
+func printVersions() {
+	fmt.Println("\n=== Versions ===")
+	fmt.Printf("go:                          Informational: %s\n", runtime.Version())
+
+	info, ok := debugpkg.ReadBuildInfo()
+	if !ok {
+		return
+	}
+
+	type modVersion struct {
+		path    string
+		version string
+	}
+	var mods []modVersion
+	seen := map[string]struct{}{}
+	add := func(path, version string) {
+		if path == "" || version == "" {
+			return
+		}
+		if _, dup := seen[path]; dup {
+			return
+		}
+		seen[path] = struct{}{}
+		mods = append(mods, modVersion{path: path, version: version})
+	}
+
+	if info.Main.Path != "" {
+		add(info.Main.Path, info.Main.Version)
+	}
+	for _, dep := range info.Deps {
+		if dep == nil {
+			continue
+		}
+		// Prefer the resolved version when a replace directive is in effect.
+		path := dep.Path
+		version := dep.Version
+		if dep.Replace != nil && dep.Replace.Version != "" {
+			version = dep.Replace.Version
+		}
+		// Only emit Azure SDK and golang.org/x modules to keep the block
+		// focused on shipping packages relevant to perf comparison.
+		if !strings.HasPrefix(path, "github.com/Azure/") &&
+			!strings.HasPrefix(path, "golang.org/x/") {
+			continue
+		}
+		add(path, version)
+	}
+
+	sort.Slice(mods, func(i, j int) bool { return mods[i].path < mods[j].path })
+	for _, m := range mods {
+		fmt.Printf("%s: Informational: %s\n", m.path, m.version)
+	}
+}

--- a/sdk/internal/perf/workload_config.go
+++ b/sdk/internal/perf/workload_config.go
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package perf
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type runInvocation struct {
+	TestName    string
+	CLIArgs     []string
+	ConfigArgs  []string
+	ConfigPath  string
+	Workload    string
+	UsesConfig  bool
+	HasTestName bool
+}
+
+type workloadFile struct {
+	DefaultWorkload string                      `json:"defaultWorkload"`
+	Workloads       map[string]workloadSettings `json:"workloads"`
+}
+
+type workloadSettings struct {
+	Test       string         `json:"test"`
+	Parameters map[string]any `json:"parameters"`
+	Args       []string       `json:"args"`
+}
+
+func resolveRunInvocation(args []string) (runInvocation, error) {
+	invocation := runInvocation{}
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		switch {
+		case arg == "--config":
+			if i+1 >= len(args) {
+				return runInvocation{}, fmt.Errorf("missing value for --config")
+			}
+			invocation.ConfigPath = args[i+1]
+			i++
+			continue
+		case strings.HasPrefix(arg, "--config="):
+			invocation.ConfigPath = strings.TrimPrefix(arg, "--config=")
+			continue
+		case arg == "--workload":
+			if i+1 >= len(args) {
+				return runInvocation{}, fmt.Errorf("missing value for --workload")
+			}
+			invocation.Workload = args[i+1]
+			i++
+			continue
+		case strings.HasPrefix(arg, "--workload="):
+			invocation.Workload = strings.TrimPrefix(arg, "--workload=")
+			continue
+		}
+
+		if i == 0 && !strings.HasPrefix(arg, "-") {
+			invocation.TestName = arg
+			invocation.HasTestName = true
+			continue
+		}
+
+		invocation.CLIArgs = append(invocation.CLIArgs, arg)
+	}
+
+	if invocation.ConfigPath == "" {
+		return invocation, nil
+	}
+
+	invocation.UsesConfig = true
+	cfg, err := loadWorkloadFile(invocation.ConfigPath)
+	if err != nil {
+		return runInvocation{}, err
+	}
+
+	workloadName := invocation.Workload
+	if workloadName == "" {
+		workloadName = cfg.DefaultWorkload
+	}
+	if workloadName == "" {
+		return runInvocation{}, fmt.Errorf("no workload specified. provide --workload or set defaultWorkload in %s", invocation.ConfigPath)
+	}
+
+	workload, ok := cfg.Workloads[workloadName]
+	if !ok {
+		return runInvocation{}, fmt.Errorf("workload %q not found in %s", workloadName, invocation.ConfigPath)
+	}
+
+	if invocation.TestName == "" {
+		invocation.TestName = workload.Test
+	}
+	if invocation.TestName == "" {
+		return runInvocation{}, fmt.Errorf("workload %q in %s is missing test", workloadName, invocation.ConfigPath)
+	}
+
+	invocation.Workload = workloadName
+	invocation.ConfigArgs = workloadToArgs(workload)
+	return invocation, nil
+}
+
+func loadWorkloadFile(path string) (workloadFile, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return workloadFile{}, fmt.Errorf("failed to read config file %s: %w", path, err)
+	}
+
+	dec := json.NewDecoder(strings.NewReader(string(b)))
+	dec.UseNumber()
+
+	var cfg workloadFile
+	if err = dec.Decode(&cfg); err != nil {
+		return workloadFile{}, fmt.Errorf("failed to parse config file %s: %w", path, err)
+	}
+
+	return cfg, nil
+}
+
+func workloadToArgs(workload workloadSettings) []string {
+	args := append([]string{}, workload.Args...)
+
+	if len(workload.Parameters) == 0 {
+		return args
+	}
+
+	keys := make([]string, 0, len(workload.Parameters))
+	for k := range workload.Parameters {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		value := parameterValueToString(workload.Parameters[key])
+		if value == "" {
+			continue
+		}
+		args = append(args, fmt.Sprintf("--%s=%s", key, value))
+	}
+
+	return args
+}
+
+func parameterValueToString(v any) string {
+	switch tv := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return tv
+	case bool:
+		return strconv.FormatBool(tv)
+	case json.Number:
+		return tv.String()
+	case float64:
+		if tv == float64(int64(tv)) {
+			return strconv.FormatInt(int64(tv), 10)
+		}
+		return strconv.FormatFloat(tv, 'f', -1, 64)
+	default:
+		return fmt.Sprintf("%v", tv)
+	}
+}

--- a/sdk/internal/perf/workload_config_test.go
+++ b/sdk/internal/perf/workload_config_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package perf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveRunInvocationFromConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "workloads.json")
+
+	err := os.WriteFile(configPath, []byte(`{
+		"defaultWorkload": "wl-upload",
+		"workloads": {
+			"wl-upload": {
+				"test": "UploadBlobTest",
+				"parameters": {
+					"duration": 5,
+					"warmup": 2,
+					"debug": true
+				}
+			}
+		}
+	}`), 0o600)
+	require.NoError(t, err)
+
+	invocation, err := resolveRunInvocation([]string{"--config", configPath})
+	require.NoError(t, err)
+	require.Equal(t, "UploadBlobTest", invocation.TestName)
+	require.Equal(t, "wl-upload", invocation.Workload)
+	require.True(t, invocation.UsesConfig)
+	require.Contains(t, invocation.ConfigArgs, "--duration=5")
+	require.Contains(t, invocation.ConfigArgs, "--warmup=2")
+	require.Contains(t, invocation.ConfigArgs, "--debug=true")
+}
+
+func TestResolveRunInvocationCLITakesPrecedence(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "workloads.json")
+
+	err := os.WriteFile(configPath, []byte(`{
+		"defaultWorkload": "wl-upload",
+		"workloads": {
+			"wl-upload": {
+				"test": "UploadBlobTest",
+				"parameters": {
+					"duration": 5
+				}
+			}
+		}
+	}`), 0o600)
+	require.NoError(t, err)
+
+	invocation, err := resolveRunInvocation([]string{"--config", configPath, "--duration", "9"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"--duration", "9"}, invocation.CLIArgs)
+	invocationArgs := append([]string{}, invocation.ConfigArgs...)
+	invocationArgs = append(invocationArgs, invocation.CLIArgs...)
+	require.Contains(t, invocationArgs, "--duration=5")
+	require.Contains(t, invocationArgs, "--duration")
+	require.Contains(t, invocationArgs, "9")
+}

--- a/sdk/storage/azblob/testdata/perf/download_blob.go
+++ b/sdk/storage/azblob/testdata/perf/download_blob.go
@@ -4,15 +4,16 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/perf"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 )
@@ -32,14 +33,18 @@ type downloadTestGlobal struct {
 	perf.PerfTestOptions
 	containerName string
 	blobName      string
+	size          int
 }
 
 // NewDownloadTest is called once per process
 func NewDownloadTest(ctx context.Context, options perf.PerfTestOptions) (perf.GlobalPerfTest, error) {
 	d := &downloadTestGlobal{
 		PerfTestOptions: options,
-		containerName:   "downloadcontainer",
-		blobName:        "downloadblob",
+		// Suffix with a unique timestamp so concurrent runs and --no-cleanup
+		// leftovers from prior runs do not collide on container creation.
+		containerName: fmt.Sprintf("downloadcontainer-%d", time.Now().UnixNano()),
+		blobName:      "downloadblob",
+		size:          downloadTestOpts.size,
 	}
 
 	connStr, ok := os.LookupEnv("AZURE_STORAGE_CONNECTION_STRING")
@@ -58,12 +63,23 @@ func NewDownloadTest(ctx context.Context, options perf.PerfTestOptions) (perf.Gl
 
 	blobClient := containerClient.NewBlockBlobClient(d.blobName)
 
-	data, err := perf.NewRandomStream(downloadTestOpts.size)
+	// Seed the test blob without materializing the full payload in RAM. We
+	// stream a randomStream (tiles a 1 MiB random seed up to d.size) through
+	// UploadStream, which internally stages parallel blocks. This keeps the
+	// process memory bounded by the SDK's BlockSize x Concurrency buffer pool
+	// regardless of how large d.size is.
+	seed, err := generateRandomBytes(randomSeedSize)
 	if err != nil {
 		return nil, err
 	}
-
-	_, err = blobClient.Upload(context.Background(), data, nil)
+	_, err = blobClient.UploadStream(
+		context.Background(),
+		newRandomStream(seed, int64(d.size)),
+		&blockblob.UploadStreamOptions{
+			BlockSize:   commonBlockSize,
+			Concurrency: int(commonConcurrency),
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -89,8 +105,11 @@ func (d *downloadTestGlobal) GlobalCleanup(ctx context.Context) error {
 type downloadPerfTest struct {
 	*downloadTestGlobal
 	perf.PerfTestOptions
-	data       io.ReadSeekCloser
-	blobClient *blockblob.Client
+	blobClient *blob.Client
+	// buffer is a per-goroutine, preallocated download target reused across
+	// iterations for the "buffer" download method. Avoids per-iteration
+	// allocation/copy cost in the measurement.
+	buffer []byte
 }
 
 // NewPerfTest is called once per goroutine
@@ -113,26 +132,41 @@ func (g *downloadTestGlobal) NewPerfTest(ctx context.Context, options *perf.Perf
 	if err != nil {
 		return nil, err
 	}
-	d.blobClient = containerClient.NewBlockBlobClient(d.blobName)
+	d.blobClient = containerClient.NewBlockBlobClient(d.blobName).BlobClient()
 
-	data, err := perf.NewRandomStream(downloadTestOpts.size)
-	if err != nil {
-		return nil, err
+	if downloadMethod == "buffer" {
+		// Guard against allocating per-goroutine buffers that won't fit in
+		// available system memory. The total memory cost of the buffer
+		// download method is roughly size * parallel; we apply the same 80%
+		// budget check used by --upload-method=buffer.
+		if err := checkBufferUploadMemoryBudget(int64(g.size)*int64(perf.Parallel()), perf.Parallel()); err != nil {
+			return nil, fmt.Errorf("--download-method buffer: %w", err)
+		}
+		d.buffer = make([]byte, g.size)
 	}
-	d.data = data
 
-	return d, err
+	return d, nil
 }
 
 func (d *downloadPerfTest) Run(ctx context.Context) error {
-	get, err := d.blobClient.DownloadStream(ctx, nil)
-	if err != nil {
+	switch downloadMethod {
+	case "buffer":
+		_, err := d.blobClient.DownloadBuffer(ctx, d.buffer, &blob.DownloadBufferOptions{
+			BlockSize:   commonBlockSize,
+			Concurrency: uint16(commonConcurrency),
+		})
 		return err
+	case "stream", "":
+		get, err := d.blobClient.DownloadStream(ctx, nil)
+		if err != nil {
+			return err
+		}
+		defer get.Body.Close()
+		_, err = io.Copy(io.Discard, get.Body)
+		return err
+	default:
+		return fmt.Errorf("unknown --download-method %q (expected stream|buffer)", downloadMethod)
 	}
-	downloadedData := &bytes.Buffer{}
-	defer get.Body.Close()
-	_, err = downloadedData.ReadFrom(get.Body)
-	return err
 }
 
 func (*downloadPerfTest) Cleanup(ctx context.Context) error {

--- a/sdk/storage/azblob/testdata/perf/download_blob.go
+++ b/sdk/storage/azblob/testdata/perf/download_blob.go
@@ -139,8 +139,8 @@ func (g *downloadTestGlobal) NewPerfTest(ctx context.Context, options *perf.Perf
 		// available system memory. The total memory cost of the buffer
 		// download method is roughly size * parallel; we apply the same 80%
 		// budget check used by --upload-method=buffer.
-		if err := checkBufferUploadMemoryBudget(int64(g.size)*int64(perf.Parallel()), perf.Parallel()); err != nil {
-			return nil, fmt.Errorf("--download-method buffer: %w", err)
+		if err := checkBufferMemoryBudget("--download-method buffer", int64(g.size)*int64(perf.Parallel())); err != nil {
+			return nil, err
 		}
 		d.buffer = make([]byte, g.size)
 	}

--- a/sdk/storage/azblob/testdata/perf/go.mod
+++ b/sdk/storage/azblob/testdata/perf/go.mod
@@ -13,4 +13,6 @@ require (
 	golang.org/x/text v0.36.0 // indirect
 )
 
+replace github.com/Azure/azure-sdk-for-go/sdk/internal => ../../../../internal
+
 replace github.com/Azure/azure-sdk-for-go/sdk/storage/azblob => ../../.

--- a/sdk/storage/azblob/testdata/perf/go.sum
+++ b/sdk/storage/azblob/testdata/perf/go.sum
@@ -2,8 +2,6 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 h1:jHb/wfvRikGdxMXYV3QG/SzU
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1/go.mod h1:pzBXCYn05zvYIrwLgtK8Ap8QcjRg+0i76tMQdWN6wOk=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpzme37xbCDdNTxU7O9eb5+LB4=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1/go.mod h1:IYus9qsFobWIc2YVwe/WPjcnyCkPKtnHAqUYeebc8z0=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1 h1:/Zt+cDPnpC3OVDm/JKLOs7M2DKmLRIIp3XIx9pHHiig=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1/go.mod h1:Ng3urmn6dYe8gnbCMoHHVl5APYz2txho3koEkV2o2HA=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.1 h1:edShSHV3DV90+kt+CMaEXEzR9QF7wFrPJxVGz2blMIU=

--- a/sdk/storage/azblob/testdata/perf/list_blobs.go
+++ b/sdk/storage/azblob/testdata/perf/list_blobs.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/perf"
@@ -21,23 +22,25 @@ type listTestOptions struct {
 
 var listTestOpts = listTestOptions{count: 100}
 
-// uploadTestRegister is called once per process
+// listTestRegister is called once per process
 func listTestRegister() {
-	flag.IntVar(&listTestOpts.count, "num-blobs", 100, "Number of blobs to list.")
+	flag.IntVar(&listTestOpts.count, "num-blobs", 100, "Total number of blobs to create in the container and list during the test.")
 }
 
 type listTestGlobal struct {
 	perf.PerfTestOptions
 	containerName string
-	blobName      string
+	blobPrefix    string
 }
 
 // NewListTest is called once per process
 func NewListTest(ctx context.Context, options perf.PerfTestOptions) (perf.GlobalPerfTest, error) {
 	l := &listTestGlobal{
 		PerfTestOptions: options,
-		containerName:   "listcontainer",
-		blobName:        "listblob",
+		// Suffix with a unique timestamp so concurrent runs and --no-cleanup
+		// leftovers from prior runs do not collide on container creation.
+		containerName: fmt.Sprintf("listcontainer-%d", time.Now().UnixNano()),
+		blobPrefix:    "listblob",
 	}
 	connStr, ok := os.LookupEnv("AZURE_STORAGE_CONNECTION_STRING")
 	if !ok {
@@ -53,14 +56,13 @@ func NewListTest(ctx context.Context, options perf.PerfTestOptions) (perf.Global
 		return nil, err
 	}
 
-	for i := 0; i < 100; i++ {
-		blobClient := containerClient.NewBlockBlobClient(fmt.Sprintf("%s%d", l.blobName, i))
-		_, err = blobClient.Upload(
-			context.Background(),
-			NopCloser(bytes.NewReader([]byte(""))),
-			nil,
-		)
-		if err != nil {
+	// Seed the container with the requested number of empty blobs. The earlier
+	// implementation hard-coded 100 here, which meant matrix entries asking
+	// for thousands of blobs silently listed at most 100.
+	emptyBody := NopCloser(bytes.NewReader(nil))
+	for i := 0; i < listTestOpts.count; i++ {
+		blobClient := containerClient.NewBlockBlobClient(fmt.Sprintf("%s%d", l.blobPrefix, i))
+		if _, err = blobClient.Upload(context.Background(), emptyBody, nil); err != nil {
 			return nil, err
 		}
 	}
@@ -119,13 +121,14 @@ func (g *listTestGlobal) NewPerfTest(ctx context.Context, options *perf.PerfTest
 }
 
 func (m *listPerfTest) Run(ctx context.Context) error {
-	c := int32(listTestOpts.count)
-	pager := m.containerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
-		MaxResults: &c,
-	})
+	opts := &container.ListBlobsFlatOptions{}
+	if listPageSize > 0 {
+		p := int32(listPageSize)
+		opts.MaxResults = &p
+	}
+	pager := m.containerClient.NewListBlobsFlatPager(opts)
 	for pager.More() {
-		_, err := pager.NextPage(context.Background())
-		if err != nil {
+		if _, err := pager.NextPage(ctx); err != nil {
 			return err
 		}
 	}

--- a/sdk/storage/azblob/testdata/perf/perfautomation-tests.yml
+++ b/sdk/storage/azblob/testdata/perf/perfautomation-tests.yml
@@ -1,0 +1,57 @@
+Service: storage-blob
+
+Project: sdk/storage/azblob/testdata/perf
+
+PrimaryPackage: github.com/Azure/azure-sdk-for-go/sdk/storage/azblob
+
+# Each entry below is a column in the comparison table. Pin every Azure
+# SDK module that matters for the comparison so the columns differ only
+# by what you intend to vary.
+PackageVersions:
+  # Published baseline. azblob v1.6.4 transitively requires azcore >= v1.21.0,
+  # so pin azcore to v1.21.0 (Go's MVS will not allow a lower version).
+  - github.com/Azure/azure-sdk-for-go/sdk/storage/azblob: v1.6.4
+    github.com/Azure/azure-sdk-for-go/sdk/azcore: v1.21.0
+  # Current source under test (uses `replace` directives to local checkouts).
+  - github.com/Azure/azure-sdk-for-go/sdk/storage/azblob: source
+    github.com/Azure/azure-sdk-for-go/sdk/azcore: source
+
+Tests:
+  # `Test` is the display name shown in result reports.
+  # `Class` is what perf-automation passes to the runner as the test
+  # name argument — for Go this MUST match a key registered in main.go's
+  # perf.Run(map[string]perf.PerfMethods{ "DownloadBlobTest": {...}, ... }).
+  - Test: Download
+    Class: DownloadBlobTest
+    Arguments:
+      # Small blob, single GET, high goroutine fan-out.
+      - --size 10240 --parallel 64 --latency
+      # Medium blob, single GET.
+      - --size 10485760 --parallel 32 --latency
+      # 1 GiB single-stream baseline.
+      - --size 1073741824 --parallel 1 --warmup 60 --duration 60 --latency
+      - --size 1073741824 --parallel 8 --warmup 60 --duration 60 --latency
+      # 1 GiB parallel-ranged GETs (DownloadBuffer): 8 MiB blocks, 8 concurrent ranges.
+      - --size 1073741824 --parallel 1 --warmup 60 --duration 60 --latency --download-method buffer --block-size 8388608 --concurrency 8
+
+  - Test: Upload
+    Class: UploadBlobTest
+    Arguments:
+      # Small blob, single PUT, high goroutine fan-out.
+      - --size 10240 --parallel 64 --latency
+      # Medium blob, single PUT.
+      - --size 10485760 --parallel 32 --latency
+      # 1 GiB single PUT baseline.
+      - --size 1073741824 --parallel 1 --warmup 60 --duration 60 --latency
+      - --size 1073741824 --parallel 8 --warmup 60 --duration 60 --latency
+      # 1 GiB parallel staged blocks (UploadBuffer): 8 MiB blocks, 8 concurrent stage-blocks.
+      - --size 1073741824 --parallel 1 --warmup 60 --duration 60 --latency --upload-method buffer --block-size 8388608 --concurrency 8
+      # 1 GiB chunked from an io.Reader (UploadStream): 8 MiB blocks, 8 concurrent stage-blocks.
+      - --size 1073741824 --parallel 1 --warmup 60 --duration 60 --latency --upload-method stream --block-size 8388608 --concurrency 8
+
+  - Test: List
+    Class: ListBlobTest
+    Arguments:
+      - --num-blobs 5 --parallel 64 --latency
+      - --num-blobs 500 --parallel 32 --latency --page-size 500
+      - --num-blobs 50000 --parallel 32 --warmup 60 --duration 60 --latency --page-size 5000

--- a/sdk/storage/azblob/testdata/perf/shared.go
+++ b/sdk/storage/azblob/testdata/perf/shared.go
@@ -37,7 +37,13 @@ var (
 
 	// commonConcurrency is the SDK Concurrency (parallel blocks per operation)
 	// for chunked upload/download paths. 0 means "use the SDK default".
-	commonConcurrency uint
+	//
+	// Typed as uint16 because the strictest SDK option that consumes this
+	// value (blockblob.UploadBufferOptions.Concurrency,
+	// blob.DownloadBufferOptions.Concurrency) is uint16. Using uint16 here
+	// rules out silent truncation/overflow at the cast sites and lets the
+	// CLI fail fast (via uint16Flag.Set) for values outside [0, 65535].
+	commonConcurrency uint16
 
 	// uploadMethod selects which upload API the upload test exercises:
 	//   single  -> blockblob.Client.Upload       (single REST PUT; default)
@@ -56,10 +62,31 @@ var (
 
 func init() {
 	flag.Int64Var(&commonBlockSize, "block-size", 0, "Block/chunk size in bytes for chunked upload/download (0=SDK default).")
-	flag.UintVar(&commonConcurrency, "concurrency", 0, "Max number of blocks transferred in parallel per chunked upload/download operation (0=SDK default).")
+	flag.Var((*uint16Flag)(&commonConcurrency), "concurrency", "Max number of blocks transferred in parallel per chunked upload/download operation (0=SDK default; max 65535).")
 	flag.StringVar(&uploadMethod, "upload-method", "single", "Upload method: single|buffer|stream.")
 	flag.StringVar(&downloadMethod, "download-method", "stream", "Download method: stream|buffer.")
 	flag.IntVar(&listPageSize, "page-size", 5000, "MaxResults page size used by list operations.")
+}
+
+// uint16Flag is a flag.Value backed by a uint16 so the CLI rejects values
+// outside [0, 65535] at parse time instead of silently truncating at the
+// SDK option cast site.
+type uint16Flag uint16
+
+func (u *uint16Flag) String() string {
+	if u == nil {
+		return "0"
+	}
+	return strconv.FormatUint(uint64(*u), 10)
+}
+
+func (u *uint16Flag) Set(value string) error {
+	parsed, err := strconv.ParseUint(value, 10, 16)
+	if err != nil {
+		return fmt.Errorf("invalid --concurrency value %q (must be a uint16 in [0, 65535]): %w", value, err)
+	}
+	*u = uint16Flag(parsed)
+	return nil
 }
 
 // generateRandomBytes returns size bytes of random data, suitable for use as an
@@ -175,17 +202,21 @@ func availableSystemMemoryBytes() uint64 {
 	return 0
 }
 
-// checkBufferUploadMemoryBudget returns an error when the user requests an
-// in-memory buffer upload (--upload-method buffer) whose --size would exceed a
+// checkBufferMemoryBudget returns an error when the caller requests an
+// in-memory buffer for upload or download whose total size would exceed a
 // safe fraction (80%) of available system memory. This guards against the
-// runtime OOM that would otherwise abort the process inside
-// generateRandomBytes() before any HTTP request is made.
+// runtime OOM that would otherwise abort the process before any HTTP request
+// is made.
 //
-// parallel is the --parallel value: each parallel goroutine in the upload
-// test shares the same single payload (allocated once in NewUploadTest), so
-// the budget check is independent of parallel for the buffer path. The
-// parameter is accepted for symmetry / future use.
-func checkBufferUploadMemoryBudget(sizeBytes int64, _ int) error {
+// flagLabel is the flag-and-value pair that triggered the check (e.g.
+// "--upload-method buffer" or "--download-method buffer") and is embedded in
+// the error message so the text matches the invoked flag.
+//
+// sizeBytes is the total number of bytes the caller intends to allocate
+// across all goroutines (upload shares one payload across --parallel, so the
+// caller passes the per-payload size; download allocates one buffer per
+// goroutine, so the caller passes size * parallel).
+func checkBufferMemoryBudget(flagLabel string, sizeBytes int64) error {
 	if sizeBytes <= 0 {
 		return nil
 	}
@@ -197,10 +228,10 @@ func checkBufferUploadMemoryBudget(sizeBytes int64, _ int) error {
 	budget := uint64(float64(avail) * safetyFraction)
 	if uint64(sizeBytes) > budget {
 		return fmt.Errorf(
-			"--upload-method buffer requires materializing the full --size in RAM: "+
-				"requested %d bytes (%.2f GiB) exceeds %d%% of available system memory (%d bytes, %.2f GiB available). "+
-				"Use --upload-method stream for large payloads, or reduce --size",
-			sizeBytes, float64(sizeBytes)/(1<<30),
+			"%s requires materializing %d bytes (%.2f GiB) in RAM, "+
+				"which exceeds %d%% of available system memory (%d bytes, %.2f GiB available). "+
+				"Use a streaming method for large payloads, or reduce --size/--parallel",
+			flagLabel, sizeBytes, float64(sizeBytes)/(1<<30),
 			int(safetyFraction*100), avail, float64(avail)/(1<<30),
 		)
 	}

--- a/sdk/storage/azblob/testdata/perf/shared.go
+++ b/sdk/storage/azblob/testdata/perf/shared.go
@@ -4,7 +4,15 @@
 package main
 
 import (
+	"bufio"
+	"crypto/rand"
+	"flag"
+	"fmt"
 	"io"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
 )
 
 type nopCloser struct {
@@ -18,4 +26,183 @@ func (n nopCloser) Close() error {
 // NopCloser returns a ReadSeekCloser with a no-op close method wrapping the provided io.ReadSeeker.
 func NopCloser(rs io.ReadSeeker) io.ReadSeekCloser {
 	return nopCloser{rs}
+}
+
+// Shared CLI flags exposed by every storage perf test. Defaults preserve
+// the historical behavior so existing perf matrices keep working unchanged.
+var (
+	// commonBlockSize is the SDK BlockSize for chunked upload/download paths.
+	// 0 means "use the SDK default".
+	commonBlockSize int64
+
+	// commonConcurrency is the SDK Concurrency (parallel blocks per operation)
+	// for chunked upload/download paths. 0 means "use the SDK default".
+	commonConcurrency uint
+
+	// uploadMethod selects which upload API the upload test exercises:
+	//   single  -> blockblob.Client.Upload       (single REST PUT; default)
+	//   buffer  -> blockblob.Client.UploadBuffer (parallel staged blocks)
+	//   stream  -> blockblob.Client.UploadStream (chunked from io.Reader)
+	uploadMethod string
+
+	// downloadMethod selects which download API the download test exercises:
+	//   stream  -> blob.Client.DownloadStream (single GET; default)
+	//   buffer  -> blob.Client.DownloadBuffer (parallel ranged GETs)
+	downloadMethod string
+
+	// listPageSize is the MaxResults page size used by the list test.
+	listPageSize int
+)
+
+func init() {
+	flag.Int64Var(&commonBlockSize, "block-size", 0, "Block/chunk size in bytes for chunked upload/download (0=SDK default).")
+	flag.UintVar(&commonConcurrency, "concurrency", 0, "Max number of blocks transferred in parallel per chunked upload/download operation (0=SDK default).")
+	flag.StringVar(&uploadMethod, "upload-method", "single", "Upload method: single|buffer|stream.")
+	flag.StringVar(&downloadMethod, "download-method", "stream", "Download method: stream|buffer.")
+	flag.IntVar(&listPageSize, "page-size", 5000, "MaxResults page size used by list operations.")
+}
+
+// generateRandomBytes returns size bytes of random data, suitable for use as an
+// in-memory payload for upload tests.
+func generateRandomBytes(size int) ([]byte, error) {
+	if size < 0 {
+		return nil, fmt.Errorf("invalid size %d", size)
+	}
+	buf := make([]byte, size)
+	if size == 0 {
+		return buf, nil
+	}
+	if _, err := rand.Read(buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// randomSeedSize is the size of the repeating random seed used to back
+// streaming/single-PUT upload payloads. Picked large enough to amortize the
+// per-iteration tiling cost without holding the full --size in RAM.
+const randomSeedSize = 1 << 20 // 1 MiB
+
+// randomStream is an io.ReadSeekCloser that produces `total` bytes by tiling
+// `seed` (a small random buffer) repeatedly. It allows multi-GiB / TiB upload
+// payloads without allocating the full payload in memory and without per-byte
+// crypto/rand calls on the hot path.
+//
+// Safe for use by a single goroutine. Each parallel perf-test goroutine should
+// own its own randomStream so the read offset is goroutine-local.
+type randomStream struct {
+	seed  []byte
+	total int64
+	pos   int64
+}
+
+// newRandomStream returns a randomStream that yields `total` bytes by tiling
+// the provided seed (which must be non-empty).
+func newRandomStream(seed []byte, total int64) *randomStream {
+	return &randomStream{seed: seed, total: total}
+}
+
+func (r *randomStream) Read(p []byte) (int, error) {
+	if r.pos >= r.total {
+		return 0, io.EOF
+	}
+	remaining := r.total - r.pos
+	if int64(len(p)) > remaining {
+		p = p[:remaining]
+	}
+	n := 0
+	for n < len(p) {
+		off := int((r.pos + int64(n)) % int64(len(r.seed)))
+		c := copy(p[n:], r.seed[off:])
+		n += c
+	}
+	r.pos += int64(n)
+	return n, nil
+}
+
+func (r *randomStream) Seek(offset int64, whence int) (int64, error) {
+	var abs int64
+	switch whence {
+	case io.SeekStart:
+		abs = offset
+	case io.SeekCurrent:
+		abs = r.pos + offset
+	case io.SeekEnd:
+		abs = r.total + offset
+	default:
+		return 0, fmt.Errorf("randomStream.Seek: invalid whence %d", whence)
+	}
+	if abs < 0 {
+		return 0, fmt.Errorf("randomStream.Seek: negative position %d", abs)
+	}
+	r.pos = abs
+	return abs, nil
+}
+
+func (r *randomStream) Close() error { return nil }
+
+// availableSystemMemoryBytes returns the amount of physical memory the kernel
+// believes is currently available to user processes, in bytes. Returns 0 if
+// the value can't be determined (e.g. non-Linux OS, restricted container).
+//
+// On Linux it parses /proc/meminfo's MemAvailable line. On other platforms it
+// returns 0 so callers should treat 0 as "unknown" rather than "no memory".
+func availableSystemMemoryBytes() uint64 {
+	if runtime.GOOS != "linux" {
+		return 0
+	}
+	f, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "MemAvailable:") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return 0
+		}
+		kb, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			return 0
+		}
+		return kb * 1024
+	}
+	return 0
+}
+
+// checkBufferUploadMemoryBudget returns an error when the user requests an
+// in-memory buffer upload (--upload-method buffer) whose --size would exceed a
+// safe fraction (80%) of available system memory. This guards against the
+// runtime OOM that would otherwise abort the process inside
+// generateRandomBytes() before any HTTP request is made.
+//
+// parallel is the --parallel value: each parallel goroutine in the upload
+// test shares the same single payload (allocated once in NewUploadTest), so
+// the budget check is independent of parallel for the buffer path. The
+// parameter is accepted for symmetry / future use.
+func checkBufferUploadMemoryBudget(sizeBytes int64, _ int) error {
+	if sizeBytes <= 0 {
+		return nil
+	}
+	avail := availableSystemMemoryBytes()
+	if avail == 0 {
+		return nil // unknown — skip the check rather than guess
+	}
+	const safetyFraction = 0.8
+	budget := uint64(float64(avail) * safetyFraction)
+	if uint64(sizeBytes) > budget {
+		return fmt.Errorf(
+			"--upload-method buffer requires materializing the full --size in RAM: "+
+				"requested %d bytes (%.2f GiB) exceeds %d%% of available system memory (%d bytes, %.2f GiB available). "+
+				"Use --upload-method stream for large payloads, or reduce --size",
+			sizeBytes, float64(sizeBytes)/(1<<30),
+			int(safetyFraction*100), avail, float64(avail)/(1<<30),
+		)
+	}
+	return nil
 }

--- a/sdk/storage/azblob/testdata/perf/upload_blob.go
+++ b/sdk/storage/azblob/testdata/perf/upload_blob.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io"
 	"os"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/perf"
@@ -30,16 +30,40 @@ func uploadTestRegister() {
 type uploadTestGlobal struct {
 	perf.PerfTestOptions
 	containerName         string
-	blobName              string
+	blobPrefix            string
 	globalContainerClient *container.Client
+
+	// size is the per-iteration upload size in bytes.
+	size int64
+
+	// payload is populated only for --upload-method=buffer (which requires a
+	// []byte). For stream/single paths it stays nil and randomSeed is used to
+	// avoid materializing arbitrarily large payloads in memory.
+	payload []byte
+
+	// randomSeed is a small (randomSeedSize) random buffer tiled by
+	// randomStream to produce the per-iteration upload bytes for stream/single
+	// methods. Shared (read-only) across goroutines.
+	randomSeed []byte
 }
 
 // NewUploadTest is called once per process
 func NewUploadTest(ctx context.Context, options perf.PerfTestOptions) (perf.GlobalPerfTest, error) {
 	u := &uploadTestGlobal{
 		PerfTestOptions: options,
-		containerName:   "uploadcontainer",
-		blobName:        "uploadblob",
+		// Suffix with a unique timestamp so concurrent runs and --no-cleanup
+		// leftovers from prior runs do not collide on container creation.
+		containerName: fmt.Sprintf("uploadcontainer-%d", time.Now().UnixNano()),
+		blobPrefix:    "uploadblob",
+		size:          int64(uploadTestOpts.size),
+	}
+
+	// Validate memory budget before doing any I/O so the user gets a clear
+	// error instead of an OOM kill or a network call followed by a panic.
+	if uploadMethod == "buffer" {
+		if err := checkBufferUploadMemoryBudget(u.size, 1); err != nil {
+			return nil, err
+		}
 	}
 
 	connStr, ok := os.LookupEnv("AZURE_STORAGE_CONNECTION_STRING")
@@ -57,6 +81,24 @@ func NewUploadTest(ctx context.Context, options perf.PerfTestOptions) (perf.Glob
 		return nil, err
 	}
 
+	// Only the buffer method requires the full payload to be materialized in
+	// RAM (the API signature is []byte). For stream/single we keep a small
+	// random seed and tile it via randomStream so --size can be arbitrarily
+	// large without OOMing the process.
+	if uploadMethod == "buffer" {
+		payload, err := generateRandomBytes(uploadTestOpts.size)
+		if err != nil {
+			return nil, err
+		}
+		u.payload = payload
+	} else {
+		seed, err := generateRandomBytes(randomSeedSize)
+		if err != nil {
+			return nil, err
+		}
+		u.randomSeed = seed
+	}
+
 	return u, nil
 }
 
@@ -68,8 +110,8 @@ func (u *uploadTestGlobal) GlobalCleanup(ctx context.Context) error {
 type uploadPerfTest struct {
 	*uploadTestGlobal
 	perf.PerfTestOptions
-	data       io.ReadSeekCloser
 	blobClient *blockblob.Client
+	blobName   string
 }
 
 // NewPerfTest is called once per goroutine
@@ -77,6 +119,9 @@ func (g *uploadTestGlobal) NewPerfTest(ctx context.Context, options *perf.PerfTe
 	u := &uploadPerfTest{
 		uploadTestGlobal: g,
 		PerfTestOptions:  *options,
+		// Each goroutine targets a unique blob to avoid same-blob write
+		// contention/throttling at the service.
+		blobName: fmt.Sprintf("%s-%s", g.blobPrefix, options.Name),
 	}
 
 	connStr, ok := os.LookupEnv("AZURE_STORAGE_CONNECTION_STRING")
@@ -96,28 +141,39 @@ func (g *uploadTestGlobal) NewPerfTest(ctx context.Context, options *perf.PerfTe
 	if err != nil {
 		return nil, err
 	}
-	bc := containerClient.NewBlockBlobClient(u.blobName)
-	if err != nil {
-		return nil, err
-	}
-	u.blobClient = bc
-
-	data, err := perf.NewRandomStream(uploadTestOpts.size)
-	if err != nil {
-		return nil, err
-	}
-	u.data = data
+	u.blobClient = containerClient.NewBlockBlobClient(u.blobName)
 
 	return u, nil
 }
 
 func (m *uploadPerfTest) Run(ctx context.Context) error {
-	_, err := m.data.Seek(0, io.SeekStart) // rewind to the beginning
-	if err != nil {
+	switch uploadMethod {
+	case "buffer":
+		_, err := m.blobClient.UploadBuffer(ctx, m.payload, &blockblob.UploadBufferOptions{
+			BlockSize:   commonBlockSize,
+			Concurrency: uint16(commonConcurrency),
+		})
 		return err
+	case "stream":
+		// Fresh randomStream per iteration so the read offset starts at 0.
+		// Tiles the shared 1 MiB random seed, so peak memory is ~1 MiB +
+		// SDK chunk buffers regardless of --size.
+		stream := newRandomStream(m.randomSeed, m.size)
+		_, err := m.blobClient.UploadStream(ctx, stream, &blockblob.UploadStreamOptions{
+			BlockSize:   commonBlockSize,
+			Concurrency: int(commonConcurrency),
+		})
+		return err
+	case "single", "":
+		// Single REST PUT. Uses a tiled randomStream so the payload is not
+		// materialized in memory; Azure Storage caps a single PUT Blob at
+		// 5000 MiB so very large --size values should use buffer or stream.
+		reader := newRandomStream(m.randomSeed, m.size)
+		_, err := m.blobClient.Upload(ctx, reader, nil)
+		return err
+	default:
+		return fmt.Errorf("unknown --upload-method %q (expected single|buffer|stream)", uploadMethod)
 	}
-	_, err = m.blobClient.Upload(ctx, m.data, nil)
-	return err
 }
 
 func (m *uploadPerfTest) Cleanup(ctx context.Context) error {

--- a/sdk/storage/azblob/testdata/perf/upload_blob.go
+++ b/sdk/storage/azblob/testdata/perf/upload_blob.go
@@ -61,7 +61,7 @@ func NewUploadTest(ctx context.Context, options perf.PerfTestOptions) (perf.Glob
 	// Validate memory budget before doing any I/O so the user gets a clear
 	// error instead of an OOM kill or a network call followed by a panic.
 	if uploadMethod == "buffer" {
-		if err := checkBufferUploadMemoryBudget(u.size, 1); err != nil {
+		if err := checkBufferMemoryBudget("--upload-method buffer", u.size); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## Purpose

Expands the Go `sdk/internal/perf` runner with the configuration surface and result artifacts required to drive Go perf workloads from the shared perf-automation matrix. Also extends the azblob perf harness so it can exercise the SDK's chunked upload/download paths.

## What's new in `sdk/internal/perf`

### New CLI flags

- `--iterations` / `-i` — repeat the measurement phase N times. Warmup runs once; per-iteration counters and latency collectors are reset between iterations.
- `--rate` / `-r` — throttle aggregate throughput to N ops/sec via a shared token channel consumed by every worker.
- `--status-interval` — seconds between live status lines.
- `--latency` / `-l` — track per-operation latency and print a percentile summary (p50/p90/p95/p99/max) plus per-call-type buckets.
- `--job-statistics` — emit a `#StartJobStatistics` / `#EndJobStatistics` JSON block consumed by perf-automation.
- `--results-file` — when combined with `--latency`, writes per-operation results (operation, latencyMs, sizeBytes) as JSON.
- `--output-file-prefix` — writes a per-run summary to `<prefix>.{json,csv,txt,md}`.
- `--config` + `--workload` — load a JSON workload-config file and select a named workload. Config parameters are merged into the CLI args before parsing, with explicit CLI flags taking precedence.
- `--resource-telemetry` — print a `runtime.MemStats` / goroutine-count delta at end of run.
- `--no-cleanup`, `--insecure`, `--sync`, `--debug`, `--maxprocs`, `--{max,min}-{io-completion,worker}-threads` — additional runner configuration knobs.
- Short aliases `-d`, `-w`, `-p`, `-i`, `-r`, `-l`, `-x` registered for the most common flags.

### Always-on process sampler

- A background sampler records CPU% (busy CPU-seconds derived from `runtime/metrics` `/cpu/classes/total` minus `/cpu/classes/idle`) and memory (`/memory/classes/total:bytes`) at a 1 s cadence.
- The live status line gained `CPU` and `Memory(MiB)` columns:

  ```
  Current   Total   Average   CPU   Memory(MiB)
  ```

- The final summary prints `averageCpuPercent` and `averageMemoryBytes`; both also appear in the run-artifact files.

### Iteration loop and lifecycle

- `Run()` flow is now: `GlobalSetup -> Setup -> Warmup -> (Run x iterations) -> Cleanup -> GlobalCleanup`, with per-iteration measurement state reset.
- Workers are spawned per phase rather than once at startup, so warmup and each measurement iteration get a clean goroutine set.
- Test-proxy bootstrap (live -> record -> playback) is extracted into a single `bootstrapProxies()` helper invoked once before the measurement phase.
- Fixed a warmup-termination heuristic that fired spuriously on long-running iterations (for example, multi-GiB blob transfers) by waiting until every worker has actually finished its warmup loop.

### Versions block

- Adds a `=== Versions ===` block at the end of a run listing the Go runtime version and the resolved versions of every compiled-in `github.com/Azure/...` and `golang.org/x/...` module (read from `debug.ReadBuildInfo`).

### Refactor for testability

- `init()` delegates to `registerFlags(*flag.FlagSet)` so tests can parse arbitrary argv slices against a fresh `FlagSet` without disturbing `flag.CommandLine`.

### Documentation

- README rewritten with the complete flag table and a note about the always-on CPU/memory sampler.

## What's new in `sdk/storage/azblob/testdata/perf`

- New flags: `--upload-method` (`single|buffer|stream`), `--download-method` (`stream|buffer`), `--block-size`, `--concurrency`, `--page-size`, `--num-blobs`.
- Upload and download tests now use a tiled `randomStream` so multi-GiB `--size` values no longer materialize the full payload in RAM. The `buffer` paths (which require a `[]byte`) are guarded by a system-memory budget check that fails fast with a clear message when `--size x --parallel` would exceed 80% of available memory.
- Unique per-run container names and per-worker blob names eliminate cross-run collisions and same-blob write contention at the service.
- Added `perfautomation-tests.yml` describing the published-vs-source comparison matrix.

## Tests

New `sdk/internal/perf/perf_options_test.go` — 13 tests / 45 sub-tests covering:

- defaults for every flag
- long-form parsing for every flag
- short-form parsing for every flag that defines a short alias
- rate-limiter token cadence
- latency and call-type collectors
- `--results-file` JSON shape
- `--output-file-prefix` writes all four artifact files with populated CPU/memory fields
- status-line column formatters (sentinel `n/a` handling)
- process-stats sampler regression guard (non-negative CPU%)
- `printVersions` (Go runtime + module list with the `Informational:` marker)
- `printJobStatistics` block markers and payload

The existing `sdk/internal/perf/workload_config_test.go` covers `--config` / `--workload` resolution and CLI override precedence.

All pre-existing tests (`TestRun`, `TestParseProxyURLs`, recording and random-stream tests) continue to pass.

To run locally:

```bash
cd sdk/internal/perf && go test ./... -count=1
cd sdk/storage/azblob/testdata/perf && go build ./...
```

## PR checklist

- [x] The purpose of this PR is explained above.
- [x] The PR does not update generated files.
- [x] Tests are included for the new flags and behaviors.
- [ ] `sdk/internal/perf` is an internal package without a versioned CHANGELOG; please advise if an entry should land elsewhere (for example, `sdk/storage/azblob/CHANGELOG.md`) for the harness changes.
- [x] MIT license headers are included in each new file.