### PR TITLE
[Cosmos] Release: azcosmos 1.5.0-beta.7

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -2,13 +2,11 @@
 
 <!-- cSpell:ignore documentdb unmarshalling -->
 
-## 1.5.0-beta.7 (Unreleased)
+## 1.5.0-beta.7 (2026-06-02)
 
 ### Features Added
 
 * Added retry policy for transient `500`, `502`, and `504` server errors on read requests. The request is retried once in the current region and, if applicable, once against the next preferred region. Writes are not retried. This matches the behavior of the .NET, Java, and Python Cosmos SDKs. See [PR 26821](https://github.com/Azure/azure-sdk-for-go/pull/26821).
-
-### Breaking Changes
 
 ### Bugs Fixed
 


### PR DESCRIPTION
## azcosmos Release 1.5.0-beta.7

### Version Changes
- azcosmos: 1.5.0-beta.6 → 1.5.0-beta.7

### CHANGELOG

#### Features Added
* Added retry policy for transient `500`, `502`, and `504` server errors on read requests. The request is retried once in the current region and, if applicable, once against the next preferred region. Writes are not retried. See [PR 26821](https://github.com/Azure/azure-sdk-for-go/pull/26821).

#### Bugs Fixed
* Fixed missing OTel tracing spans for internal queries executed by `ReadManyItems`. See [PR 26813](https://github.com/Azure/azure-sdk-for-go/pull/26813).
* 403/`WriteForbidden` retries refresh the global endpoint manager fire-and-forget (CAS-gated) instead of blocking on a synchronous `gem.Update`. See [PR 26889](https://github.com/Azure/azure-sdk-for-go/pull/26889).
* Connection-error retry policy now attempts up to 3 retries against the current region before failing over, and performs at most one cross-region failover per call. Writes on ambiguous transport failures no longer fail over to another region. See [PR 26858](https://github.com/Azure/azure-sdk-for-go/pull/26858) and [PR 26915](https://github.com/Azure/azure-sdk-for-go/pull/26915).
* HTTP `408 Request Timeout` responses are now handled by the Cosmos client retry policy. See [PR 26858](https://github.com/Azure/azure-sdk-for-go/pull/26858).
* Fixed excessive `GetDatabaseAccount` HTTP calls when using preferred regions. See [PR 26815](https://github.com/Azure/azure-sdk-for-go/pull/26815).
* Partition key range cache now serves concurrent callers from a single in-flight refresh per container. See [PR 26855](https://github.com/Azure/azure-sdk-for-go/pull/26855).
* Partition key range cache change-feed pagination is now resilient to mid-drain throttling. See [PR 26855](https://github.com/Azure/azure-sdk-for-go/pull/26855).

#### Other Changes
* Tightened the default HTTP client: 5s dial timeout, 65s wall-clock cap per HTTP attempt, larger idle connection pool, and faster HTTP/2 health checks. See [PR 26856](https://github.com/Azure/azure-sdk-for-go/pull/26856).

### Release date
2026-06-02

### Release tracking
[Work item 27103](https://dev.azure.com/azure-sdk/Release/_workitems/edit/27103/)