### PR TITLE
Support token type in bearer auth policy

### DIFF
--- a/sdk/azcore/internal/exported/exported.go
+++ b/sdk/azcore/internal/exported/exported.go
@@ -51,6 +51,9 @@ type AccessToken struct {
 	// RefreshOn is a suggested time to refresh the token.
 	// Clients should ignore this value when it's zero.
 	RefreshOn time.Time
+	// TokenType is the token type used in the Authorization header.
+	// Clients should treat an empty value as "Bearer".
+	TokenType string
 }
 
 // TokenRequestOptions contain specific parameter that may be used by credentials types when attempting to get a token.

--- a/sdk/azcore/runtime/policy_bearer_token.go
+++ b/sdk/azcore/runtime/policy_bearer_token.go
@@ -101,7 +101,11 @@ func (b *BearerTokenPolicy) authenticateAndAuthorize(req *policy.Request) func(p
 			// retrying authentication, the credential would have done so already
 			return errorinfo.NonRetriableError(err)
 		}
-		req.Raw().Header.Set(shared.HeaderAuthorization, shared.BearerTokenPrefix+tk.Token)
+		tokenType := tk.TokenType
+		if tokenType == "" {
+			tokenType = strings.TrimSpace(shared.BearerTokenPrefix)
+		}
+		req.Raw().Header.Set(shared.HeaderAuthorization, tokenType+" "+tk.Token)
 		return nil
 	}
 }

--- a/sdk/azcore/runtime/policy_bearer_token_test.go
+++ b/sdk/azcore/runtime/policy_bearer_token_test.go
@@ -80,6 +80,30 @@ func TestBearerPolicy_SuccessGetToken(t *testing.T) {
 	}
 }
 
+func TestBearerPolicy_SuccessGetPoPToken(t *testing.T) {
+	srv, close := mock.NewTLSServer()
+	defer close()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK))
+	popCredential := mockCredential{
+		getTokenImpl: func(ctx context.Context, options policy.TokenRequestOptions) (exported.AccessToken, error) {
+			return exported.AccessToken{Token: tokenValue, ExpiresOn: time.Now().Add(time.Hour), TokenType: "PoP"}, nil
+		},
+	}
+	b := NewBearerTokenPolicy(popCredential, []string{scope}, nil)
+	pipeline := NewPipeline(
+		"testmodule",
+		"v0.1.0",
+		PipelineOptions{PerRetry: []policy.Policy{b}},
+		&policy.ClientOptions{Transport: srv},
+	)
+	req, err := NewRequest(context.Background(), http.MethodGet, srv.URL())
+	require.NoError(t, err)
+
+	resp, err := pipeline.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, "PoP "+tokenValue, resp.Request.Header.Get(shared.HeaderAuthorization))
+}
+
 func TestBearerPolicy_CredentialFailGetToken(t *testing.T) {
 	srv, close := mock.NewTLSServer()
 	defer close()


### PR DESCRIPTION
Adds an optional AccessToken TokenType field and updates BearerTokenPolicy to use it when setting the Authorization header. This is a Core prerequisite for PoP/MSI token binding flows while preserving Bearer as the default.\n\nValidation:\n- go test ./runtime -run 'TestBearerPolicy_SuccessGet(Token|PoPToken)$'