### PR TITLE
[Refresh] armdatabox v3.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/databox/armdatabox/CHANGELOG.md
+++ b/sdk/resourcemanager/databox/armdatabox/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 3.0.0-beta.1 (2026-05-25)
+## 3.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Type of `AdditionalErrorInfo.Info` has been changed from `any` to `map[string]any`

--- a/sdk/resourcemanager/databox/armdatabox/version.go
+++ b/sdk/resourcemanager/databox/armdatabox/version.go
@@ -6,5 +6,5 @@ package armdatabox
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databox/armdatabox"
-	moduleVersion = "v3.0.0-beta.1"
+	moduleVersion = "v3.0.0"
 )


### PR DESCRIPTION
Promote `armdatabox` to stable `v3.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.