### PR TITLE
[Refresh] armprivatedns v2.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/privatedns/armprivatedns/CHANGELOG.md
+++ b/sdk/resourcemanager/privatedns/armprivatedns/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.1 (2026-03-16)
+## 2.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Struct `ProxyResource` has been removed

--- a/sdk/resourcemanager/privatedns/armprivatedns/version.go
+++ b/sdk/resourcemanager/privatedns/armprivatedns/version.go
@@ -6,5 +6,5 @@ package armprivatedns
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v2.0.0"
 )


### PR DESCRIPTION
Promote `armprivatedns` to stable `v2.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.