### PR TITLE
[Refresh] armnetworkfunction v3.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/networkfunction/armnetworkfunction/CHANGELOG.md
+++ b/sdk/resourcemanager/networkfunction/armnetworkfunction/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 3.0.0-beta.1 (2026-03-09)
+## 3.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Type of `AzureTrafficCollector.SystemData` has been changed from `*TrackedResourceSystemData` to `*SystemData`

--- a/sdk/resourcemanager/networkfunction/armnetworkfunction/version.go
+++ b/sdk/resourcemanager/networkfunction/armnetworkfunction/version.go
@@ -6,5 +6,5 @@ package armnetworkfunction
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/networkfunction/armnetworkfunction"
-	moduleVersion = "v3.0.0-beta.1"
+	moduleVersion = "v3.0.0"
 )


### PR DESCRIPTION
Promote `armnetworkfunction` to stable `v3.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.