### PR TITLE
azcertificates: live recording for PlatformManaged + review fixes (follow-up to #26809)

### DIFF
--- a/sdk/security/keyvault/azcertificates/CHANGELOG.md
+++ b/sdk/security/keyvault/azcertificates/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other Changes
 
+- Default service API version moved to `2026-03-01-preview`. Pin via `ClientOptions.APIVersion` to stay on `2025-07-01`.
+
 ## 1.5.0 (2026-05-26)
 
 ### Features Added

--- a/sdk/security/keyvault/azcertificates/CHANGELOG.md
+++ b/sdk/security/keyvault/azcertificates/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Release History
 
-## 1.5.1-beta.2 (2026-06-03)
+## 1.5.1-beta.1 (2026-06-04)
 
 ### Features Added
-* we added an experimental feature for azure key vault internal usage. Any calls using this property will fail and is not recommended to be used at this point.
+* Added an experimental PlatformManaged property on CertificatePolicy for Azure Key Vault internal usage. Any calls using this property will fail and it is not recommended to be used at this point. [#26922](https://github.com/Azure/azure-sdk-for-go/pull/26922)
 
 ### Other Changes
 * Upgraded to API service version `2026-03-01-preview`

--- a/sdk/security/keyvault/azcertificates/CHANGELOG.md
+++ b/sdk/security/keyvault/azcertificates/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## 1.5.1-beta.1 (2026-06-04)
 
 ### Features Added
-
-- We added an experimental feature for Azure Key Vault internal usage. Any calls using this property will fail and is not recommended to be used at this point.
+* Added an experimental PlatformManaged property on CertificatePolicy for Azure Key Vault internal usage. Any calls using this property will fail and it is not recommended to be used at this point. [#26922](https://github.com/Azure/azure-sdk-for-go/pull/26922)
 
 ### Other Changes
 * Upgraded to API service version `2026-03-01-preview`

--- a/sdk/security/keyvault/azcertificates/CHANGELOG.md
+++ b/sdk/security/keyvault/azcertificates/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### Features Added
 
-- Added an experimental `PlatformManaged` property on `CertificatePolicy` for Azure Key Vault internal usage. Any calls using this property will fail and it is not recommended to be used at this point.
+- We added an experimental feature for Azure Key Vault internal usage. Any calls using this property will fail and is not recommended to be used at this point.
+
+### Other Changes
+* Upgraded to API service version `2026-03-01-preview`
 
 ## 1.5.0 (2026-05-26)
 

--- a/sdk/security/keyvault/azcertificates/CHANGELOG.md
+++ b/sdk/security/keyvault/azcertificates/CHANGELOG.md
@@ -1,18 +1,10 @@
 # Release History
 
-## 1.5.1-beta.1 (Unreleased)
+## 1.5.1-beta.1 (2026-06-04)
 
 ### Features Added
 
 - Added an experimental `PlatformManaged` property on `CertificatePolicy` for Azure Key Vault internal usage. Any calls using this property will fail and it is not recommended to be used at this point.
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
-
-- Default service API version moved to `2026-03-01-preview`. Pin via `ClientOptions.APIVersion` to stay on `2025-07-01`.
 
 ## 1.5.0 (2026-05-26)
 

--- a/sdk/security/keyvault/azcertificates/CHANGELOG.md
+++ b/sdk/security/keyvault/azcertificates/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Release History
 
-## 1.5.1-beta.1 (2026-06-04)
+## 1.5.1-beta.2 (2026-06-03)
 
 ### Features Added
-* Added an experimental PlatformManaged property on CertificatePolicy for Azure Key Vault internal usage. Any calls using this property will fail and it is not recommended to be used at this point. [#26922](https://github.com/Azure/azure-sdk-for-go/pull/26922)
+* we added an experimental feature for azure key vault internal usage. Any calls using this property will fail and is not recommended to be used at this point.
 
 ### Other Changes
 * Upgraded to API service version `2026-03-01-preview`

--- a/sdk/security/keyvault/azcertificates/assets.json
+++ b/sdk/security/keyvault/azcertificates/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/security/keyvault/azcertificates",
-  "Tag": "go/security/keyvault/azcertificates_fa9d1951e5"
+  "Tag": "go/security/keyvault/azcertificates_5db2f995e2"
 }

--- a/sdk/security/keyvault/azcertificates/assets.json
+++ b/sdk/security/keyvault/azcertificates/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/security/keyvault/azcertificates",
-  "Tag": "go/security/keyvault/azcertificates_5db2f995e2"
+  "Tag": "go/security/keyvault/azcertificates_3f66d152c6"
 }

--- a/sdk/security/keyvault/azcertificates/client_test.go
+++ b/sdk/security/keyvault/azcertificates/client_test.go
@@ -751,3 +751,40 @@ func TestSubjectAlternativeNames(t *testing.T) {
 
 	testSerde(t, sans)
 }
+
+// TestPlatformManaged exercises the experimental PlatformManaged property on
+// CertificatePolicy. The feature is intended for internal Azure Key Vault usage
+// only and requires a valid OneCert-managed domain; this test issues a
+// PublicTLSServerAuth certificate for a OneCert-owned host and verifies the
+// PlatformManaged configuration round-trips through Create + Get.
+func TestPlatformManaged(t *testing.T) {
+	client := startTest(t)
+
+	certName := getName(t, "platformmanaged")
+	dnsName := "onecertdomain.contoso.com"
+	policy := azcertificates.CertificatePolicy{
+		PlatformManaged: azcertificates.NewPlatformManaged("PublicTLSServerAuth", map[string]any{
+			"sans": map[string]any{
+				"dns_names": []string{dnsName},
+			},
+		}),
+	}
+	createParams := azcertificates.CreateCertificateParameters{CertificatePolicy: &policy}
+	testSerde(t, &createParams)
+
+	_, err := client.CreateCertificate(ctx, certName, createParams, nil)
+	require.NoError(t, err)
+	defer cleanUpCert(t, client, certName)
+
+	policyResp, err := client.GetCertificatePolicy(ctx, certName, nil)
+	require.NoError(t, err)
+	require.NotNil(t, policyResp.PlatformManaged)
+	require.NotNil(t, policyResp.PlatformManaged.CertificateUsage)
+	require.Equal(t, "PublicTLSServerAuth", *policyResp.PlatformManaged.CertificateUsage)
+
+	sansRaw, ok := policyResp.PlatformManaged.Metadata["sans"].(map[string]any)
+	require.True(t, ok, "expected metadata.sans to round-trip as object, got %T", policyResp.PlatformManaged.Metadata["sans"])
+	dnsNamesRaw, ok := sansRaw["dns_names"].([]any)
+	require.True(t, ok, "expected metadata.sans.dns_names to round-trip as array, got %T", sansRaw["dns_names"])
+	require.Contains(t, dnsNamesRaw, dnsName)
+}

--- a/sdk/security/keyvault/azcertificates/client_test.go
+++ b/sdk/security/keyvault/azcertificates/client_test.go
@@ -761,7 +761,7 @@ func TestPlatformManaged(t *testing.T) {
 	client := startTest(t)
 
 	certName := getName(t, "platformmanaged")
-	dnsName := "onecertdomain.contoso.com"
+	dnsName := "sanitized.example.invalid"
 	policy := azcertificates.CertificatePolicy{
 		PlatformManaged: azcertificates.NewPlatformManaged("PublicTLSServerAuth", map[string]any{
 			"sans": map[string]any{

--- a/sdk/security/keyvault/azcertificates/client_test.go
+++ b/sdk/security/keyvault/azcertificates/client_test.go
@@ -781,6 +781,7 @@ func TestPlatformManaged(t *testing.T) {
 	require.NotNil(t, policyResp.PlatformManaged)
 	require.NotNil(t, policyResp.PlatformManaged.CertificateUsage)
 	require.Equal(t, "PublicTLSServerAuth", *policyResp.PlatformManaged.CertificateUsage)
+	require.NotNil(t, policyResp.PlatformManaged.Metadata)
 
 	sansRaw, ok := policyResp.PlatformManaged.Metadata["sans"].(map[string]any)
 	require.True(t, ok, "expected metadata.sans to round-trip as object, got %T", policyResp.PlatformManaged.Metadata["sans"])

--- a/sdk/security/keyvault/azcertificates/custom_client.go
+++ b/sdk/security/keyvault/azcertificates/custom_client.go
@@ -26,6 +26,11 @@ type ClientOptions struct {
 }
 
 // NewPlatformManaged creates a PlatformManaged certificate policy configuration.
+//
+// PlatformManaged is in preview as of API version 2026-03-01-preview and is currently
+// intended for first-party Microsoft Azure Key Vault internal usage only. Calls using
+// this property will fail for external customers and the shape may change before GA.
+// It is not recommended for use at this point.
 func NewPlatformManaged(certificateUsage string, metadata map[string]any) *PlatformManaged {
 	return &PlatformManaged{
 		CertificateUsage: &certificateUsage,

--- a/sdk/security/keyvault/azcertificates/custom_client_test.go
+++ b/sdk/security/keyvault/azcertificates/custom_client_test.go
@@ -91,11 +91,13 @@ func TestCreateCertificateRequestIncludesPlatformManaged(t *testing.T) {
 
 	req, err := client.createCertificateCreateRequest(context.Background(), "cert-name", parameters, nil)
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, req.Raw().Body.Close())
+	}()
 	require.Equal(t, version20260301Preview, req.Raw().URL.Query().Get("api-version"))
 
 	body, err := io.ReadAll(req.Raw().Body)
 	require.NoError(t, err)
-	require.NoError(t, req.Raw().Body.Close())
 	require.JSONEq(t, `{
 		"policy": {
 			"issuer": {"name": "Self"},
@@ -124,11 +126,13 @@ func TestUpdateCertificatePolicyRequestIncludesPlatformManaged(t *testing.T) {
 
 	req, err := client.updateCertificatePolicyCreateRequest(context.Background(), "cert-name", policy, nil)
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, req.Raw().Body.Close())
+	}()
 	require.Equal(t, version20260301Preview, req.Raw().URL.Query().Get("api-version"))
 
 	body, err := io.ReadAll(req.Raw().Body)
 	require.NoError(t, err)
-	require.NoError(t, req.Raw().Body.Close())
 	require.JSONEq(t, `{
 		"issuer": {"name": "Self"},
 		"platformManaged": {

--- a/sdk/security/keyvault/azcertificates/custom_client_test.go
+++ b/sdk/security/keyvault/azcertificates/custom_client_test.go
@@ -95,6 +95,7 @@ func TestCreateCertificateRequestIncludesPlatformManaged(t *testing.T) {
 
 	body, err := io.ReadAll(req.Raw().Body)
 	require.NoError(t, err)
+	require.NoError(t, req.Raw().Body.Close())
 	require.JSONEq(t, `{
 		"policy": {
 			"issuer": {"name": "Self"},
@@ -127,6 +128,7 @@ func TestUpdateCertificatePolicyRequestIncludesPlatformManaged(t *testing.T) {
 
 	body, err := io.ReadAll(req.Raw().Body)
 	require.NoError(t, err)
+	require.NoError(t, req.Raw().Body.Close())
 	require.JSONEq(t, `{
 		"issuer": {"name": "Self"},
 		"platformManaged": {

--- a/sdk/security/keyvault/azcertificates/version.go
+++ b/sdk/security/keyvault/azcertificates/version.go
@@ -5,5 +5,5 @@ package azcertificates
 
 const (
 	moduleName = "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates"
-	version    = "v1.5.1-beta.1"
+	version    = "v1.5.1-beta.2"
 )

--- a/sdk/security/keyvault/azcertificates/version.go
+++ b/sdk/security/keyvault/azcertificates/version.go
@@ -5,5 +5,5 @@ package azcertificates
 
 const (
 	moduleName = "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates"
-	version    = "v1.5.1-beta.2"
+	version    = "v1.5.1-beta.1"
 )


### PR DESCRIPTION
Follow-up to #26809.

**Changes (all scoped to `sdk/security/keyvault/azcertificates/`):**

- **Live recording for PlatformManaged**: new `TestPlatformManaged` in `client_test.go` that creates a PlatformManaged certificate with `certificateUsage: PublicTLSServerAuth` and snake_case `metadata.sans.dns_names`, then verifies the platformManaged config round-trips via `GetCertificatePolicy`. Recorded live; `assets.json` tag bumped.
- **Review feedback from #26809**:
  - Godoc warning on `NewPlatformManaged` — preview, first-party Azure Key Vault internal usage only, calls will fail for external callers, not recommended at this point.
  - `CHANGELOG` entry under `1.5.1-beta.1` documents the experimental PlatformManaged feature and the API service version upgrade to `2026-03-01-preview`.
- **Review feedback on this PR**:
  - Closed request bodies via `defer` immediately after request creation in `custom_client_test.go` so they are released even if an assertion fails before `Close`.
  - Sanitized placeholder domain in `TestPlatformManaged` fixtures.

No generated code changes. Unit tests pass locally; the new live test plays back from the recording asset.
