### PR TITLE
[Refresh] armelastic v3.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/elastic/armelastic/CHANGELOG.md
+++ b/sdk/resourcemanager/elastic/armelastic/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 3.0.0-beta.1 (2026-03-16)
+## 3.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Function `*MonitoredSubscriptionsClient.BeginCreateorUpdate` parameter(s) have been changed from `(ctx context.Context, resourceGroupName string, monitorName string, configurationName string, options *MonitoredSubscriptionsClientBeginCreateorUpdateOptions)` to `(ctx context.Context, resourceGroupName string, monitorName string, configurationName string, body MonitoredSubscriptionProperties, options *MonitoredSubscriptionsClientBeginCreateorUpdateOptions)`

--- a/sdk/resourcemanager/elastic/armelastic/version.go
+++ b/sdk/resourcemanager/elastic/armelastic/version.go
@@ -15,5 +15,5 @@ package armelastic
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/elastic/armelastic"
-	moduleVersion = "v3.0.0-beta.1"
+	moduleVersion = "v3.0.0"
 )


### PR DESCRIPTION
Promote `armelastic` to stable `v3.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.