### PR TITLE
[Refresh] armdataboundaries v1.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/databoundaries/armdataboundaries/CHANGELOG.md
+++ b/sdk/resourcemanager/databoundaries/armdataboundaries/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
 ## 1.0.0 (2026-06-24)
+
 ### Other Changes
 
+- General availability of the `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databoundaries/armdataboundaries` package.
 
 ## 0.2.0 (2026-05-20)
 ### Features Added

--- a/sdk/resourcemanager/databoundaries/armdataboundaries/CHANGELOG.md
+++ b/sdk/resourcemanager/databoundaries/armdataboundaries/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.0.0 (2026-06-24)
+### Other Changes
+
+
 ## 0.2.0 (2026-05-20)
 ### Features Added
 

--- a/sdk/resourcemanager/databoundaries/armdataboundaries/version.go
+++ b/sdk/resourcemanager/databoundaries/armdataboundaries/version.go
@@ -6,5 +6,5 @@ package armdataboundaries
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databoundaries/armdataboundaries"
-	moduleVersion = "v0.2.0"
+	moduleVersion = "v1.0.0"
 )


### PR DESCRIPTION
Promote `armdataboundaries` to stable `v1.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.