### PR TITLE
[Refresh] armpowerbidedicated v2.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/powerbidedicated/armpowerbidedicated/CHANGELOG.md
+++ b/sdk/resourcemanager/powerbidedicated/armpowerbidedicated/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.1 (2026-03-16)
+## 2.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Type of `SystemData.CreatedByType` has been changed from `*IdentityType` to `*CreatedByType`

--- a/sdk/resourcemanager/powerbidedicated/armpowerbidedicated/version.go
+++ b/sdk/resourcemanager/powerbidedicated/armpowerbidedicated/version.go
@@ -6,5 +6,5 @@ package armpowerbidedicated
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/powerbidedicated/armpowerbidedicated"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v2.0.0"
 )


### PR DESCRIPTION
Promote `armpowerbidedicated` to stable `v2.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.