### PR TITLE
[Refresh] armredis v4.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/redis/armredis/CHANGELOG.md
+++ b/sdk/resourcemanager/redis/armredis/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.0.0-beta.1 (2026-03-16)
+## 4.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Type of `OperationStatus.PercentComplete` has been changed from `*float32` to `*float64`

--- a/sdk/resourcemanager/redis/armredis/version.go
+++ b/sdk/resourcemanager/redis/armredis/version.go
@@ -6,5 +6,5 @@ package armredis
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis"
-	moduleVersion = "v4.0.0-beta.1"
+	moduleVersion = "v4.0.0"
 )


### PR DESCRIPTION
Promote `armredis` to stable `v4.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.