### PR TITLE
[Refresh] armstoragesync v2.0.0 (stable)

### DIFF
--- a/sdk/resourcemanager/storagesync/armstoragesync/CHANGELOG.md
+++ b/sdk/resourcemanager/storagesync/armstoragesync/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.1 (2026-05-20)
+## 2.0.0 (2026-06-24)
 ### Breaking Changes
 
 - Function `*ServerEndpointsClient.BeginUpdate` parameter(s) have been changed from `(ctx context.Context, resourceGroupName string, storageSyncServiceName string, syncGroupName string, serverEndpointName string, options *ServerEndpointsClientBeginUpdateOptions)` to `(ctx context.Context, resourceGroupName string, storageSyncServiceName string, syncGroupName string, serverEndpointName string, parameters ServerEndpointUpdateParameters, options *ServerEndpointsClientBeginUpdateOptions)`

--- a/sdk/resourcemanager/storagesync/armstoragesync/version.go
+++ b/sdk/resourcemanager/storagesync/armstoragesync/version.go
@@ -6,5 +6,5 @@ package armstoragesync
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storagesync/armstoragesync"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v2.0.0"
 )


### PR DESCRIPTION
Promote `armstoragesync` to stable `v2.0.0`. Spec API version is GA/stable. Version + CHANGELOG regenerated with `generator version --sdkreleasetype stable`. Part of the beta-to-stable refresh effort.