### PR TITLE
[Refresh] armmanagementgroups v2.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/managementgroups/armmanagementgroups/CHANGELOG.md
+++ b/sdk/resourcemanager/managementgroups/armmanagementgroups/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.1 (2026-05-11)
+## 2.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Type of `Operation.Display` has been changed from `*OperationDisplayProperties` to `*OperationDisplay`

--- a/sdk/resourcemanager/managementgroups/armmanagementgroups/version.go
+++ b/sdk/resourcemanager/managementgroups/armmanagementgroups/version.go
@@ -6,5 +6,5 @@ package armmanagementgroups
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v2.0.0"
 )


### PR DESCRIPTION
Promote `armmanagementgroups` to stable `v2.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.