### PR TITLE
[Refresh] armcommunication v3.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/communication/armcommunication/CHANGELOG.md
+++ b/sdk/resourcemanager/communication/armcommunication/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 3.0.0-beta.1 (2026-03-11)
+## 3.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Struct `CheckNameAvailabilityRequest` has been removed

--- a/sdk/resourcemanager/communication/armcommunication/version.go
+++ b/sdk/resourcemanager/communication/armcommunication/version.go
@@ -6,5 +6,5 @@ package armcommunication
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/communication/armcommunication"
-	moduleVersion = "v3.0.0-beta.1"
+	moduleVersion = "v3.0.0"
 )


### PR DESCRIPTION
Promote `armcommunication` to stable `v3.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.