### PR TITLE
[Refresh] armdatabricks v2.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/databricks/armdatabricks/CHANGELOG.md
+++ b/sdk/resourcemanager/databricks/armdatabricks/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.1 (2026-05-20)
+## 2.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Type of `WorkspaceCustomParameters.EnableNoPublicIP` has been changed from `*WorkspaceCustomBooleanParameter` to `*WorkspaceNoPublicIPBooleanParameter`

--- a/sdk/resourcemanager/databricks/armdatabricks/version.go
+++ b/sdk/resourcemanager/databricks/armdatabricks/version.go
@@ -6,5 +6,5 @@ package armdatabricks
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v2.0.0"
 )


### PR DESCRIPTION
Promote `armdatabricks` to stable `v2.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.