### PR TITLE
[Refresh] armguestconfiguration v2.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/guestconfiguration/armguestconfiguration/CHANGELOG.md
+++ b/sdk/resourcemanager/guestconfiguration/armguestconfiguration/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.1 (2026-05-25)
+## 2.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Struct `ErrorResponse` has been removed

--- a/sdk/resourcemanager/guestconfiguration/armguestconfiguration/version.go
+++ b/sdk/resourcemanager/guestconfiguration/armguestconfiguration/version.go
@@ -6,5 +6,5 @@ package armguestconfiguration
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/guestconfiguration/armguestconfiguration"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v2.0.0"
 )


### PR DESCRIPTION
Promote `armguestconfiguration` to stable `v2.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.