### PR TITLE
[Refresh] armrelay v2.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/relay/armrelay/CHANGELOG.md
+++ b/sdk/resourcemanager/relay/armrelay/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.1 (2026-03-19)
+## 2.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Type of `Operation.Origin` has been changed from `*string` to `*Origin`

--- a/sdk/resourcemanager/relay/armrelay/version.go
+++ b/sdk/resourcemanager/relay/armrelay/version.go
@@ -6,5 +6,5 @@ package armrelay
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/relay/armrelay"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v2.0.0"
 )


### PR DESCRIPTION
Promote `armrelay` to stable `v2.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.