### PR TITLE
[Refresh] armresourcehealth v1.4.0 (stable)

### DIFF
--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/CHANGELOG.md
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 1.4.0 (2026-06-24)
+### Features Added
+
+- New value `EventTypeValuesBilling` added to enum type `EventTypeValues`
+- New enum type `EventSubTypeValues` with values `EventSubTypeValuesForeignExchangeRateChange`, `EventSubTypeValuesMeterIDChanges`, `EventSubTypeValuesOverbilling`, `EventSubTypeValuesPriceChanges`, `EventSubTypeValuesRetirement`, `EventSubTypeValuesTaxChanges`, `EventSubTypeValuesUnauthorizedPartyAbuse`, `EventSubTypeValuesUnderbilling`
+- New function `*EventClient.FetchBilllingCommunicationDetailsBySubscriptionIDAndTrackingID(ctx context.Context, eventTrackingID string, options *EventClientFetchBilllingCommunicationDetailsBySubscriptionIDAndTrackingIDOptions) (EventClientFetchBilllingCommunicationDetailsBySubscriptionIDAndTrackingIDResponse, error)`
+- New field `BillingID`, `CurrencyType`, `EventSubType`, `EventTags`, `IsEventSensitive`, `NewRate`, `OldRate` in struct `EventProperties`
+- New field `ImpactedServiceGUID` in struct `Impact`
+- New field `PreviousID`, `Priority`, `ServiceGUID` in struct `MetadataSupportedValueDetail`
+- New field `EventTags` in struct `Update`
+
+
 ## 2.0.0-beta.1 (2026-05-20)
 ### Breaking Changes
 
@@ -15,19 +27,6 @@
 - New field `ImpactedServiceGUID` in struct `Impact`
 - New field `PreviousID`, `Priority`, `ServiceGUID` in struct `MetadataSupportedValueDetail`
 - New field `EventTags` in struct `Update`
-
-
-## 1.4.0-beta.2 (2024-02-07)
-### Bugs Fixed
-
-- Unmarshal time values in ISO8601 format.
-
-## 1.4.0-beta.1 (2023-11-30)
-### Features Added
-
-- New enum type `EventSubTypeValues` with values `EventSubTypeValuesRetirement`
-- New field `MaintenanceEndTime`, `MaintenanceStartTime`, `ResourceGroup`, `ResourceName`, `Status` in struct `EventImpactedResourceProperties`
-- New field `ArgQuery`, `EventSubType`, `MaintenanceID`, `MaintenanceType` in struct `EventProperties`
 
 
 ## 1.3.0 (2023-11-30)

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/version.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/version.go
@@ -6,5 +6,5 @@ package armresourcehealth
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v1.4.0"
 )


### PR DESCRIPTION
Promote `armresourcehealth` to stable `v1.4.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.