### PR TITLE
[Refresh] armmarketplace v2.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/marketplace/armmarketplace/CHANGELOG.md
+++ b/sdk/resourcemanager/marketplace/armmarketplace/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.1 (2026-03-09)
+## 2.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Function `*PrivateStoreClient.CreateApprovalRequest` parameter(s) have been changed from `(ctx context.Context, privateStoreID string, requestApprovalID string, options *PrivateStoreClientCreateApprovalRequestOptions)` to `(ctx context.Context, privateStoreID string, requestApprovalID string, payload RequestApprovalResource, options *PrivateStoreClientCreateApprovalRequestOptions)`

--- a/sdk/resourcemanager/marketplace/armmarketplace/version.go
+++ b/sdk/resourcemanager/marketplace/armmarketplace/version.go
@@ -6,5 +6,5 @@ package armmarketplace
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/marketplace/armmarketplace"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v2.0.0"
 )


### PR DESCRIPTION
Promote `armmarketplace` to stable `v2.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.