### PR TITLE
[Refresh] armsqlvirtualmachine v1.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/sqlvirtualmachine/armsqlvirtualmachine/CHANGELOG.md
+++ b/sdk/resourcemanager/sqlvirtualmachine/armsqlvirtualmachine/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.0.0 (2026-06-24)
+### Other Changes
+
+
 ## 0.11.0 (2026-03-19)
 ### Breaking Changes
 

--- a/sdk/resourcemanager/sqlvirtualmachine/armsqlvirtualmachine/CHANGELOG.md
+++ b/sdk/resourcemanager/sqlvirtualmachine/armsqlvirtualmachine/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0 (2026-06-24)
 ### Other Changes
 
+- General availability of the `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sqlvirtualmachine/armsqlvirtualmachine` package.
 
 ## 0.11.0 (2026-03-19)
 ### Breaking Changes

--- a/sdk/resourcemanager/sqlvirtualmachine/armsqlvirtualmachine/version.go
+++ b/sdk/resourcemanager/sqlvirtualmachine/armsqlvirtualmachine/version.go
@@ -6,5 +6,5 @@ package armsqlvirtualmachine
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sqlvirtualmachine/armsqlvirtualmachine"
-	moduleVersion = "v0.11.0"
+	moduleVersion = "v1.0.0"
 )


### PR DESCRIPTION
Promote `armsqlvirtualmachine` to stable `v1.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.