### PR TITLE
[Refresh] armdomainregistration v1.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/domainregistration/armdomainregistration/CHANGELOG.md
+++ b/sdk/resourcemanager/domainregistration/armdomainregistration/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Release History
 
 ## 1.0.0 (2026-06-24)
+
 ### Other Changes
+
+- General availability of the `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/domainregistration/armdomainregistration` package.
 
 
 ## 0.1.0 (2026-02-14)

--- a/sdk/resourcemanager/domainregistration/armdomainregistration/CHANGELOG.md
+++ b/sdk/resourcemanager/domainregistration/armdomainregistration/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.0.0 (2026-06-24)
+### Other Changes
+
+
 ## 0.1.0 (2026-02-14)
 ### Other Changes
 

--- a/sdk/resourcemanager/domainregistration/armdomainregistration/version.go
+++ b/sdk/resourcemanager/domainregistration/armdomainregistration/version.go
@@ -6,5 +6,5 @@ package armdomainregistration
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/domainregistration/armdomainregistration"
-	moduleVersion = "v0.1.0"
+	moduleVersion = "v1.0.0"
 )


### PR DESCRIPTION
Promote `armdomainregistration` to stable `v1.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.