### PR TITLE
[Refresh] armsubscriptions v2.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/resources/armsubscriptions/CHANGELOG.md
+++ b/sdk/resourcemanager/resources/armsubscriptions/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.1 (2026-05-20)
+## 2.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Struct `ErrorAdditionalInfo` has been removed

--- a/sdk/resourcemanager/resources/armsubscriptions/version.go
+++ b/sdk/resourcemanager/resources/armsubscriptions/version.go
@@ -6,5 +6,5 @@ package armsubscriptions
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v2.0.0"
 )


### PR DESCRIPTION
Promote `armsubscriptions` to stable `v2.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.