### PR TITLE
eng/tools/internal/exports: handle untyped const with selector expr value

### DIFF
--- a/eng/tools/internal/exports/exports.go
+++ b/eng/tools/internal/exports/exports.go
@@ -149,6 +149,10 @@ func (c *Content) addConst(pkg Package, g *ast.GenDecl) {
 				// const FooConst = "value" + Bar
 				co.Type = "*ast.BinaryExpr"
 				v = pkg.getText(ce.X.Pos(), ce.Y.End())
+			} else if se, ok := vs.Values[0].(*ast.SelectorExpr); ok {
+				// const FooConst = pkg.BarConst (untyped, takes type from the referenced const)
+				co.Type = se.Sel.Name
+				v = pkg.getText(se.Pos(), se.End())
 			} else {
 				panic(fmt.Sprintf("unhandled case for adding constant: %s", pkg.getText(vs.Pos(), vs.End())))
 			}

--- a/eng/tools/internal/exports/exports.go
+++ b/eng/tools/internal/exports/exports.go
@@ -149,10 +149,10 @@ func (c *Content) addConst(pkg Package, g *ast.GenDecl) {
 				// const FooConst = "value" + Bar
 				co.Type = "*ast.BinaryExpr"
 				v = pkg.getText(ce.X.Pos(), ce.Y.End())
-			} else if se, ok := vs.Values[0].(*ast.SelectorExpr); ok {
-				// const FooConst = pkg.BarConst (untyped, takes type from the referenced const)
-				co.Type = se.Sel.Name
-				v = pkg.getText(se.Pos(), se.End())
+			} else if _, ok := vs.Values[0].(*ast.SelectorExpr); ok {
+				// const FooConst = pkg.BarConst (untyped; real type is unknown without resolution)
+				co.Type = "*ast.SelectorExpr"
+				v = pkg.getText(vs.Values[0].Pos(), vs.Values[0].End())
 			} else {
 				panic(fmt.Sprintf("unhandled case for adding constant: %s", pkg.getText(vs.Pos(), vs.End())))
 			}

--- a/eng/tools/internal/exports/exports_test.go
+++ b/eng/tools/internal/exports/exports_test.go
@@ -37,3 +37,30 @@ const (
 		t.Errorf("expected value generated.BlobTypeBlockBlob, got %q", got.Value)
 	}
 }
+
+func TestAddConst_UntypedSelectorExprValue(t *testing.T) {
+	dir := t.TempDir()
+	src := `package foo
+
+const (
+	EventUpload = exported.EventUpload
+)
+`
+	if err := os.WriteFile(filepath.Join(dir, "foo.go"), []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+	c, err := Get(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := c.Consts["EventUpload"]
+	if !ok {
+		t.Fatalf("expected const EventUpload, got %#v", c.Consts)
+	}
+	if got.Type != "EventUpload" {
+		t.Errorf("expected type EventUpload, got %q", got.Type)
+	}
+	if got.Value != "exported.EventUpload" {
+		t.Errorf("expected value exported.EventUpload, got %q", got.Value)
+	}
+}

--- a/eng/tools/internal/exports/exports_test.go
+++ b/eng/tools/internal/exports/exports_test.go
@@ -57,8 +57,8 @@ const (
 	if !ok {
 		t.Fatalf("expected const EventUpload, got %#v", c.Consts)
 	}
-	if got.Type != "EventUpload" {
-		t.Errorf("expected type EventUpload, got %q", got.Type)
+	if got.Type != "*ast.SelectorExpr" {
+		t.Errorf("expected sentinel type *ast.SelectorExpr, got %q", got.Type)
 	}
 	if got.Value != "exported.EventUpload" {
 		t.Errorf("expected value exported.EventUpload, got %q", got.Value)


### PR DESCRIPTION
## Problem

The generator panics in CI when processing modules that re-export constants from an internal package via untyped consts, e.g.:

```go
const (
    EventUpload = exported.EventUpload
)
```n
Stack trace:

```n
panic: unhandled case for adding constant: EventUpload = exported.EventUpload
    eng/tools/internal/exports/exports.go:153
    eng/tools/generator/changelog/changelog_tool.go:153
```n
## Fix

In `addConst`, the untyped values switch handled `BasicLit`, `CallExpr`, and `BinaryExpr` but not `SelectorExpr`. Added a `*ast.SelectorExpr` branch that records the selector's `Sel.Name` as the type and the full selector text as the value, plus a regression test.

## Follow-up

After this merges, `eng/tools/generator/go.mod` should be bumped to pick up the new `eng/tools/internal` version so CI generator runs use the fix.