### PR TITLE
[Refresh] armdynatrace v2.2.0 (stable)

### DIFF
--- a/sdk/resourcemanager/dynatrace/armdynatrace/CHANGELOG.md
+++ b/sdk/resourcemanager/dynatrace/armdynatrace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.2.0-beta.1 (2026-03-19)
+## 2.2.0 (2026-06-24)
 ### Features Added
 
 - New value `MarketplaceSubscriptionStatusUnsubscribed` added to enum type `MarketplaceSubscriptionStatus`

--- a/sdk/resourcemanager/dynatrace/armdynatrace/version.go
+++ b/sdk/resourcemanager/dynatrace/armdynatrace/version.go
@@ -6,5 +6,5 @@ package armdynatrace
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dynatrace/armdynatrace"
-	moduleVersion = "v2.2.0-beta.1"
+	moduleVersion = "v2.2.0"
 )


### PR DESCRIPTION
Promote `armdynatrace` to stable `v2.2.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.