### PR TITLE
[Refresh] armhardwaresecuritymodules v3.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/hardwaresecuritymodules/armhardwaresecuritymodules/CHANGELOG.md
+++ b/sdk/resourcemanager/hardwaresecuritymodules/armhardwaresecuritymodules/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 3.0.0-beta.1 (2026-03-12)
+## 3.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Operation `*CloudHsmClusterBackupStatusClient.BeginGet` has been changed to non-LRO, use `*CloudHsmClusterBackupStatusClient.Get` instead.

--- a/sdk/resourcemanager/hardwaresecuritymodules/armhardwaresecuritymodules/version.go
+++ b/sdk/resourcemanager/hardwaresecuritymodules/armhardwaresecuritymodules/version.go
@@ -6,5 +6,5 @@ package armhardwaresecuritymodules
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hardwaresecuritymodules/armhardwaresecuritymodules"
-	moduleVersion = "v3.0.0-beta.1"
+	moduleVersion = "v3.0.0"
 )


### PR DESCRIPTION
Promote `armhardwaresecuritymodules` to stable `v3.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.