### PR TITLE
Keyvault/azadmin/ekm Code coverage improvement

### DIFF
--- a/sdk/security/keyvault/azadmin/ekm/client_mock_test.go
+++ b/sdk/security/keyvault/azadmin/ekm/client_mock_test.go
@@ -1,0 +1,383 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package ekm_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/mock"
+	azcred "github.com/Azure/azure-sdk-for-go/sdk/internal/test/credential"
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azadmin/ekm"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise every KeyVaultClient operation against a mock HTTP
+// transport so the generated request/response code is covered even when the
+// live EKM tests are skipped (the default in CI, where no EKM proxy is
+// provisioned). They intentionally don't depend on EKM_PROXY_HOST or
+// recordings — the goal is unit coverage of the client, not service behavior.
+
+const mockEKMConnectionBody = `{
+	"host":"ekm-proxy.example.com:443",
+	"path_prefix":"/v1",
+	"server_subject_common_name":"ekm-proxy.example.com",
+	"server_ca_certificates":["YXp1cmUtc2RrLWZvci1nby1la20tdGVzdC1jYS1jZXJ0aWZpY2F0ZS1ieXRlcw=="]
+}`
+
+const mockEKMCertificateBody = `{
+	"subject_common_name":"CN=hsm-client",
+	"ca_certificates":["YXp1cmUtc2RrLWZvci1nby1la20tdGVzdC1jYS1jZXJ0aWZpY2F0ZS1ieXRlcw=="]
+}`
+
+const mockEKMProxyInfoBody = `{
+	"api_version":"1.0",
+	"ekm_vendor":"Contoso",
+	"ekm_product":"Contoso EKM 1.0",
+	"proxy_vendor":"Contoso",
+	"proxy_name":"Contoso Proxy 2.0"
+}`
+
+// newMockClient builds a KeyVaultClient wired to the given mock transport.
+// Retries are disabled so each test only needs to enqueue a single response —
+// the challenge auth policy issues a body-less probe first, but that probe
+// receives the same mock response as the main request because we always
+// configure responses via SetResponse or a predicate that matches both.
+func newMockClient(t *testing.T, srv *mock.Server) *ekm.KeyVaultClient {
+	t.Helper()
+	opts := &ekm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: srv,
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+	client, err := ekm.NewClient(hsmURL, &azcred.Fake{}, opts)
+	require.NoError(t, err)
+	return client
+}
+
+// sampleConnection returns a Connection value that round-trips cleanly through
+// the generated serde so it can be used as a request body in mock tests.
+func sampleConnection() ekm.Connection {
+	return ekm.Connection{
+		Host:                    to.Ptr("ekm-proxy.example.com:443"),
+		ServerCaCertificates:    [][]byte{[]byte("ca-cert-bytes")},
+		ServerSubjectCommonName: to.Ptr("ekm-proxy.example.com"),
+		PathPrefix:              to.Ptr("/v1"),
+	}
+}
+
+func TestCreateEkmConnection_Mock(t *testing.T) {
+	srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer closeSrv()
+	srv.SetResponse(
+		mock.WithStatusCode(http.StatusOK),
+		mock.WithBody([]byte(mockEKMConnectionBody)),
+	)
+
+	client := newMockClient(t, srv)
+	res, err := client.CreateEkmConnection(context.Background(), sampleConnection(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, res.Host)
+	require.Equal(t, "ekm-proxy.example.com:443", *res.Host)
+	require.NotNil(t, res.PathPrefix)
+	require.Equal(t, "/v1", *res.PathPrefix)
+	require.Len(t, res.ServerCaCertificates, 1)
+}
+
+func TestCreateEkmConnection_MockError(t *testing.T) {
+	srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer closeSrv()
+	srv.SetResponse(
+		mock.WithStatusCode(http.StatusConflict),
+		mock.WithBody([]byte(`{"error":{"code":"Conflict","message":"already exists"}}`)),
+	)
+
+	client := newMockClient(t, srv)
+	_, err := client.CreateEkmConnection(context.Background(), sampleConnection(), nil)
+	require.Error(t, err)
+	var respErr *azcore.ResponseError
+	require.ErrorAs(t, err, &respErr)
+	require.Equal(t, http.StatusConflict, respErr.StatusCode)
+}
+
+func TestGetEkmConnection_Mock(t *testing.T) {
+	srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer closeSrv()
+	srv.SetResponse(
+		mock.WithStatusCode(http.StatusOK),
+		mock.WithBody([]byte(mockEKMConnectionBody)),
+	)
+
+	client := newMockClient(t, srv)
+	res, err := client.GetEkmConnection(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, res.Host)
+	require.Equal(t, "ekm-proxy.example.com:443", *res.Host)
+	require.NotNil(t, res.ServerSubjectCommonName)
+	require.Equal(t, "ekm-proxy.example.com", *res.ServerSubjectCommonName)
+}
+
+func TestGetEkmConnection_MockError(t *testing.T) {
+	srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer closeSrv()
+	srv.SetResponse(
+		mock.WithStatusCode(http.StatusNotFound),
+		mock.WithBody([]byte(`{"error":{"code":"NotFound","message":"no ekm connection"}}`)),
+	)
+
+	client := newMockClient(t, srv)
+	_, err := client.GetEkmConnection(context.Background(), nil)
+	require.Error(t, err)
+	var respErr *azcore.ResponseError
+	require.ErrorAs(t, err, &respErr)
+	require.Equal(t, http.StatusNotFound, respErr.StatusCode)
+}
+
+func TestGetEkmConnection_MockInvalidBody(t *testing.T) {
+	srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer closeSrv()
+	srv.SetResponse(
+		mock.WithStatusCode(http.StatusOK),
+		mock.WithBody([]byte("not-json")),
+	)
+
+	client := newMockClient(t, srv)
+	_, err := client.GetEkmConnection(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestUpdateEkmConnection_Mock(t *testing.T) {
+	srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer closeSrv()
+	srv.SetResponse(
+		mock.WithStatusCode(http.StatusOK),
+		mock.WithBody([]byte(mockEKMConnectionBody)),
+	)
+
+	client := newMockClient(t, srv)
+	res, err := client.UpdateEkmConnection(context.Background(), sampleConnection(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, res.PathPrefix)
+	require.Equal(t, "/v1", *res.PathPrefix)
+}
+
+func TestUpdateEkmConnection_MockError(t *testing.T) {
+	srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer closeSrv()
+	srv.SetResponse(
+		mock.WithStatusCode(http.StatusBadRequest),
+		mock.WithBody([]byte(`{"error":{"code":"BadRequest","message":"bad request"}}`)),
+	)
+
+	client := newMockClient(t, srv)
+	_, err := client.UpdateEkmConnection(context.Background(), sampleConnection(), nil)
+	require.Error(t, err)
+	var respErr *azcore.ResponseError
+	require.ErrorAs(t, err, &respErr)
+	require.Equal(t, http.StatusBadRequest, respErr.StatusCode)
+}
+
+func TestDeleteEkmConnection_Mock(t *testing.T) {
+	srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer closeSrv()
+	srv.SetResponse(
+		mock.WithStatusCode(http.StatusOK),
+		mock.WithBody([]byte(mockEKMConnectionBody)),
+	)
+
+	client := newMockClient(t, srv)
+	res, err := client.DeleteEkmConnection(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, res.Host)
+	require.Equal(t, "ekm-proxy.example.com:443", *res.Host)
+}
+
+func TestDeleteEkmConnection_MockError(t *testing.T) {
+	srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer closeSrv()
+	srv.SetResponse(
+		mock.WithStatusCode(http.StatusNotFound),
+		mock.WithBody([]byte(`{"error":{"code":"NotFound","message":"no ekm connection"}}`)),
+	)
+
+	client := newMockClient(t, srv)
+	_, err := client.DeleteEkmConnection(context.Background(), nil)
+	require.Error(t, err)
+	var respErr *azcore.ResponseError
+	require.ErrorAs(t, err, &respErr)
+	require.Equal(t, http.StatusNotFound, respErr.StatusCode)
+}
+
+func TestGetEkmCertificate_Mock(t *testing.T) {
+	srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer closeSrv()
+	srv.SetResponse(
+		mock.WithStatusCode(http.StatusOK),
+		mock.WithBody([]byte(mockEKMCertificateBody)),
+	)
+
+	client := newMockClient(t, srv)
+	res, err := client.GetEkmCertificate(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, res.SubjectCommonName)
+	require.Equal(t, "CN=hsm-client", *res.SubjectCommonName)
+	require.Len(t, res.CaCertificates, 1)
+}
+
+func TestGetEkmCertificate_MockError(t *testing.T) {
+	srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer closeSrv()
+	srv.SetResponse(
+		mock.WithStatusCode(http.StatusForbidden),
+		mock.WithBody([]byte(`{"error":{"code":"Forbidden","message":"no permission"}}`)),
+	)
+
+	client := newMockClient(t, srv)
+	_, err := client.GetEkmCertificate(context.Background(), nil)
+	require.Error(t, err)
+	var respErr *azcore.ResponseError
+	require.ErrorAs(t, err, &respErr)
+	require.Equal(t, http.StatusForbidden, respErr.StatusCode)
+}
+
+func TestCheckEkmConnection_Mock(t *testing.T) {
+	srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer closeSrv()
+	srv.SetResponse(
+		mock.WithStatusCode(http.StatusOK),
+		mock.WithBody([]byte(mockEKMProxyInfoBody)),
+	)
+
+	client := newMockClient(t, srv)
+	res, err := client.CheckEkmConnection(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, res.APIVersion)
+	require.Equal(t, "1.0", *res.APIVersion)
+	require.NotNil(t, res.EkmVendor)
+	require.Equal(t, "Contoso", *res.EkmVendor)
+	require.NotNil(t, res.EkmProduct)
+	require.NotNil(t, res.ProxyVendor)
+	require.NotNil(t, res.ProxyName)
+}
+
+func TestCheckEkmConnection_MockError(t *testing.T) {
+	srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+	defer closeSrv()
+	srv.SetResponse(
+		mock.WithStatusCode(http.StatusBadGateway),
+		mock.WithBody([]byte(`{"error":{"code":"BadGateway","message":"proxy unreachable"}}`)),
+	)
+
+	client := newMockClient(t, srv)
+	_, err := client.CheckEkmConnection(context.Background(), nil)
+	require.Error(t, err)
+	var respErr *azcore.ResponseError
+	require.ErrorAs(t, err, &respErr)
+	require.Equal(t, http.StatusBadGateway, respErr.StatusCode)
+}
+
+// TestEkmRequestRouting asserts that each operation makes the right HTTP
+// method/path/api-version combination. It uses an inspector transport rather
+// than per-test predicates because the challenge auth policy may issue a
+// body-less probe before the real request, and the request shape we care
+// about (method + path + query) is preserved across both.
+func TestEkmRequestRouting(t *testing.T) {
+	type call struct {
+		method string
+		path   string
+	}
+	for _, tc := range []struct {
+		name   string
+		invoke func(t *testing.T, c *ekm.KeyVaultClient)
+		want   call
+		body   string
+	}{
+		{
+			name: "CheckEkmConnection",
+			invoke: func(t *testing.T, c *ekm.KeyVaultClient) {
+				_, err := c.CheckEkmConnection(context.Background(), nil)
+				require.NoError(t, err)
+			},
+			want: call{http.MethodPost, "/ekm/check"},
+			body: mockEKMProxyInfoBody,
+		},
+		{
+			name: "CreateEkmConnection",
+			invoke: func(t *testing.T, c *ekm.KeyVaultClient) {
+				_, err := c.CreateEkmConnection(context.Background(), sampleConnection(), nil)
+				require.NoError(t, err)
+			},
+			want: call{http.MethodPost, "/ekm/create"},
+			body: mockEKMConnectionBody,
+		},
+		{
+			name: "DeleteEkmConnection",
+			invoke: func(t *testing.T, c *ekm.KeyVaultClient) {
+				_, err := c.DeleteEkmConnection(context.Background(), nil)
+				require.NoError(t, err)
+			},
+			want: call{http.MethodDelete, "/ekm"},
+			body: mockEKMConnectionBody,
+		},
+		{
+			name: "GetEkmCertificate",
+			invoke: func(t *testing.T, c *ekm.KeyVaultClient) {
+				_, err := c.GetEkmCertificate(context.Background(), nil)
+				require.NoError(t, err)
+			},
+			want: call{http.MethodGet, "/ekm/certificate"},
+			body: mockEKMCertificateBody,
+		},
+		{
+			name: "GetEkmConnection",
+			invoke: func(t *testing.T, c *ekm.KeyVaultClient) {
+				_, err := c.GetEkmConnection(context.Background(), nil)
+				require.NoError(t, err)
+			},
+			want: call{http.MethodGet, "/ekm"},
+			body: mockEKMConnectionBody,
+		},
+		{
+			name: "UpdateEkmConnection",
+			invoke: func(t *testing.T, c *ekm.KeyVaultClient) {
+				_, err := c.UpdateEkmConnection(context.Background(), sampleConnection(), nil)
+				require.NoError(t, err)
+			},
+			want: call{http.MethodPatch, "/ekm"},
+			body: mockEKMConnectionBody,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, closeSrv := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
+			defer closeSrv()
+			var got call
+			var apiVersion string
+			srv.AppendResponse(
+				mock.WithStatusCode(http.StatusOK),
+				mock.WithBody([]byte(tc.body)),
+				mock.WithPredicate(func(req *http.Request) bool {
+					got.method = req.Method
+					got.path = req.URL.Path
+					apiVersion = req.URL.Query().Get("api-version")
+					return true
+				}),
+			)
+			srv.AppendResponse(
+				mock.WithStatusCode(http.StatusOK),
+				mock.WithBody([]byte(tc.body)),
+			)
+
+			client := newMockClient(t, srv)
+			tc.invoke(t, client)
+			require.Equal(t, tc.want.method, got.method)
+			require.Equal(t, tc.want.path, got.path)
+			require.NotEmpty(t, apiVersion, "api-version query parameter should be set")
+		})
+	}
+}

--- a/sdk/security/keyvault/azadmin/ekm/utils_test.go
+++ b/sdk/security/keyvault/azadmin/ekm/utils_test.go
@@ -124,6 +124,14 @@ func startRecording(t *testing.T) {
 }
 
 func startEKMTest(t *testing.T) *ekm.KeyVaultClient {
+	// EKM tests require an external key manager proxy reachable from the
+	// Managed HSM. CI doesn't provision one, so live runs are skipped unless
+	// EKM_PROXY_HOST is supplied. Recording runs still execute (so recordings
+	// can be refreshed against an environment that does have a real proxy)
+	// and playback runs always execute against the recordings.
+	if recording.GetRecordMode() == recording.LiveMode && os.Getenv("EKM_PROXY_HOST") == "" {
+		t.Skip("skipping live EKM test: set EKM_PROXY_HOST to run against a real EKM proxy")
+	}
 	startRecording(t)
 	transport, err := recording.NewRecordingHTTPClient(t, nil)
 	require.NoError(t, err)

--- a/sdk/security/keyvault/azkeys/assets.json
+++ b/sdk/security/keyvault/azkeys/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/security/keyvault/azkeys",
-  "Tag": "go/security/keyvault/azkeys_ff983e62e3"
+  "Tag": "go/security/keyvault/azkeys_79ee35f2c3"
 }

--- a/sdk/security/keyvault/azkeys/assets.json
+++ b/sdk/security/keyvault/azkeys/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/security/keyvault/azkeys",
-  "Tag": "go/security/keyvault/azkeys_79ee35f2c3"
+  "Tag": "go/security/keyvault/azkeys_1065a79558"
 }

--- a/sdk/security/keyvault/azkeys/client_test.go
+++ b/sdk/security/keyvault/azkeys/client_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -824,6 +825,15 @@ func TestSecureWrapUnwrap(t *testing.T) {
 }
 
 func TestExternalKeyReference(t *testing.T) {
+	// External-key creation requires a working EKM connection on the HSM
+	// pointed at an EKM proxy that exposes the key named by EKM_EXTERNAL_ID.
+	// CI doesn't provision that, so live runs are skipped unless the env var
+	// is supplied. Recording runs still execute (so recordings can be
+	// refreshed against an environment that does have a real proxy) and
+	// playback runs always execute against the recordings.
+	if recording.GetRecordMode() == recording.LiveMode && os.Getenv("EKM_EXTERNAL_ID") == "" {
+		t.Skip("skipping live external-key test: set EKM_EXTERNAL_ID to run against a real EKM proxy")
+	}
 	keyClient := startTest(t, false)
 
 	localKeyName := "ekm-external-key-test"

--- a/sdk/security/keyvault/azkeys/client_test.go
+++ b/sdk/security/keyvault/azkeys/client_test.go
@@ -852,19 +852,8 @@ func TestExternalKeyReference(t *testing.T) {
 	}
 
 	created, err := keyClient.CreateKey(ctx, localKeyName, params, nil)
-	if err != nil {
-		// The most common failure is that no EKM connection is configured on
-		// the HSM, in which case the service returns a 4xx. Surface that as a
-		// skip — including in playback, where the recording may legitimately
-		// have captured that 4xx — so the wire contract test still runs without
-		// requiring a fully provisioned EKM proxy.
-		var httpErr *azcore.ResponseError
-		if errors.As(err, &httpErr) {
-			t.Skipf("CreateKey failed (HTTP %d, %s); is an EKM connection configured on the HSM?",
-				httpErr.StatusCode, httpErr.ErrorCode)
-		}
-		require.NoError(t, err)
-	}
+	require.NoError(t, err)
+
 	t.Cleanup(func() {
 		_, _ = keyClient.DeleteKey(context.Background(), localKeyName, nil)
 	})

--- a/sdk/security/keyvault/azkeys/client_test.go
+++ b/sdk/security/keyvault/azkeys/client_test.go
@@ -834,7 +834,7 @@ func TestExternalKeyReference(t *testing.T) {
 	if recording.GetRecordMode() == recording.LiveMode && os.Getenv("EKM_EXTERNAL_ID") == "" {
 		t.Skip("skipping live external-key test: set EKM_EXTERNAL_ID to run against a real EKM proxy")
 	}
-	keyClient := startTest(t, false)
+	keyClient := startTest(t, true)
 
 	localKeyName := "ekm-external-key-test"
 	ctx := context.Background()

--- a/sdk/security/keyvault/azkeys/client_test.go
+++ b/sdk/security/keyvault/azkeys/client_test.go
@@ -836,12 +836,8 @@ func TestExternalKeyReference(t *testing.T) {
 	}
 	keyClient := startTest(t, true)
 
-	localKeyName := "ekm-external-key-test"
+	localKeyName := createRandomName(t, "ekm-external-key-test")
 	ctx := context.Background()
-
-	// Best-effort cleanup of a prior run. Run this in playback too so the
-	// corresponding entry in the recording is consumed in lockstep.
-	_, _ = keyClient.DeleteKey(ctx, localKeyName, nil)
 
 	// ExternalKey and Kty are mutually exclusive on CreateKey: the key material
 	// lives at the EKM proxy, so the Key Vault never picks its own key type.
@@ -855,7 +851,15 @@ func TestExternalKeyReference(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		_, _ = keyClient.DeleteKey(context.Background(), localKeyName, nil)
+		_, err = keyClient.DeleteKey(context.Background(), localKeyName, nil)
+		require.NoError(t, err)
+		pollStatus(t, 404, func() error {
+			_, err := keyClient.GetDeletedKey(context.Background(), localKeyName, nil)
+			return err
+		})
+
+		_, err = keyClient.PurgeDeletedKey(context.Background(), localKeyName, nil)
+		require.NoError(t, err)
 	})
 
 	require.NotNil(t, created.Attributes, "expected attributes on created key")

--- a/sdk/security/keyvault/azkeys/utils_test.go
+++ b/sdk/security/keyvault/azkeys/utils_test.go
@@ -79,6 +79,19 @@ func run(m *testing.M) int {
 	externalKeyID = recording.GetEnvVariable("EKM_EXTERNAL_ID", fakeExternalKeyID)
 	enableHSM = mhsmURL != fakeHsmURL
 
+	if recording.GetRecordMode() != recording.LiveMode {
+		// AZSDK3430 sanitizes every JSON $..id field to "Sanitized", which would
+		// overwrite legitimate id values the tests assert on (for example the
+		// external-key id on KeyAttributes.ExternalKey). Other Key Vault modules
+		// disable it for the same reason.
+		err := recording.RemoveRegisteredSanitizers([]string{
+			"AZSDK3430", // id in body
+		}, nil)
+		if err != nil {
+			panic(err)
+		}
+	}
+
 	if recording.GetRecordMode() == recording.RecordingMode {
 		for _, path := range []string{"$.error.message", "$.key.kid", "$.recoveryId"} {
 			err := recording.AddBodyKeySanitizer(path, fakeVaultURL, vaultURL, nil)


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

When live tests are being run, and an EKM host is unavailable, the live tests are skipped, resulting in lower coverage.
This commit introduced a test against a fake client, restoring the coverage to its intended value, even when EKM is unavailable.

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
