### PR TITLE
Export ShareNFSSettings and ShareNFSSettingsEncryptionInTransit in azfile

### DIFF
--- a/sdk/storage/azfile/CHANGELOG.md
+++ b/sdk/storage/azfile/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.8.0-beta.1 (Unreleased)
 
 ### Features Added
+* Exported `ShareNFSSettings` and `ShareNFSSettingsEncryptionInTransit` types.
 
 ### Breaking Changes
 

--- a/sdk/storage/azfile/service/models.go
+++ b/sdk/storage/azfile/service/models.go
@@ -121,6 +121,12 @@ type SMBSettings = generated.SMBSettings
 // SMBMultichannel - Settings for SMB multichannel
 type SMBMultichannel = generated.SMBMultichannel
 
+// ShareNFSSettings - Settings for NFS protocol.
+type ShareNFSSettings = generated.ShareNFSSettings
+
+// ShareNFSSettingsEncryptionInTransit - Enable or disable encryption in transit.
+type ShareNFSSettingsEncryptionInTransit = generated.ShareNFSSettingsEncryptionInTransit
+
 // ---------------------------------------------------------------------------------------------------------------------
 
 // ListSharesOptions contains the optional parameters for the Client.NewListSharesPager method.


### PR DESCRIPTION
Fixes #26816

### What this does

`service.ProtocolSettings` is public and has an `NFS` field of type `*ShareNFSSettings`. But `ShareNFSSettings` (and the `ShareNFSSettingsEncryptionInTransit` type it holds) were never exported from the package, so there was no way to actually read or build that field from outside the SDK.

This adds the two missing type aliases, the same way the SMB settings types are already exported right next to them.

### Changes

- `sdk/storage/azfile/service/models.go`: add public aliases for `ShareNFSSettings` and `ShareNFSSettingsEncryptionInTransit`.
- `sdk/storage/azfile/CHANGELOG.md`: note the new exported types under the unreleased version.

### Notes

- No behavior change — these are type aliases to existing generated types.
- The doc comment uses "Settings for NFS protocol" (the generated type's own comment says "SMB" by mistake).

---

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
- [ ] Tests are included and/or updated for code changes. (No new tests — this only exports existing types and adds no behavior. Existing `service` tests pass.)
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.
