### PR TITLE
Add upload-llm-artifacts common template step + pipelineArtifact output

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -51,12 +51,19 @@ jobs:
       image: $(OSVmImage)
     os: ${{ parameters.OSName }}
 
-  # Only run CG on the linux build(s) so we don't run it on all the jobs.
-  ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.OSName, 'linux')) }}:
-    templateContext:
+  templateContext:
+    # Only run CG on the linux build(s) so we don't run it on all the jobs.
+    ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.OSName, 'linux')) }}:
       sdl:
         componentgovernance:
           enabled: true
+    # See eng/common/pipelines/templates/steps/upload-llm-artifacts.yml for corresponding file copy step
+    outputs:
+      - output: pipelineArtifact
+        targetPath: '$(Build.ArtifactStagingDirectory)/llm-artifacts'
+        artifactName: "LLM Artifacts - $(System.JobName) - $(System.JobAttempt)"
+        condition: eq(variables['uploadLlmArtifacts'], 'true')
+        sbomEnabled: false
 
   steps:
   - template: /eng/pipelines/templates/steps/sparse-checkout-for-servicedirectory.yml

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -167,3 +167,4 @@ steps:
   - template: /eng/common/pipelines/templates/steps/upload-llm-artifacts.yml
     parameters:
       TestResultsGlob: 'report.xml'
+      SearchFolder: '$(Build.SourcesDirectory)/sdk'

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -152,11 +152,18 @@ steps:
       displayName: 'Dump Test Proxy logs'
       condition: succeededOrFailed()
 
-  # todo: combine test results into a test results file, this will be broken for now.
+  # Each tested package writes its own report.xml into its package directory (see eng/scripts/test.ps1),
+  # so search recursively under sdk and merge rather than expecting a single service-level file.
   - task: PublishTestResults@2
     condition: succeededOrFailed()
     inputs:
       testRunner: JUnit
-      testResultsFiles: '$(Build.SourcesDirectory)/sdk/${{parameters.ServiceDirectory}}/report.xml'
+      testResultsFiles: '**/report.xml'
+      searchFolder: '$(Build.SourcesDirectory)/sdk'
+      mergeTestResults: true
       testRunTitle: 'Go ${{ parameters.GoVersion }} on ${{ parameters.Image }}'
       failTaskOnFailedTests: true
+
+  - template: /eng/common/pipelines/templates/steps/upload-llm-artifacts.yml
+    parameters:
+      TestResultsGlob: 'report.xml'


### PR DESCRIPTION
This pull request introduces a new pipeline step to collect and upload test result files as "LLM Artifacts" to support downstream LLM tooling (such as GitHub Copilot) for test analysis. The changes add a reusable, language-agnostic template for staging test result files and update the CI test job to use this template and publish the artifacts when available.

The test results publishing step now recursively finds all `report.xml` files under the `sdk` directory and merges them, ensuring all package-level test results are included instead of expecting a single file. (`eng/pipelines/templates/steps/build-test.yml`)