### PR TITLE
[Refresh] armconsumption v2.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/consumption/armconsumption/CHANGELOG.md
+++ b/sdk/resourcemanager/consumption/armconsumption/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.1 (2026-03-19)
+## 2.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Type of `ModernReservationRecommendation.Properties` has been changed from `*ModernReservationRecommendationProperties` to `ModernReservationRecommendationPropertiesClassification`

--- a/sdk/resourcemanager/consumption/armconsumption/version.go
+++ b/sdk/resourcemanager/consumption/armconsumption/version.go
@@ -6,5 +6,5 @@ package armconsumption
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v2.0.0"
 )


### PR DESCRIPTION
Promote `armconsumption` to stable `v2.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.