### PR TITLE
[Refresh] armresources v4.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/resources/armresources/CHANGELOG.md
+++ b/sdk/resourcemanager/resources/armresources/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.0.0-beta.1 (2026-05-20)
+## 4.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Struct `GenericResourceFilter` has been removed

--- a/sdk/resourcemanager/resources/armresources/version.go
+++ b/sdk/resourcemanager/resources/armresources/version.go
@@ -6,5 +6,5 @@ package armresources
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
-	moduleVersion = "v4.0.0-beta.1"
+	moduleVersion = "v4.0.0"
 )


### PR DESCRIPTION
Promote `armresources` to stable `v4.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.