### PR TITLE
eng/tools/generator: release v0.4.14

### DIFF
--- a/eng/tools/generator/CHANGELOG.md
+++ b/eng/tools/generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.4.14 (2026-06-03)
+
+### Bugs Fixed
+
+- Bumped `eng/tools/internal` dependency to pick up the fix for the `addConst` panic on untyped consts whose value is a selector expression (e.g. `const EventUpload = exported.EventUpload`).
+
 ## 0.4.13 (2026-05-28)
 
 ### Bugs Fixed

--- a/eng/tools/generator/go.mod
+++ b/eng/tools/generator/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/azure-sdk-for-go/eng/tools/generator
 go 1.25.0
 
 require (
-	github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260521025626-22b44eb319ae
+	github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260603090812-118bb357a68b
 	github.com/Masterminds/semver v1.5.0
 	github.com/ahmetb/go-linq/v3 v3.2.0
 	github.com/go-git/go-git/v5 v5.16.5

--- a/eng/tools/generator/go.sum
+++ b/eng/tools/generator/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
-github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260521025626-22b44eb319ae h1:bX+jDmV4IoLD8bAbrki3HS4RxBONTOswEHBYxUz7EKA=
-github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260521025626-22b44eb319ae/go.mod h1:1wiEmZuPMe5xsZ5BBhoHXpa1Qatbjwp+ETnMY/PbP84=
+github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260603090812-118bb357a68b h1:SgD2c/PETXFuxxqYyq79JA0UPhkwz8YFiPATEZ6vNUI=
+github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260603090812-118bb357a68b/go.mod h1:1wiEmZuPMe5xsZ5BBhoHXpa1Qatbjwp+ETnMY/PbP84=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=

--- a/eng/tools/generator/version.go
+++ b/eng/tools/generator/version.go
@@ -5,5 +5,5 @@ package main
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/eng/tools/generator"
-	moduleVersion = "v0.4.13"
+	moduleVersion = "v0.4.14"
 )


### PR DESCRIPTION
Bumps `eng/tools/internal` to `v0.0.0-20260603090812-118bb357a68b` to pick up the fix from #26931 for the `addConst` panic on untyped consts whose value is a selector expression (e.g. `const EventUpload = exported.EventUpload`).

Without this bump, the CI generator (which uses the published `eng/tools/internal` module version) still hits the panic when generating changelogs for modules like `sdk/storage/azfile`.