### PR TITLE
[Refresh] armfrontdoor v2.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/frontdoor/armfrontdoor/CHANGELOG.md
+++ b/sdk/resourcemanager/frontdoor/armfrontdoor/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.1 (2026-03-09)
+## 2.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Enum `NetworkOperationStatus` has been removed

--- a/sdk/resourcemanager/frontdoor/armfrontdoor/version.go
+++ b/sdk/resourcemanager/frontdoor/armfrontdoor/version.go
@@ -6,5 +6,5 @@ package armfrontdoor
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v2.0.0"
 )


### PR DESCRIPTION
Promote `armfrontdoor` to stable `v2.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.