### PR TITLE
Bump armmonitorworkspaces to v1.0.0 for GA release

### DIFF
--- a/sdk/resourcemanager/monitor/armmonitorworkspaces/CHANGELOG.md
+++ b/sdk/resourcemanager/monitor/armmonitorworkspaces/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0 (2026-06-12)
+
+### Other Changes
+
+- General availability of the `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitorworkspaces` package.
+
 ## 0.1.0 (2026-05-20)
 ### Other Changes
 

--- a/sdk/resourcemanager/monitor/armmonitorworkspaces/version.go
+++ b/sdk/resourcemanager/monitor/armmonitorworkspaces/version.go
@@ -6,5 +6,5 @@ package armmonitorworkspaces
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitorworkspaces"
-	moduleVersion = "v0.1.0"
+	moduleVersion = "v1.0.0"
 )


### PR DESCRIPTION
This PR bumps the Azure Monitor Workspaces Go SDK from v0.1.0 to v1.0.0 for the GA release.

## Changes
- Updated moduleVersion in version.go from v0.1.0 to v1.0.0
- Added 1.0.0 GA release entry in CHANGELOG.md

## Release Plan
Work Item: 34968
Dashboard: https://azsdk-releaseplan-dashboard-hveph5aqhhcfhtgu.westus-01.azurewebsites.net/?releaseplan=34968
## Release Plan Details
- Release Plan: https://azsdk-releaseplan-dashboard-hveph5aqhhcfhtgu.westus-01.azurewebsites.net/?releaseplan=34968
- Work Item Link: https://dev.azure.com/azure-sdk/fe81d705-3c06-41e5-bf7c-5ebea18efe89/_workitems/edit/34968
- Spec Pull Request: 
- Spec API version: 