### PR TITLE
[Refresh] armnetwork v10.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/network/armnetwork/CHANGELOG.md
+++ b/sdk/resourcemanager/network/armnetwork/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 10.0.0-beta.1 (2026-06-10)
+## 10.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Function `*IpamPoolsClient.Update` parameter(s) have been changed from `(ctx context.Context, resourceGroupName string, networkManagerName string, poolName string, options *IpamPoolsClientUpdateOptions)` to `(ctx context.Context, resourceGroupName string, networkManagerName string, poolName string, body IpamPoolUpdate, options *IpamPoolsClientUpdateOptions)`

--- a/sdk/resourcemanager/network/armnetwork/version.go
+++ b/sdk/resourcemanager/network/armnetwork/version.go
@@ -6,5 +6,5 @@ package armnetwork
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
-	moduleVersion = "v10.0.0-beta.1"
+	moduleVersion = "v10.0.0"
 )


### PR DESCRIPTION
Promote `armnetwork` to stable `v10.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.