### PR TITLE
[Refresh] armpeering v2.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/peering/armpeering/CHANGELOG.md
+++ b/sdk/resourcemanager/peering/armpeering/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.1 (2026-03-19)
+## 2.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Struct `ErrorDetail` has been removed

--- a/sdk/resourcemanager/peering/armpeering/version.go
+++ b/sdk/resourcemanager/peering/armpeering/version.go
@@ -6,5 +6,5 @@ package armpeering
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/peering/armpeering"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v2.0.0"
 )


### PR DESCRIPTION
Promote `armpeering` to stable `v2.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.