### PR TITLE
[Refresh] armrecoveryservicessiterecovery v3.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/recoveryservices/armrecoveryservicessiterecovery/CHANGELOG.md
+++ b/sdk/resourcemanager/recoveryservices/armrecoveryservicessiterecovery/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 3.0.0-beta.1 (2026-03-09)
+## 3.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Struct `ApplianceQueryParameter` has been removed

--- a/sdk/resourcemanager/recoveryservices/armrecoveryservicessiterecovery/version.go
+++ b/sdk/resourcemanager/recoveryservices/armrecoveryservicessiterecovery/version.go
@@ -6,5 +6,5 @@ package armrecoveryservicessiterecovery
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicessiterecovery"
-	moduleVersion = "v3.0.0-beta.1"
+	moduleVersion = "v3.0.0"
 )


### PR DESCRIPTION
Promote `armrecoveryservicessiterecovery` to stable `v3.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.