### PR TITLE
[Refresh] armdatafactory v11.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/datafactory/armdatafactory/CHANGELOG.md
+++ b/sdk/resourcemanager/datafactory/armdatafactory/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 11.0.0-beta.1 (2026-03-23)
+## 11.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Type of `JiraObjectDataset.TypeProperties` has been changed from `*GenericDatasetTypeProperties` to `*JiraTableDatasetTypeProperties`

--- a/sdk/resourcemanager/datafactory/armdatafactory/version.go
+++ b/sdk/resourcemanager/datafactory/armdatafactory/version.go
@@ -6,5 +6,5 @@ package armdatafactory
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory"
-	moduleVersion = "v11.0.0-beta.1"
+	moduleVersion = "v11.0.0"
 )


### PR DESCRIPTION
Promote `armdatafactory` to stable `v11.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.