### PR TITLE
[Refresh] armrecoveryservices v3.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/recoveryservices/armrecoveryservices/CHANGELOG.md
+++ b/sdk/resourcemanager/recoveryservices/armrecoveryservices/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 3.0.0-beta.1 (2026-03-16)
+## 3.0.0 (2026-06-24)
 ### Breaking Changes
 
+- Function `*VaultExtendedInfoClient.CreateOrUpdate` parameter(s) have been changed from `(ctx context.Context, resourceGroupName string, vaultName string, resourceExtendedInfoDetails VaultExtendedInfoResource, options *VaultExtendedInfoClientCreateOrUpdateOptions)` to `(ctx context.Context, resourceGroupName string, vaultName string, resourceResourceExtendedInfoDetails VaultExtendedInfoResource, options *VaultExtendedInfoClientCreateOrUpdateOptions)`
+- Function `*VaultExtendedInfoClient.Update` parameter(s) have been changed from `(ctx context.Context, resourceGroupName string, vaultName string, resourceExtendedInfoDetails VaultExtendedInfoResource, options *VaultExtendedInfoClientUpdateOptions)` to `(ctx context.Context, resourceGroupName string, vaultName string, resourceResourceExtendedInfoDetails VaultExtendedInfoResource, options *VaultExtendedInfoClientUpdateOptions)`
 - Struct `ErrorDetail` has been removed
 - Struct `ErrorResponse` has been removed
 - Struct `PatchTrackedResource` has been removed

--- a/sdk/resourcemanager/recoveryservices/armrecoveryservices/CHANGELOG.md
+++ b/sdk/resourcemanager/recoveryservices/armrecoveryservices/CHANGELOG.md
@@ -3,8 +3,6 @@
 ## 3.0.0 (2026-06-24)
 ### Breaking Changes
 
-- Function `*VaultExtendedInfoClient.CreateOrUpdate` parameter(s) have been changed from `(ctx context.Context, resourceGroupName string, vaultName string, resourceExtendedInfoDetails VaultExtendedInfoResource, options *VaultExtendedInfoClientCreateOrUpdateOptions)` to `(ctx context.Context, resourceGroupName string, vaultName string, resourceResourceExtendedInfoDetails VaultExtendedInfoResource, options *VaultExtendedInfoClientCreateOrUpdateOptions)`
-- Function `*VaultExtendedInfoClient.Update` parameter(s) have been changed from `(ctx context.Context, resourceGroupName string, vaultName string, resourceExtendedInfoDetails VaultExtendedInfoResource, options *VaultExtendedInfoClientUpdateOptions)` to `(ctx context.Context, resourceGroupName string, vaultName string, resourceResourceExtendedInfoDetails VaultExtendedInfoResource, options *VaultExtendedInfoClientUpdateOptions)`
 - Struct `ErrorDetail` has been removed
 - Struct `ErrorResponse` has been removed
 - Struct `PatchTrackedResource` has been removed

--- a/sdk/resourcemanager/recoveryservices/armrecoveryservices/version.go
+++ b/sdk/resourcemanager/recoveryservices/armrecoveryservices/version.go
@@ -6,5 +6,5 @@ package armrecoveryservices
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices"
-	moduleVersion = "v3.0.0-beta.1"
+	moduleVersion = "v3.0.0"
 )


### PR DESCRIPTION
Promote `armrecoveryservices` to stable `v3.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.