### PR TITLE
[Refresh] armreservations v4.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/reservations/armreservations/CHANGELOG.md
+++ b/sdk/resourcemanager/reservations/armreservations/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.0.0-beta.1 (2026-05-20)
+## 4.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Enum `DisplayProvisioningState` has been removed

--- a/sdk/resourcemanager/reservations/armreservations/version.go
+++ b/sdk/resourcemanager/reservations/armreservations/version.go
@@ -6,5 +6,5 @@ package armreservations
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations"
-	moduleVersion = "v4.0.0-beta.1"
+	moduleVersion = "v4.0.0"
 )


### PR DESCRIPTION
Promote `armreservations` to stable `v4.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.