### PR TITLE
[Refresh] armedgeorder v2.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/edgeorder/armedgeorder/CHANGELOG.md
+++ b/sdk/resourcemanager/edgeorder/armedgeorder/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.1 (2026-03-19)
+## 2.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Function `*ClientFactory.NewManagementClient` has been removed

--- a/sdk/resourcemanager/edgeorder/armedgeorder/version.go
+++ b/sdk/resourcemanager/edgeorder/armedgeorder/version.go
@@ -6,5 +6,5 @@ package armedgeorder
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/edgeorder/armedgeorder"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v2.0.0"
 )


### PR DESCRIPTION
Promote `armedgeorder` to stable `v2.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.