### PR TITLE
[Refresh] armresourcehealth v1.4.0 (stable)

### DIFF
--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/CHANGELOG.md
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/CHANGELOG.md
@@ -1,33 +1,15 @@
 # Release History
 
-## 2.0.0-beta.1 (2026-05-20)
-### Breaking Changes
-
-- Field `MaintenanceEndTime`, `MaintenanceStartTime`, `ResourceGroup`, `ResourceName`, `Status` of struct `EventImpactedResourceProperties` has been removed
-- Field `ArgQuery`, `MaintenanceID`, `MaintenanceType` of struct `EventProperties` has been removed
-
+## 1.4.0 (2026-06-24)
 ### Features Added
 
-- New value `EventSubTypeValuesForeignExchangeRateChange`, `EventSubTypeValuesMeterIDChanges`, `EventSubTypeValuesOverbilling`, `EventSubTypeValuesPriceChanges`, `EventSubTypeValuesTaxChanges`, `EventSubTypeValuesUnauthorizedPartyAbuse`, `EventSubTypeValuesUnderbilling` added to enum type `EventSubTypeValues`
 - New value `EventTypeValuesBilling` added to enum type `EventTypeValues`
+- New enum type `EventSubTypeValues` with values `EventSubTypeValuesForeignExchangeRateChange`, `EventSubTypeValuesMeterIDChanges`, `EventSubTypeValuesOverbilling`, `EventSubTypeValuesPriceChanges`, `EventSubTypeValuesRetirement`, `EventSubTypeValuesTaxChanges`, `EventSubTypeValuesUnauthorizedPartyAbuse`, `EventSubTypeValuesUnderbilling`
 - New function `*EventClient.FetchBilllingCommunicationDetailsBySubscriptionIDAndTrackingID(ctx context.Context, eventTrackingID string, options *EventClientFetchBilllingCommunicationDetailsBySubscriptionIDAndTrackingIDOptions) (EventClientFetchBilllingCommunicationDetailsBySubscriptionIDAndTrackingIDResponse, error)`
-- New field `BillingID`, `CurrencyType`, `EventTags`, `IsEventSensitive`, `NewRate`, `OldRate` in struct `EventProperties`
+- New field `BillingID`, `CurrencyType`, `EventSubType`, `EventTags`, `IsEventSensitive`, `NewRate`, `OldRate` in struct `EventProperties`
 - New field `ImpactedServiceGUID` in struct `Impact`
 - New field `PreviousID`, `Priority`, `ServiceGUID` in struct `MetadataSupportedValueDetail`
 - New field `EventTags` in struct `Update`
-
-
-## 1.4.0-beta.2 (2024-02-07)
-### Bugs Fixed
-
-- Unmarshal time values in ISO8601 format.
-
-## 1.4.0-beta.1 (2023-11-30)
-### Features Added
-
-- New enum type `EventSubTypeValues` with values `EventSubTypeValuesRetirement`
-- New field `MaintenanceEndTime`, `MaintenanceStartTime`, `ResourceGroup`, `ResourceName`, `Status` in struct `EventImpactedResourceProperties`
-- New field `ArgQuery`, `EventSubType`, `MaintenanceID`, `MaintenanceType` in struct `EventProperties`
 
 
 ## 1.3.0 (2023-11-30)

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/README.md
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/README.md
@@ -18,7 +18,7 @@ This project uses [Go modules](https://github.com/golang/go/wiki/Modules) for ve
 Install the Azure Resource Health module:
 
 ```sh
-go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2
+go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth
 ```
 
 ## Authorization

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/availabilitystatuses_client_example_test.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/availabilitystatuses_client_example_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"log"
 )
 

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/childavailabilitystatuses_client_example_test.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/childavailabilitystatuses_client_example_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"log"
 )
 

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/childresources_client_example_test.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/childresources_client_example_test.go
@@ -7,7 +7,7 @@ package armresourcehealth_test
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"log"
 )
 

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/emergingissues_client_example_test.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/emergingissues_client_example_test.go
@@ -7,7 +7,7 @@ package armresourcehealth_test
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"log"
 )
 

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/event_client_example_test.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/event_client_example_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"log"
 )
 

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/events_client_example_test.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/events_client_example_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"log"
 )
 

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/availabilitystatuses_server.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/availabilitystatuses_server.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"net/http"
 	"net/url"
 	"regexp"

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/childavailabilitystatuses_server.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/childavailabilitystatuses_server.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"net/http"
 	"net/url"
 	"regexp"

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/childresources_server.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/childresources_server.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"net/http"
 	"net/url"
 	"regexp"

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/emergingissues_server.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/emergingissues_server.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"net/http"
 	"net/url"
 	"regexp"

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/event_server.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/event_server.go
@@ -11,7 +11,7 @@ import (
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"net/http"
 	"net/url"
 	"regexp"

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/events_server.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/events_server.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"net/http"
 	"net/url"
 	"regexp"

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/impactedresources_server.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/impactedresources_server.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"net/http"
 	"net/url"
 	"regexp"

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/metadata_server.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/metadata_server.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"net/http"
 	"net/url"
 	"regexp"

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/operations_server.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/operations_server.go
@@ -11,7 +11,7 @@ import (
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"net/http"
 	"slices"
 )

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/securityadvisoryimpactedresources_server.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/fake/securityadvisoryimpactedresources_server.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"net/http"
 	"net/url"
 	"regexp"

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/go.mod
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/go.mod
@@ -1,4 +1,4 @@
-module github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2
+module github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth
 
 go 1.25.0
 

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/impactedresources_client_example_test.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/impactedresources_client_example_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"log"
 )
 

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/metadata_client_example_test.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/metadata_client_example_test.go
@@ -7,7 +7,7 @@ package armresourcehealth_test
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"log"
 )
 

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/operations_client_example_test.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/operations_client_example_test.go
@@ -7,7 +7,7 @@ package armresourcehealth_test
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"log"
 )
 

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/securityadvisoryimpactedresources_client_example_test.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/securityadvisoryimpactedresources_client_example_test.go
@@ -7,7 +7,7 @@ package armresourcehealth_test
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
 	"log"
 )
 

--- a/sdk/resourcemanager/resourcehealth/armresourcehealth/version.go
+++ b/sdk/resourcemanager/resourcehealth/armresourcehealth/version.go
@@ -6,5 +6,5 @@ package armresourcehealth
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
-	moduleVersion = "v2.0.0-beta.1"
+	moduleVersion = "v1.4.0"
 )


### PR DESCRIPTION
Promote `armresourcehealth` to stable `v1.4.0`. There are **no breaking changes** vs the previous stable `v1.3.0`, so this is a minor bump (not a major); the module path is reverted off `/v2` accordingly. Supersedes #27093.