### PR TITLE
Fix the context propagation to the azure servicebus token credential provider

### DIFF
--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs Fixed
 
 - Fixed missing `consumers.Delete()` call when checkpoint initialization fails, which could block future consumer creation for the affected partition. (#24983)
+- Propagate the caller's `context.Context` through to the underlying `azcore.TokenCredential.GetToken` call instead of using `context.TODO()`. Credentials that rely on the context (for cancellation, deadlines, or values used to fetch the token) now behave correctly during authentication.
 
 ## 2.0.2 (2026-03-10)
 

--- a/sdk/messaging/azeventhubs/internal/auth/token.go
+++ b/sdk/messaging/azeventhubs/internal/auth/token.go
@@ -4,6 +4,8 @@
 // Package auth provides an abstraction over claims-based security for Azure Event Hub and Service Bus.
 package auth
 
+import "context"
+
 const (
 	// CBSTokenTypeJWT is the type of token to be used for JWTs. For example Azure Active Directory tokens.
 	CBSTokenTypeJWT TokenType = "jwt"
@@ -25,7 +27,7 @@ type (
 
 	// TokenProvider abstracts the fetching of authentication tokens
 	TokenProvider interface {
-		GetToken(uri string) (*Token, error)
+		GetToken(ctx context.Context, uri string) (*Token, error)
 	}
 )
 

--- a/sdk/messaging/azeventhubs/internal/cbs.go
+++ b/sdk/messaging/azeventhubs/internal/cbs.go
@@ -51,7 +51,7 @@ func NegotiateClaim(ctx context.Context, audience string, conn amqpwrap.AMQPClie
 		return origErr
 	}
 
-	token, err := provider.GetToken(audience)
+	token, err := provider.GetToken(ctx, audience)
 	if err != nil {
 		azlog.Writef(exported.EventAuth, "Failed to get token from provider: %s", err)
 		return closeLink(ctx, err)

--- a/sdk/messaging/azeventhubs/internal/cbs_test.go
+++ b/sdk/messaging/azeventhubs/internal/cbs_test.go
@@ -31,7 +31,7 @@ func TestNegotiateClaimWithCloseTimeout(t *testing.T) {
 			client.EXPECT().NewSession(test.NotCancelled, gomock.Any()).Return(session, nil)
 			session.EXPECT().NewReceiver(test.NotCancelled, gomock.Any(), gomock.Any(), gomock.Any()).Return(receiver, nil)
 			session.EXPECT().NewSender(test.NotCancelled, gomock.Any(), gomock.Any(), gomock.Any()).Return(sender, nil)
-			tp.EXPECT().GetToken(gomock.Any()).Return(&auth.Token{}, nil)
+			tp.EXPECT().GetToken(gomock.Any(), gomock.Any()).Return(&auth.Token{}, nil)
 
 			mock.SetupRPC(sender, receiver, 1, func(sent, response *amqp.Message) {
 				response.ApplicationProperties = map[string]any{
@@ -76,7 +76,7 @@ func TestNegotiateClaimWithAuthFailure(t *testing.T) {
 	session.EXPECT().Close(test.NotCancelled)
 	session.EXPECT().ConnID().Return(uint64(101))
 
-	tp.EXPECT().GetToken(gomock.Any()).Return(&auth.Token{}, nil)
+	tp.EXPECT().GetToken(gomock.Any(), gomock.Any()).Return(&auth.Token{}, nil)
 
 	mock.SetupRPC(sender, receiver, 1, func(sent, response *amqp.Message) {
 		// this is the kind of error you get if your connection string is inconsistent
@@ -112,7 +112,7 @@ func TestNegotiateClaimSuccess(t *testing.T) {
 	client.EXPECT().NewSession(test.NotCancelled, gomock.Any()).Return(session, nil)
 	session.EXPECT().NewReceiver(test.NotCancelled, gomock.Any(), gomock.Any(), gomock.Any()).Return(receiver, nil)
 	session.EXPECT().NewSender(test.NotCancelled, gomock.Any(), gomock.Any(), gomock.Any()).Return(sender, nil)
-	tp.EXPECT().GetToken(gomock.Any()).Return(&auth.Token{}, nil)
+	tp.EXPECT().GetToken(gomock.Any(), gomock.Any()).Return(&auth.Token{}, nil)
 
 	session.EXPECT().Close(test.NotCancelled)
 

--- a/sdk/messaging/azeventhubs/internal/links_test.go
+++ b/sdk/messaging/azeventhubs/internal/links_test.go
@@ -243,7 +243,7 @@ func TestLinksManagementRetry(t *testing.T) {
 	getEventHubProps := func(ctx context.Context, lwid LinkWithID[amqpwrap.RPCLink]) error {
 		called++
 		// mostly lifted from mgmt.go/getEventHubProperties
-		token, err := ns.GetTokenForEntity(testParams.EventHubName)
+		token, err := ns.GetTokenForEntity(ctx, testParams.EventHubName)
 
 		if err != nil {
 			return err

--- a/sdk/messaging/azeventhubs/internal/mock/mock_token.go
+++ b/sdk/messaging/azeventhubs/internal/mock/mock_token.go
@@ -7,6 +7,7 @@
 package mock
 
 import (
+	context "context"
 	reflect "reflect"
 
 	auth "github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2/internal/auth"
@@ -37,16 +38,16 @@ func (m *MockTokenProvider) EXPECT() *MockTokenProviderMockRecorder {
 }
 
 // GetToken mocks base method.
-func (m *MockTokenProvider) GetToken(uri string) (*auth.Token, error) {
+func (m *MockTokenProvider) GetToken(ctx context.Context, uri string) (*auth.Token, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetToken", uri)
+	ret := m.ctrl.Call(m, "GetToken", ctx, uri)
 	ret0, _ := ret[0].(*auth.Token)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetToken indicates an expected call of GetToken.
-func (mr *MockTokenProviderMockRecorder) GetToken(uri interface{}) *gomock.Call {
+func (mr *MockTokenProviderMockRecorder) GetToken(ctx, uri interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToken", reflect.TypeOf((*MockTokenProvider)(nil).GetToken), uri)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToken", reflect.TypeOf((*MockTokenProvider)(nil).GetToken), ctx, uri)
 }

--- a/sdk/messaging/azeventhubs/internal/namespace.go
+++ b/sdk/messaging/azeventhubs/internal/namespace.go
@@ -334,7 +334,7 @@ func (ns *Namespace) startNegotiateClaimRenewer(ctx context.Context,
 			return time.Time{}, err
 		}
 
-		token, expiration, err := ns.TokenProvider.GetTokenAsTokenProvider(audience)
+		token, expiration, err := ns.TokenProvider.GetTokenAsTokenProvider(ctx, audience)
 
 		if err != nil {
 			log.Writef(exported.EventAuth, "(%s) negotiate claim, failed getting token: %s", entityPath, err.Error())

--- a/sdk/messaging/azeventhubs/internal/namespace_eh.go
+++ b/sdk/messaging/azeventhubs/internal/namespace_eh.go
@@ -37,14 +37,14 @@ func (ns *Namespace) NewRPCLink(ctx context.Context, managementPath string) (amq
 	return rpcLink, connID, nil
 }
 
-func (ns *Namespace) GetTokenForEntity(eventHub string) (*auth.Token, error) {
+func (ns *Namespace) GetTokenForEntity(ctx context.Context, eventHub string) (*auth.Token, error) {
 	audience := ns.GetEntityAudience(eventHub)
-	return ns.TokenProvider.GetToken(audience)
+	return ns.TokenProvider.GetToken(ctx, audience)
 }
 
 type NamespaceForManagementOps interface {
 	NamespaceForAMQPLinks
-	GetTokenForEntity(eventHub string) (*auth.Token, error)
+	GetTokenForEntity(ctx context.Context, eventHub string) (*auth.Token, error)
 }
 
 // TODO: might just consolidate.

--- a/sdk/messaging/azeventhubs/internal/sas/sas.go
+++ b/sdk/messaging/azeventhubs/internal/sas/sas.go
@@ -7,6 +7,7 @@
 package sas
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
@@ -86,7 +87,7 @@ func NewTokenProvider(opts ...TokenProviderOption) (*TokenProvider, error) {
 }
 
 // GetToken gets a CBS SAS token
-func (t *TokenProvider) GetToken(audience string) (*auth.Token, error) {
+func (t *TokenProvider) GetToken(ctx context.Context, audience string) (*auth.Token, error) {
 	if t.sas != "" {
 		// the expiration date doesn't matter here so we'll just set it 0.
 		return auth.NewToken(auth.CBSTokenTypeSAS, t.sas, "0"), nil

--- a/sdk/messaging/azeventhubs/internal/sas/sas_test.go
+++ b/sdk/messaging/azeventhubs/internal/sas/sas_test.go
@@ -3,6 +3,7 @@
 package sas
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -53,7 +54,7 @@ func TestTokenProviderWithSAS(t *testing.T) {
 	tp, err := NewTokenProvider(TokenProviderWithSAS("hello"))
 	require.NoError(t, err)
 
-	token, err := tp.GetToken("audience")
+	token, err := tp.GetToken(context.Background(), "audience")
 	require.NoError(t, err)
 
 	require.Equal(t, &auth.Token{
@@ -75,7 +76,7 @@ func TestTokenProviderWithKey(t *testing.T) {
 		return now
 	}
 
-	token, err := tp.GetToken("audience")
+	token, err := tp.GetToken(context.Background(), "audience")
 	require.NoError(t, err)
 
 	require.Equal(t, &auth.Token{

--- a/sdk/messaging/azeventhubs/internal/sbauth/token_provider.go
+++ b/sdk/messaging/azeventhubs/internal/sbauth/token_provider.go
@@ -61,21 +61,21 @@ type singleUseTokenProvider auth.Token
 
 // GetToken will return this token.
 // This function makes us compatible with auth.TokenProvider.
-func (tp *singleUseTokenProvider) GetToken(uri string) (*auth.Token, error) {
+func (tp *singleUseTokenProvider) GetToken(ctx context.Context, uri string) (*auth.Token, error) {
 	return (*auth.Token)(tp), nil
 }
 
 // GetToken will retrieve a new token.
 // This function makes us compatible with auth.TokenProvider.
-func (tp *TokenProvider) GetToken(uri string) (*auth.Token, error) {
-	token, _, err := tp.getTokenImpl(uri)
+func (tp *TokenProvider) GetToken(ctx context.Context, uri string) (*auth.Token, error) {
+	token, _, err := tp.getTokenImpl(ctx, uri)
 	return token, err
 }
 
 // GetToken returns a token (that is compatible as an auth.TokenProvider) and
 // the calculated time when you should renew your token.
-func (tp *TokenProvider) GetTokenAsTokenProvider(uri string) (*singleUseTokenProvider, time.Time, error) {
-	token, renewAt, err := tp.getTokenImpl(uri)
+func (tp *TokenProvider) GetTokenAsTokenProvider(ctx context.Context, uri string) (*singleUseTokenProvider, time.Time, error) {
+	token, renewAt, err := tp.getTokenImpl(ctx, uri)
 
 	if err != nil {
 		return nil, time.Time{}, err
@@ -84,17 +84,17 @@ func (tp *TokenProvider) GetTokenAsTokenProvider(uri string) (*singleUseTokenPro
 	return (*singleUseTokenProvider)(token), renewAt, nil
 }
 
-func (tp *TokenProvider) getTokenImpl(uri string) (*auth.Token, time.Time, error) {
+func (tp *TokenProvider) getTokenImpl(ctx context.Context, uri string) (*auth.Token, time.Time, error) {
 	if tp.sasTokenProvider != nil {
-		return tp.getSASToken(uri)
+		return tp.getSASToken(ctx, uri)
 	} else {
-		return tp.getAZCoreToken()
+		return tp.getAZCoreToken(ctx)
 	}
 }
 
-func (tpa *TokenProvider) getAZCoreToken() (*auth.Token, time.Time, error) {
+func (tpa *TokenProvider) getAZCoreToken(ctx context.Context) (*auth.Token, time.Time, error) {
 	// not sure if URI plays in here.
-	accessToken, err := tpa.tokenCred.GetToken(context.TODO(), policy.TokenRequestOptions{
+	accessToken, err := tpa.tokenCred.GetToken(ctx, policy.TokenRequestOptions{
 		Scopes: []string{
 			"https://eventhubs.azure.net//.default",
 		},
@@ -115,8 +115,8 @@ func (tpa *TokenProvider) getAZCoreToken() (*auth.Token, time.Time, error) {
 		nil
 }
 
-func (tpa *TokenProvider) getSASToken(uri string) (*auth.Token, time.Time, error) {
-	authToken, err := tpa.sasTokenProvider.GetToken(uri)
+func (tpa *TokenProvider) getSASToken(ctx context.Context, uri string) (*auth.Token, time.Time, error) {
+	authToken, err := tpa.sasTokenProvider.GetToken(ctx, uri)
 
 	if err != nil {
 		return nil, time.Time{}, err

--- a/sdk/messaging/azeventhubs/mgmt.go
+++ b/sdk/messaging/azeventhubs/mgmt.go
@@ -56,7 +56,7 @@ func getEventHubProperties[LinkT internal.AMQPLink](ctx context.Context, eventNa
 }
 
 func getEventHubPropertiesInternal(ctx context.Context, ns internal.NamespaceForManagementOps, rpcLink amqpwrap.RPCLink, eventHub string, options *GetEventHubPropertiesOptions) (EventHubProperties, error) {
-	token, err := ns.GetTokenForEntity(eventHub)
+	token, err := ns.GetTokenForEntity(ctx, eventHub)
 
 	if err != nil {
 		return EventHubProperties{}, internal.TransformError(err)
@@ -132,7 +132,7 @@ func getPartitionProperties[LinkT internal.AMQPLink](ctx context.Context, eventN
 }
 
 func getPartitionPropertiesInternal(ctx context.Context, ns internal.NamespaceForManagementOps, rpcLink amqpwrap.RPCLink, eventHub string, partitionID string, options *GetPartitionPropertiesOptions) (PartitionProperties, error) {
-	token, err := ns.GetTokenForEntity(eventHub)
+	token, err := ns.GetTokenForEntity(ctx, eventHub)
 
 	if err != nil {
 		return PartitionProperties{}, err

--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Read `com.microsoft:max-message-batch-size` vendor property from the AMQP sender link to correctly limit batch size on Premium large-message entities, where `max-message-size` can be up to 100 MB but the batch limit is 1 MB.
+- Propagate the caller's `context.Context` through to the underlying `azcore.TokenCredential.GetToken` call instead of using `context.TODO()`. Credentials that rely on the context (for cancellation, deadlines, or values used to fetch the token) now behave correctly during authentication.
 
 ### Other Changes
 

--- a/sdk/messaging/azservicebus/internal/atom/per_retry_auth_policy.go
+++ b/sdk/messaging/azservicebus/internal/atom/per_retry_auth_policy.go
@@ -44,7 +44,7 @@ func (p *perRetryAuthPolicy) Do(req *policy.Request) (*http.Response, error) {
 }
 
 func (p *perRetryAuthPolicy) AddTokenHeader(headerName string, req *http.Request, targetURI string) error {
-	signature, err := p.tp.GetToken(targetURI)
+	signature, err := p.tp.GetToken(req.Context(), targetURI)
 
 	if err != nil {
 		return err

--- a/sdk/messaging/azservicebus/internal/auth/token.go
+++ b/sdk/messaging/azservicebus/internal/auth/token.go
@@ -4,6 +4,8 @@
 // Package auth provides an abstraction over claims-based security for Azure Event Hub and Service Bus.
 package auth
 
+import "context"
+
 const (
 	// CBSTokenTypeJWT is the type of token to be used for JWTs. For example Azure Active Directory tokens.
 	CBSTokenTypeJWT TokenType = "jwt"
@@ -25,7 +27,7 @@ type (
 
 	// TokenProvider abstracts the fetching of authentication tokens
 	TokenProvider interface {
-		GetToken(uri string) (*Token, error)
+		GetToken(ctx context.Context, uri string) (*Token, error)
 	}
 )
 

--- a/sdk/messaging/azservicebus/internal/cbs.go
+++ b/sdk/messaging/azservicebus/internal/cbs.go
@@ -51,7 +51,7 @@ func NegotiateClaim(ctx context.Context, audience string, conn amqpwrap.AMQPClie
 		return origErr
 	}
 
-	token, err := provider.GetToken(audience)
+	token, err := provider.GetToken(ctx, audience)
 	if err != nil {
 		azlog.Writef(exported.EventAuth, "Failed to get token from provider: %s", err)
 		return closeLink(ctx, err)

--- a/sdk/messaging/azservicebus/internal/mock/mock_token.go
+++ b/sdk/messaging/azservicebus/internal/mock/mock_token.go
@@ -7,6 +7,7 @@
 package mock
 
 import (
+	context "context"
 	reflect "reflect"
 
 	auth "github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/auth"
@@ -37,16 +38,16 @@ func (m *MockTokenProvider) EXPECT() *MockTokenProviderMockRecorder {
 }
 
 // GetToken mocks base method.
-func (m *MockTokenProvider) GetToken(uri string) (*auth.Token, error) {
+func (m *MockTokenProvider) GetToken(ctx context.Context, uri string) (*auth.Token, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetToken", uri)
+	ret := m.ctrl.Call(m, "GetToken", ctx, uri)
 	ret0, _ := ret[0].(*auth.Token)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetToken indicates an expected call of GetToken.
-func (mr *MockTokenProviderMockRecorder) GetToken(uri interface{}) *gomock.Call {
+func (mr *MockTokenProviderMockRecorder) GetToken(ctx, uri interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToken", reflect.TypeOf((*MockTokenProvider)(nil).GetToken), uri)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToken", reflect.TypeOf((*MockTokenProvider)(nil).GetToken), ctx, uri)
 }

--- a/sdk/messaging/azservicebus/internal/namespace.go
+++ b/sdk/messaging/azservicebus/internal/namespace.go
@@ -365,7 +365,7 @@ func (ns *Namespace) startNegotiateClaimRenewer(ctx context.Context,
 			return time.Time{}, err
 		}
 
-		token, expiration, err := ns.TokenProvider.GetTokenAsTokenProvider(audience)
+		token, expiration, err := ns.TokenProvider.GetTokenAsTokenProvider(ctx, audience)
 
 		if err != nil {
 			log.Writef(exported.EventAuth, "(%s) negotiate claim, failed getting token: %s", entityPath, err.Error())

--- a/sdk/messaging/azservicebus/internal/sas/sas.go
+++ b/sdk/messaging/azservicebus/internal/sas/sas.go
@@ -7,6 +7,7 @@
 package sas
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
@@ -86,7 +87,7 @@ func NewTokenProvider(opts ...TokenProviderOption) (*TokenProvider, error) {
 }
 
 // GetToken gets a CBS SAS token
-func (t *TokenProvider) GetToken(audience string) (*auth.Token, error) {
+func (t *TokenProvider) GetToken(ctx context.Context, audience string) (*auth.Token, error) {
 	if t.sas != "" {
 		return auth.NewToken(auth.CBSTokenTypeSAS, t.sas, "0"), nil
 	}

--- a/sdk/messaging/azservicebus/internal/sas/sas_test.go
+++ b/sdk/messaging/azservicebus/internal/sas/sas_test.go
@@ -3,6 +3,7 @@
 package sas
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -52,7 +53,7 @@ func TestTokenProviderWithSAS(t *testing.T) {
 	tp, err := NewTokenProvider(TokenProviderWithSAS("hello"))
 	require.NoError(t, err)
 
-	token, err := tp.GetToken("audience")
+	token, err := tp.GetToken(context.Background(), "audience")
 	require.NoError(t, err)
 
 	require.Equal(t, &auth.Token{
@@ -74,7 +75,7 @@ func TestTokenProviderWithKey(t *testing.T) {
 		return now
 	}
 
-	token, err := tp.GetToken("audience")
+	token, err := tp.GetToken(context.Background(), "audience")
 	require.NoError(t, err)
 
 	require.Equal(t, &auth.Token{

--- a/sdk/messaging/azservicebus/internal/sbauth/token_provider.go
+++ b/sdk/messaging/azservicebus/internal/sbauth/token_provider.go
@@ -61,21 +61,21 @@ type singleUseTokenProvider auth.Token
 
 // GetToken will return this token.
 // This function makes us compatible with auth.TokenProvider.
-func (tp *singleUseTokenProvider) GetToken(uri string) (*auth.Token, error) {
+func (tp *singleUseTokenProvider) GetToken(ctx context.Context, uri string) (*auth.Token, error) {
 	return (*auth.Token)(tp), nil
 }
 
 // GetToken will retrieve a new token.
 // This function makes us compatible with auth.TokenProvider.
-func (tp *TokenProvider) GetToken(uri string) (*auth.Token, error) {
-	token, _, err := tp.getTokenImpl(uri)
+func (tp *TokenProvider) GetToken(ctx context.Context, uri string) (*auth.Token, error) {
+	token, _, err := tp.getTokenImpl(ctx, uri)
 	return token, err
 }
 
 // GetToken returns a token (that is compatible as an auth.TokenProvider) and
 // the calculated time when you should renew your token.
-func (tp *TokenProvider) GetTokenAsTokenProvider(uri string) (*singleUseTokenProvider, time.Time, error) {
-	token, renewAt, err := tp.getTokenImpl(uri)
+func (tp *TokenProvider) GetTokenAsTokenProvider(ctx context.Context, uri string) (*singleUseTokenProvider, time.Time, error) {
+	token, renewAt, err := tp.getTokenImpl(ctx, uri)
 
 	if err != nil {
 		return nil, time.Time{}, err
@@ -84,17 +84,17 @@ func (tp *TokenProvider) GetTokenAsTokenProvider(uri string) (*singleUseTokenPro
 	return (*singleUseTokenProvider)(token), renewAt, nil
 }
 
-func (tp *TokenProvider) getTokenImpl(uri string) (*auth.Token, time.Time, error) {
+func (tp *TokenProvider) getTokenImpl(ctx context.Context, uri string) (*auth.Token, time.Time, error) {
 	if tp.sasTokenProvider != nil {
-		return tp.getSASToken(uri)
+		return tp.getSASToken(ctx, uri)
 	} else {
-		return tp.getAZCoreToken()
+		return tp.getAZCoreToken(ctx)
 	}
 }
 
-func (tpa *TokenProvider) getAZCoreToken() (*auth.Token, time.Time, error) {
+func (tpa *TokenProvider) getAZCoreToken(ctx context.Context) (*auth.Token, time.Time, error) {
 	// not sure if URI plays in here.
-	accessToken, err := tpa.tokenCred.GetToken(context.TODO(), policy.TokenRequestOptions{
+	accessToken, err := tpa.tokenCred.GetToken(ctx, policy.TokenRequestOptions{
 		Scopes: []string{
 			"https://servicebus.azure.net//.default",
 		},
@@ -115,8 +115,8 @@ func (tpa *TokenProvider) getAZCoreToken() (*auth.Token, time.Time, error) {
 		nil
 }
 
-func (tpa *TokenProvider) getSASToken(uri string) (*auth.Token, time.Time, error) {
-	authToken, err := tpa.sasTokenProvider.GetToken(uri)
+func (tpa *TokenProvider) getSASToken(ctx context.Context, uri string) (*auth.Token, time.Time, error) {
+	authToken, err := tpa.sasTokenProvider.GetToken(ctx, uri)
 
 	if err != nil {
 		return nil, time.Time{}, err


### PR DESCRIPTION
Signed-off-by: Joni Collinge <jonathancollinge@live.com>

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

Currently the `azservicebus` package is providing a token provider interface over the `azcore` token credential implementation that does not propagate the context. The token credential provides methods such as `GetToken` that require a context and support implementations grabbing the token source from the context but the azure service bus package is just passing `context.TODO()` which causes existing auth providers to break here.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
