### PR TITLE
[Refresh] armdataboxedge v2.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/databoxedge/armdataboxedge/CHANGELOG.md
+++ b/sdk/resourcemanager/databoxedge/armdataboxedge/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.1 (2026-05-19)
+## 2.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Struct `ARMBaseModel` has been removed

--- a/sdk/resourcemanager/databoxedge/armdataboxedge/version.go
+++ b/sdk/resourcemanager/databoxedge/armdataboxedge/version.go
@@ -6,5 +6,5 @@ package armdataboxedge
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databoxedge/armdataboxedge"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v2.0.0"
 )


### PR DESCRIPTION
Promote `armdataboxedge` to stable `v2.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.