### PR TITLE
[Refresh] armoperationalinsights v3.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/operationalinsights/armoperationalinsights/CHANGELOG.md
+++ b/sdk/resourcemanager/operationalinsights/armoperationalinsights/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 3.0.0-beta.1 (2026-05-20)
+## 3.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Type of `TableProperties.ProvisioningState` has been changed from `*ProvisioningStateEnum` to `*TableProvisioningState`

--- a/sdk/resourcemanager/operationalinsights/armoperationalinsights/version.go
+++ b/sdk/resourcemanager/operationalinsights/armoperationalinsights/version.go
@@ -6,5 +6,5 @@ package armoperationalinsights
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights"
-	moduleVersion = "v3.0.0-beta.1"
+	moduleVersion = "v3.0.0"
 )


### PR DESCRIPTION
Promote `armoperationalinsights` to stable `v3.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.