### PR TITLE
[Refresh] armkusto v2.4.0 (stable)

### DIFF
--- a/sdk/resourcemanager/kusto/armkusto/CHANGELOG.md
+++ b/sdk/resourcemanager/kusto/armkusto/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.4.0-beta.1 (2026-05-20)
+## 2.4.0 (2026-06-24)
 ### Features Added
 
 - New value `DataConnectionKindEventGridWithManagedIdentity`, `DataConnectionKindEventHubWithManagedIdentity` added to enum type `DataConnectionKind`

--- a/sdk/resourcemanager/kusto/armkusto/version.go
+++ b/sdk/resourcemanager/kusto/armkusto/version.go
@@ -6,5 +6,5 @@ package armkusto
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto"
-	moduleVersion = "v2.4.0-beta.1"
+	moduleVersion = "v2.4.0"
 )


### PR DESCRIPTION
Promote `armkusto` to stable `v2.4.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.