### PR TITLE
[Refresh] armserialconsole v2.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/serialconsole/armserialconsole/CHANGELOG.md
+++ b/sdk/resourcemanager/serialconsole/armserialconsole/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.1 (2026-05-12)
+## 2.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Function `*SerialPortsClient.Delete` has been removed
@@ -18,7 +18,6 @@
 
 - New enum type `CreatedByType` with values `CreatedByTypeApplication`, `CreatedByTypeKey`, `CreatedByTypeManagedIdentity`, `CreatedByTypeUser`
 - New enum type `SerialPortConnectionState` with values `SerialPortConnectionStateActive`, `SerialPortConnectionStateInactive`
-- New function `*MicrosoftSerialConsoleClient.NewSerialPortsClient() *SerialPortsClient`
 - New struct `DisableSerialConsoleResultProperties`
 - New struct `EnableSerialConsoleResultProperties`
 - New struct `StatusProperties`

--- a/sdk/resourcemanager/serialconsole/armserialconsole/version.go
+++ b/sdk/resourcemanager/serialconsole/armserialconsole/version.go
@@ -6,5 +6,5 @@ package armserialconsole
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/serialconsole/armserialconsole"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v2.0.0"
 )


### PR DESCRIPTION
Promote `armserialconsole` from `v2.0.0-beta.1` to stable `v2.0.0`.

- Spec API version `Microsoft.SerialConsole=2024-07-01` is GA/stable.
- Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable` (computed against previous stable `v1.2.0`).

Part of the beta-to-stable refresh effort.