### PR TITLE
Remove link verification from Analyze job

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -284,16 +284,6 @@ steps:
     displayName: 'Format Check'
     condition: succeededOrFailed()
 
-  - template: /eng/common/pipelines/templates/steps/verify-links.yml
-    parameters:
-      ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-        Directory: ''
-        Urls: (eng/common/scripts/get-markdown-files-from-changed-files.ps1)
-      ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-        Directory: sdk/${{ parameters.ServiceDirectory }}
-      CheckLinkGuidance: $true
-      Condition: succeededOrFailed()
-
   - pwsh: |
       if (-not "$(Packages)") {
         Write-Host "No services were changed build. Skipping doccheck."


### PR DESCRIPTION
This pull request makes a small change to the pipeline configuration by removing the link verification step from the `analyze.yml` template. This simplifies the pipeline and avoids running the link check during builds.

Pipeline simplification:

* Removed the `verify-links.yml` template step, which previously checked for broken links in markdown files during the pipeline run.