### PR TITLE
[Refresh] armcdn v3.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/cdn/armcdn/CHANGELOG.md
+++ b/sdk/resourcemanager/cdn/armcdn/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 3.0.0-beta.1 (2026-05-18)
+## 3.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Type of `CacheExpirationActionParameters.TypeName` has been changed from `*CacheExpirationActionParametersTypeName` to `*DeliveryRuleActionParametersType`

--- a/sdk/resourcemanager/cdn/armcdn/version.go
+++ b/sdk/resourcemanager/cdn/armcdn/version.go
@@ -6,5 +6,5 @@ package armcdn
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cdn/armcdn"
-	moduleVersion = "v3.0.0-beta.1"
+	moduleVersion = "v3.0.0"
 )


### PR DESCRIPTION
Promote `armcdn` to stable `v3.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.