### PR TITLE
[Refresh] armautomation v1.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/automation/armautomation/CHANGELOG.md
+++ b/sdk/resourcemanager/automation/armautomation/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0 (2026-06-24)
 ### Other Changes
 
+- General availability of the `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/automation/armautomation` package.
 
 ## 0.10.0 (2026-05-22)
 ### Breaking Changes

--- a/sdk/resourcemanager/automation/armautomation/CHANGELOG.md
+++ b/sdk/resourcemanager/automation/armautomation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.0.0 (2026-06-24)
+### Other Changes
+
+
 ## 0.10.0 (2026-05-22)
 ### Breaking Changes
 

--- a/sdk/resourcemanager/automation/armautomation/version.go
+++ b/sdk/resourcemanager/automation/armautomation/version.go
@@ -6,5 +6,5 @@ package armautomation
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/automation/armautomation"
-	moduleVersion = "v0.10.0"
+	moduleVersion = "v1.0.0"
 )


### PR DESCRIPTION
Promote `armautomation` to stable `v1.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.