### PR TITLE
[Refresh] armbilling v2.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/billing/armbilling/CHANGELOG.md
+++ b/sdk/resourcemanager/billing/armbilling/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.1 (2026-05-14)
+## 2.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Struct `EnrollmentDetails` has been removed

--- a/sdk/resourcemanager/billing/armbilling/version.go
+++ b/sdk/resourcemanager/billing/armbilling/version.go
@@ -6,5 +6,5 @@ package armbilling
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/billing/armbilling"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v2.0.0"
 )


### PR DESCRIPTION
Promote `armbilling` to stable `v2.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.