### PR TITLE
[Refresh] armcostmanagement v3.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/costmanagement/armcostmanagement/CHANGELOG.md
+++ b/sdk/resourcemanager/costmanagement/armcostmanagement/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 3.0.0-beta.1 (2026-05-14)
+## 3.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Type of `Alert.ETag` has been changed from `*string` to `*azcore.ETag`

--- a/sdk/resourcemanager/costmanagement/armcostmanagement/version.go
+++ b/sdk/resourcemanager/costmanagement/armcostmanagement/version.go
@@ -6,5 +6,5 @@ package armcostmanagement
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/costmanagement/armcostmanagement"
-	moduleVersion = "v3.0.0-beta.1"
+	moduleVersion = "v3.0.0"
 )


### PR DESCRIPTION
Promote `armcostmanagement` to stable `v3.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.