### PR TITLE
Remove azcosmos PR trigger exclusion

### DIFF
--- a/eng/pipelines/pullrequest.yml
+++ b/eng/pipelines/pullrequest.yml
@@ -10,7 +10,6 @@ pr:
     include:
       - "*"
     exclude:
-      - sdk/data/azcosmos/
       - .github/skills/azsdk-common-*/**
 
 parameters:


### PR DESCRIPTION
## Summary
- remove the unintended sdk/data/azcosmos/ PR trigger path exclusion
- keep the common Azure SDK skill folder exclusion in place

## Validation
- Parsed eng/pipelines/pullrequest.yml with PyYAML