### PR TITLE
[Refresh] armdataprotection v4.1.0 (stable)

### DIFF
--- a/sdk/resourcemanager/dataprotection/armdataprotection/CHANGELOG.md
+++ b/sdk/resourcemanager/dataprotection/armdataprotection/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.1.0-beta.1 (2026-04-01)
+## 4.1.0 (2026-06-24)
 ### Features Added
 
 - New enum type `BlobBackupPatternType` with values `BlobBackupPatternTypePrefix`

--- a/sdk/resourcemanager/dataprotection/armdataprotection/version.go
+++ b/sdk/resourcemanager/dataprotection/armdataprotection/version.go
@@ -6,5 +6,5 @@ package armdataprotection
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dataprotection/armdataprotection"
-	moduleVersion = "v4.1.0-beta.1"
+	moduleVersion = "v4.1.0"
 )


### PR DESCRIPTION
Promote `armdataprotection` to stable `v4.1.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.