### PR TITLE
[Refresh] armdeployments v2.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/resources/armdeployments/CHANGELOG.md
+++ b/sdk/resourcemanager/resources/armdeployments/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.1 (2026-05-20)
+## 2.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Struct `DeploymentExtendedFilter` has been removed

--- a/sdk/resourcemanager/resources/armdeployments/version.go
+++ b/sdk/resourcemanager/resources/armdeployments/version.go
@@ -6,5 +6,5 @@ package armdeployments
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v2.0.0"
 )


### PR DESCRIPTION
Promote `armdeployments` to stable `v2.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.