### PR TITLE
[Refresh] armattestation v2.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/attestation/armattestation/CHANGELOG.md
+++ b/sdk/resourcemanager/attestation/armattestation/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.1 (2026-03-19)
+## 2.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Operation `*OperationsClient.List` has supported pagination, use `*OperationsClient.NewListPager` instead.

--- a/sdk/resourcemanager/attestation/armattestation/version.go
+++ b/sdk/resourcemanager/attestation/armattestation/version.go
@@ -6,5 +6,5 @@ package armattestation
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/attestation/armattestation"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v2.0.0"
 )


### PR DESCRIPTION
Promote `armattestation` to stable `v2.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.