### PR TITLE
[Refresh] armproviderhub v3.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/providerhub/armproviderhub/CHANGELOG.md
+++ b/sdk/resourcemanager/providerhub/armproviderhub/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 3.0.0-beta.1 (2026-03-16)
+## 3.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Struct `CanaryTrafficRegionRolloutConfiguration` has been removed

--- a/sdk/resourcemanager/providerhub/armproviderhub/version.go
+++ b/sdk/resourcemanager/providerhub/armproviderhub/version.go
@@ -6,5 +6,5 @@ package armproviderhub
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/providerhub/armproviderhub"
-	moduleVersion = "v3.0.0-beta.1"
+	moduleVersion = "v3.0.0"
 )


### PR DESCRIPTION
Promote `armproviderhub` to stable `v3.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.