### PR TITLE
Disable InitialIssueTriage so agentic issue-triage workflow can run

### DIFF
--- a/.github/event-processor.config
+++ b/.github/event-processor.config
@@ -1,5 +1,5 @@
 {
-  "InitialIssueTriage": "On",
+  "InitialIssueTriage": "Off",
   "ManualIssueTriage": "On",
   "ServiceAttention": "On",
   "ManualTriageAfterExternalAssignment": "On",


### PR DESCRIPTION
## Why

The legacy InitialIssueTriage rule in `Azure.Sdk.Tools.GitHubEventProcessor` (invoked from `.github/workflows/event-processor.yml` on `issues.opened`) calls the AI label service and auto-adds Category/Service labels (e.g. `Client`, `Azure.Identity`) plus `needs-team-attention` before the new agentic `.github/workflows/issue-triage.md` workflow runs.

Because `issue-triage.md` has a Step 1 precondition that exits when `the issue already has labels`, the agentic workflow short-circuits and never gets to:

- predict the correct Category (e.g. `Mgmt` for `sdk/resourcemanager/...` issues) + Service label pair, or
- perform CODEOWNERS-based owner routing and post its analysis comment.

## What

Flip `InitialIssueTriage` from `On` to `Off` in `.github/event-processor.config`. All other event-processor rules (stale handling, IssueAddressed, PR rules, etc.) remain unchanged. The agentic `issue-triage.md` workflow then owns initial triage of newly opened issues.

## References

- Rule implementation: https://github.com/Azure/azure-sdk-tools/blob/main/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/EventProcessing/IssueProcessing.cs
- Agentic workflow: `.github/workflows/issue-triage.md`
