### PR TITLE
azdatalake: fix GetProperties panic on directory-derived clients

### DIFF
--- a/sdk/storage/azdatalake/CHANGELOG.md
+++ b/sdk/storage/azdatalake/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Fixed a panic in `GetProperties` (and `DownloadStream`) for file and directory clients created via `directory.NewFileClient`/`directory.NewSubdirectoryClient`. These clients did not capture the raw HTTP response, so reading the datalake-specific headers dereferenced a nil response. Fixes [#25490](https://github.com/Azure/azure-sdk-for-go/issues/25490).
 
 ### Other Changes
 * Updated code generator to `@autorest/go@4.0.0-preview.80`.

--- a/sdk/storage/azdatalake/directory/client.go
+++ b/sdk/storage/azdatalake/directory/client.go
@@ -212,6 +212,10 @@ func (d *Client) NewFileClient(fileName string) (*file.Client, error) {
 	newBlobURL, fileURL := shared.GetURLs(fileURL)
 	var newBlobClient *blockblob.Client
 	clientOptions := &blockblob.ClientOptions{ClientOptions: d.getClientOptions().ClientOptions}
+	// The blob client built here must capture the raw response so that file.GetProperties
+	// can read the datalake-specific headers (owner, group, permissions). Without this the
+	// captured response is nil and GetProperties panics. See issue #25490.
+	clientOptions.PerCallPolicies = append([]policy.Policy{shared.NewIncludeBlobResponsePolicy()}, clientOptions.PerCallPolicies...)
 	var err error
 	if d.identityCredential() != nil {
 		newBlobClient, err = blockblob.NewClient(newBlobURL, *d.identityCredential(), clientOptions)
@@ -235,6 +239,10 @@ func (d *Client) NewSubdirectoryClient(subdirectoryName string) (*Client, error)
 	newBlobURL, subDirectoryURL := shared.GetURLs(subDirectoryURL)
 	var newBlobClient *blockblob.Client
 	clientOptions := &blockblob.ClientOptions{ClientOptions: d.getClientOptions().ClientOptions}
+	// The blob client built here must capture the raw response so that GetProperties can read
+	// the datalake-specific headers (owner, group, permissions). Without this the captured
+	// response is nil and GetProperties panics. See issue #25490.
+	clientOptions.PerCallPolicies = append([]policy.Policy{shared.NewIncludeBlobResponsePolicy()}, clientOptions.PerCallPolicies...)
 	var err error
 	if d.identityCredential() != nil {
 		newBlobClient, err = blockblob.NewClient(newBlobURL, *d.identityCredential(), clientOptions)

--- a/sdk/storage/azdatalake/file/responses.go
+++ b/sdk/storage/azdatalake/file/responses.go
@@ -242,11 +242,15 @@ func FormatDownloadStreamResponse(r *blob.DownloadStreamResponse, rawResponse *h
 		newResp.Version = r.Version
 		newResp.VersionID = r.VersionID
 	}
-	if val := rawResponse.Header.Get("x-ms-encryption-context"); val != "" {
-		newResp.EncryptionContext = &val
-	}
-	if val := rawResponse.Header.Get("x-ms-acl"); val != "" {
-		newResp.AccessControlList = &val
+	// rawResponse is only populated when the IncludeBlobResponsePolicy captured it.
+	// Guard against nil so the datalake-specific headers below never panic.
+	if rawResponse != nil {
+		if val := rawResponse.Header.Get("x-ms-encryption-context"); val != "" {
+			newResp.EncryptionContext = &val
+		}
+		if val := rawResponse.Header.Get("x-ms-acl"); val != "" {
+			newResp.AccessControlList = &val
+		}
 	}
 	return newResp
 }

--- a/sdk/storage/azdatalake/file/responses_test.go
+++ b/sdk/storage/azdatalake/file/responses_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package file
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/stretchr/testify/require"
+)
+
+// FormatDownloadStreamResponse must not panic when the raw HTTP response was not
+// captured (rawResponse is nil). This mirrors the guard tested for
+// FormatGetPropertiesResponse. See issue #25490.
+func TestFormatDownloadStreamResponseNilRawResponse(t *testing.T) {
+	require.NotPanics(t, func() {
+		resp := FormatDownloadStreamResponse(&blob.DownloadStreamResponse{}, nil)
+		// The datalake-specific fields come from the raw response, so they stay nil.
+		require.Nil(t, resp.AccessControlList)
+		require.Nil(t, resp.EncryptionContext)
+	})
+}
+
+// When the raw HTTP response is present, the datalake-specific headers are read.
+func TestFormatDownloadStreamResponseWithRawResponse(t *testing.T) {
+	rawResponse := &http.Response{Header: http.Header{}}
+	rawResponse.Header.Set("x-ms-acl", "user::rwx,group::r-x,other::---")
+	rawResponse.Header.Set("x-ms-encryption-context", "context1")
+
+	resp := FormatDownloadStreamResponse(&blob.DownloadStreamResponse{}, rawResponse)
+	require.NotNil(t, resp.AccessControlList)
+	require.Equal(t, "user::rwx,group::r-x,other::---", *resp.AccessControlList)
+	require.NotNil(t, resp.EncryptionContext)
+	require.Equal(t, "context1", *resp.EncryptionContext)
+}

--- a/sdk/storage/azdatalake/internal/path/responses.go
+++ b/sdk/storage/azdatalake/internal/path/responses.go
@@ -287,23 +287,27 @@ func FormatGetPropertiesResponse(r *blob.GetPropertiesResponse, rawResponse *htt
 	newResp.TagCount = r.TagCount
 	newResp.Version = r.Version
 	newResp.VersionID = r.VersionID
-	if val := rawResponse.Header.Get("x-ms-owner"); val != "" {
-		newResp.Owner = &val
-	}
-	if val := rawResponse.Header.Get("x-ms-group"); val != "" {
-		newResp.Group = &val
-	}
-	if val := rawResponse.Header.Get("x-ms-permissions"); val != "" {
-		newResp.Permissions = &val
-	}
-	if val := rawResponse.Header.Get("x-ms-acl"); val != "" {
-		newResp.AccessControlList = &val
-	}
-	if val := rawResponse.Header.Get("x-ms-resource-type"); val != "" {
-		newResp.ResourceType = &val
-	}
-	if val := rawResponse.Header.Get("x-ms-encryption-context"); val != "" {
-		newResp.EncryptionContext = &val
+	// rawResponse is only populated when the IncludeBlobResponsePolicy captured it.
+	// Guard against nil so the datalake-specific headers below never panic.
+	if rawResponse != nil {
+		if val := rawResponse.Header.Get("x-ms-owner"); val != "" {
+			newResp.Owner = &val
+		}
+		if val := rawResponse.Header.Get("x-ms-group"); val != "" {
+			newResp.Group = &val
+		}
+		if val := rawResponse.Header.Get("x-ms-permissions"); val != "" {
+			newResp.Permissions = &val
+		}
+		if val := rawResponse.Header.Get("x-ms-acl"); val != "" {
+			newResp.AccessControlList = &val
+		}
+		if val := rawResponse.Header.Get("x-ms-resource-type"); val != "" {
+			newResp.ResourceType = &val
+		}
+		if val := rawResponse.Header.Get("x-ms-encryption-context"); val != "" {
+			newResp.EncryptionContext = &val
+		}
 	}
 	return newResp
 }

--- a/sdk/storage/azdatalake/internal/path/responses_test.go
+++ b/sdk/storage/azdatalake/internal/path/responses_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package path
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/stretchr/testify/require"
+)
+
+// FormatGetPropertiesResponse must not panic when the raw HTTP response was not
+// captured (rawResponse is nil). This happens for clients whose pipeline does not
+// include the IncludeBlobResponsePolicy. See issue #25490.
+func TestFormatGetPropertiesResponseNilRawResponse(t *testing.T) {
+	require.NotPanics(t, func() {
+		resp := FormatGetPropertiesResponse(&blob.GetPropertiesResponse{}, nil)
+		// The datalake-specific fields come from the raw response, so they stay nil.
+		require.Nil(t, resp.Owner)
+		require.Nil(t, resp.Group)
+		require.Nil(t, resp.Permissions)
+		require.Nil(t, resp.AccessControlList)
+		require.Nil(t, resp.ResourceType)
+	})
+}
+
+// When the raw HTTP response is present, the datalake-specific headers are read.
+func TestFormatGetPropertiesResponseWithRawResponse(t *testing.T) {
+	rawResponse := &http.Response{Header: http.Header{}}
+	rawResponse.Header.Set("x-ms-owner", "owner1")
+	rawResponse.Header.Set("x-ms-group", "group1")
+	rawResponse.Header.Set("x-ms-permissions", "rwxr-x---")
+	rawResponse.Header.Set("x-ms-resource-type", "file")
+
+	resp := FormatGetPropertiesResponse(&blob.GetPropertiesResponse{}, rawResponse)
+	require.Equal(t, "owner1", *resp.Owner)
+	require.Equal(t, "group1", *resp.Group)
+	require.Equal(t, "rwxr-x---", *resp.Permissions)
+	require.Equal(t, "file", *resp.ResourceType)
+}


### PR DESCRIPTION
Fixes #25490

### What was happening

Calling `GetProperties` on a file client crashed with a nil pointer panic — but only when the file actually existed. A missing file returned an error first, so it never hit the crash.

The cause: file and directory clients created through `directory.NewFileClient` or `directory.NewSubdirectoryClient` build their underlying blob client without the include-blob-response policy. That policy is what captures the raw HTTP response. Without it the captured response is `nil`, and when `GetProperties` (and `DownloadStream`) tries to read the Data Lake headers (owner, group, permissions) off that response, it dereferences `nil` and panics.

Clients made with the top-level `file.NewClient` already register this policy, which is why they worked fine.

### The fix

- Register the include-blob-response policy in `directory.NewFileClient` and `directory.NewSubdirectoryClient`, the same way `file.NewClient` already does. This both stops the panic and makes the owner/group/permission fields come back as intended.
- Guard the response helpers (`FormatGetPropertiesResponse` and `FormatDownloadStreamResponse`) so a nil raw response can never panic again.

### Tests

Added unit tests for the formatting helper: one confirming it no longer panics on a nil response, one confirming the Data Lake headers are read when the response is present. The full live test suite needs an Azure Data Lake account, so I couldn't run that part locally.

---

- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.
