### PR TITLE
[Refresh] armcertificateregistration v1.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/certificateregistration/armcertificateregistration/CHANGELOG.md
+++ b/sdk/resourcemanager/certificateregistration/armcertificateregistration/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0 (2026-06-24)
 ### Other Changes
 
+- General availability of the `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/certificateregistration/armcertificateregistration` package.
 
 ## 0.1.0 (2026-02-13)
 ### Other Changes

--- a/sdk/resourcemanager/certificateregistration/armcertificateregistration/CHANGELOG.md
+++ b/sdk/resourcemanager/certificateregistration/armcertificateregistration/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.0.0 (2026-06-24)
+### Other Changes
+
+
 ## 0.1.0 (2026-02-13)
 ### Other Changes
 

--- a/sdk/resourcemanager/certificateregistration/armcertificateregistration/version.go
+++ b/sdk/resourcemanager/certificateregistration/armcertificateregistration/version.go
@@ -6,5 +6,5 @@ package armcertificateregistration
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/certificateregistration/armcertificateregistration"
-	moduleVersion = "v0.1.0"
+	moduleVersion = "v1.0.0"
 )


### PR DESCRIPTION
Promote `armcertificateregistration` to stable `v1.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.