### PR TITLE
[keyvault] Skip live EKM tests when infrastructure is unavailable

### DIFF
--- a/sdk/security/keyvault/azadmin/ekm/utils_test.go
+++ b/sdk/security/keyvault/azadmin/ekm/utils_test.go
@@ -124,6 +124,14 @@ func startRecording(t *testing.T) {
 }
 
 func startEKMTest(t *testing.T) *ekm.KeyVaultClient {
+	// EKM tests require an external key manager proxy reachable from the
+	// Managed HSM. CI doesn't provision one, so live runs are skipped unless
+	// EKM_PROXY_HOST is supplied. Recording runs still execute (so recordings
+	// can be refreshed against an environment that does have a real proxy)
+	// and playback runs always execute against the recordings.
+	if recording.GetRecordMode() == recording.LiveMode && os.Getenv("EKM_PROXY_HOST") == "" {
+		t.Skip("skipping live EKM test: set EKM_PROXY_HOST to run against a real EKM proxy")
+	}
 	startRecording(t)
 	transport, err := recording.NewRecordingHTTPClient(t, nil)
 	require.NoError(t, err)

--- a/sdk/security/keyvault/azkeys/assets.json
+++ b/sdk/security/keyvault/azkeys/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/security/keyvault/azkeys",
-  "Tag": "go/security/keyvault/azkeys_ff983e62e3"
+  "Tag": "go/security/keyvault/azkeys_79ee35f2c3"
 }

--- a/sdk/security/keyvault/azkeys/assets.json
+++ b/sdk/security/keyvault/azkeys/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/security/keyvault/azkeys",
-  "Tag": "go/security/keyvault/azkeys_79ee35f2c3"
+  "Tag": "go/security/keyvault/azkeys_1065a79558"
 }

--- a/sdk/security/keyvault/azkeys/client_test.go
+++ b/sdk/security/keyvault/azkeys/client_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -824,6 +825,15 @@ func TestSecureWrapUnwrap(t *testing.T) {
 }
 
 func TestExternalKeyReference(t *testing.T) {
+	// External-key creation requires a working EKM connection on the HSM
+	// pointed at an EKM proxy that exposes the key named by EKM_EXTERNAL_ID.
+	// CI doesn't provision that, so live runs are skipped unless the env var
+	// is supplied. Recording runs still execute (so recordings can be
+	// refreshed against an environment that does have a real proxy) and
+	// playback runs always execute against the recordings.
+	if recording.GetRecordMode() == recording.LiveMode && os.Getenv("EKM_EXTERNAL_ID") == "" {
+		t.Skip("skipping live external-key test: set EKM_EXTERNAL_ID to run against a real EKM proxy")
+	}
 	keyClient := startTest(t, false)
 
 	localKeyName := "ekm-external-key-test"

--- a/sdk/security/keyvault/azkeys/client_test.go
+++ b/sdk/security/keyvault/azkeys/client_test.go
@@ -852,19 +852,8 @@ func TestExternalKeyReference(t *testing.T) {
 	}
 
 	created, err := keyClient.CreateKey(ctx, localKeyName, params, nil)
-	if err != nil {
-		// The most common failure is that no EKM connection is configured on
-		// the HSM, in which case the service returns a 4xx. Surface that as a
-		// skip — including in playback, where the recording may legitimately
-		// have captured that 4xx — so the wire contract test still runs without
-		// requiring a fully provisioned EKM proxy.
-		var httpErr *azcore.ResponseError
-		if errors.As(err, &httpErr) {
-			t.Skipf("CreateKey failed (HTTP %d, %s); is an EKM connection configured on the HSM?",
-				httpErr.StatusCode, httpErr.ErrorCode)
-		}
-		require.NoError(t, err)
-	}
+	require.NoError(t, err)
+
 	t.Cleanup(func() {
 		_, _ = keyClient.DeleteKey(context.Background(), localKeyName, nil)
 	})

--- a/sdk/security/keyvault/azkeys/client_test.go
+++ b/sdk/security/keyvault/azkeys/client_test.go
@@ -834,7 +834,7 @@ func TestExternalKeyReference(t *testing.T) {
 	if recording.GetRecordMode() == recording.LiveMode && os.Getenv("EKM_EXTERNAL_ID") == "" {
 		t.Skip("skipping live external-key test: set EKM_EXTERNAL_ID to run against a real EKM proxy")
 	}
-	keyClient := startTest(t, false)
+	keyClient := startTest(t, true)
 
 	localKeyName := "ekm-external-key-test"
 	ctx := context.Background()

--- a/sdk/security/keyvault/azkeys/client_test.go
+++ b/sdk/security/keyvault/azkeys/client_test.go
@@ -836,12 +836,8 @@ func TestExternalKeyReference(t *testing.T) {
 	}
 	keyClient := startTest(t, true)
 
-	localKeyName := "ekm-external-key-test"
+	localKeyName := createRandomName(t, "ekm-external-key-test")
 	ctx := context.Background()
-
-	// Best-effort cleanup of a prior run. Run this in playback too so the
-	// corresponding entry in the recording is consumed in lockstep.
-	_, _ = keyClient.DeleteKey(ctx, localKeyName, nil)
 
 	// ExternalKey and Kty are mutually exclusive on CreateKey: the key material
 	// lives at the EKM proxy, so the Key Vault never picks its own key type.
@@ -855,7 +851,15 @@ func TestExternalKeyReference(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		_, _ = keyClient.DeleteKey(context.Background(), localKeyName, nil)
+		_, err = keyClient.DeleteKey(context.Background(), localKeyName, nil)
+		require.NoError(t, err)
+		pollStatus(t, 404, func() error {
+			_, err := keyClient.GetDeletedKey(context.Background(), localKeyName, nil)
+			return err
+		})
+
+		_, err = keyClient.PurgeDeletedKey(context.Background(), localKeyName, nil)
+		require.NoError(t, err)
 	})
 
 	require.NotNil(t, created.Attributes, "expected attributes on created key")

--- a/sdk/security/keyvault/azkeys/utils_test.go
+++ b/sdk/security/keyvault/azkeys/utils_test.go
@@ -79,6 +79,19 @@ func run(m *testing.M) int {
 	externalKeyID = recording.GetEnvVariable("EKM_EXTERNAL_ID", fakeExternalKeyID)
 	enableHSM = mhsmURL != fakeHsmURL
 
+	if recording.GetRecordMode() != recording.LiveMode {
+		// AZSDK3430 sanitizes every JSON $..id field to "Sanitized", which would
+		// overwrite legitimate id values the tests assert on (for example the
+		// external-key id on KeyAttributes.ExternalKey). Other Key Vault modules
+		// disable it for the same reason.
+		err := recording.RemoveRegisteredSanitizers([]string{
+			"AZSDK3430", // id in body
+		}, nil)
+		if err != nil {
+			panic(err)
+		}
+	}
+
 	if recording.GetRecordMode() == recording.RecordingMode {
 		for _, path := range []string{"$.error.message", "$.key.kid", "$.recoveryId"} {
 			err := recording.AddBodyKeySanitizer(path, fakeVaultURL, vaultURL, nil)


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->
MHSM pools with EKM support cannot be created automatically at the moment, so we will have to rely on playback tests until the feature is in public preview.

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
