### PR TITLE
Apply CFSClean2 network blocking policy to pipelines

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -41,6 +41,7 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
+      networkIsolationPolicy: Permissive,CFSClean
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'go - azcore'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -41,7 +41,7 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      networkIsolationPolicy: Permissive,CFSClean
+      networkIsolationPolicy: Permissive,CFSClean2
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'go - azcore'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:


### PR DESCRIPTION
This will block some unneeded connections like powershellgallery.com and npmjs.com that we already work around (but still get called by various dependencies out of our control for metadata, etc.).