### PR TITLE
ci: add typespec-go SDK regeneration ADO pipeline

### DIFF
--- a/eng/pipelines/sdk-regenerate.yml
+++ b/eng/pipelines/sdk-regenerate.yml
@@ -19,6 +19,10 @@ schedules:
     branches:
       include:
         - main
+    # This pipeline detects external @azure-tools/typespec-go emitter releases,
+    # which are not commits to this repo. Without always:true the scheduled run is
+    # skipped whenever main has not changed, silently stopping weekly regeneration.
+    always: true
 
 parameters:
   - name: UseLatestSpec

--- a/eng/pipelines/sdk-regenerate.yml
+++ b/eng/pipelines/sdk-regenerate.yml
@@ -86,6 +86,11 @@ jobs:
         inputs:
           versionSpec: '$(NodeVersion)'
 
+      # Point npm / pnpm / npx at the authenticated azure-sdk-for-js internal feed
+      # by writing an authenticated $HOME/.npmrc, so every install below (corepack,
+      # pnpm install, tsp-client) resolves packages from the internal registry.
+      - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+
       - ${{ if eq(parameters.UseDevPackage, true) }}:
           - script: |
               npm i -g corepack@latest

--- a/eng/pipelines/sdk-regenerate.yml
+++ b/eng/pipelines/sdk-regenerate.yml
@@ -116,9 +116,19 @@ jobs:
         displayName: 'Install tsp-client'
 
       - script: |
-          python3 $(sdkRoot)/eng/scripts/sdk_regenerate.py --sdk-root=$(sdkRoot) --typespec-go-root="$(emitterRoot)" --use-latest-spec=${{ parameters.UseLatestSpec }} --service-filter="${{ parameters.ServiceFilter }}" --use-dev-package=${{ parameters.UseDevPackage }}
+          python3 $(sdkRoot)/eng/scripts/sdk_regenerate.py --sdk-root=$(sdkRoot) --typespec-go-root="$(emitterRoot)" --use-latest-spec=${{ parameters.UseLatestSpec }} --service-filter="${{ parameters.ServiceFilter }}" --use-dev-package=${{ parameters.UseDevPackage }} --result-file=$(Build.ArtifactStagingDirectory)/regenerate-sdk-result.json
         displayName: 'Generate SDK'
         workingDirectory: $(sdkRoot)
+
+      # Publish the regeneration report as a build artifact. It is written outside
+      # the SDK working tree (ArtifactStagingDirectory) so it is never committed to
+      # the regeneration pull request.
+      - task: PublishPipelineArtifact@1
+        displayName: 'Publish regeneration report'
+        condition: succeededOrFailed()
+        inputs:
+          targetPath: $(Build.ArtifactStagingDirectory)/regenerate-sdk-result.json
+          artifactName: regenerate-sdk-result
 
       - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
         parameters:

--- a/eng/pipelines/sdk-regenerate.yml
+++ b/eng/pipelines/sdk-regenerate.yml
@@ -1,0 +1,134 @@
+# Regenerates the resource manager SDKs produced by the @azure-tools/typespec-go
+# emitter and opens a pull request against Azure/azure-sdk-for-go.
+#
+# Migrated from the Azure DevOps sdk-regenerate.yml pipeline that previously lived
+# in Azure/autorest.go and now lives alongside the SDK it regenerates.
+#
+# Two emitter modes (mirroring the original pipeline):
+#   * released (default): pin eng/emitter-package.json to the latest published
+#     @azure-tools/typespec-go from npm.
+#   * dev: build the emitter from an Azure/typespec-azure branch, `pnpm pack` it,
+#     and point eng/emitter-package.json at the resulting tarball.
+
+trigger: none
+pr: none
+
+schedules:
+  - cron: "0 2 * * 1" # Weekly at Monday 2 AM UTC
+    displayName: Weekly regenerate SDK
+    branches:
+      include:
+        - main
+
+parameters:
+  - name: UseLatestSpec
+    default: false
+    type: boolean
+  - name: ServiceFilter
+    type: string
+    default: '.*'
+  - name: UseDevPackage
+    default: false
+    type: boolean
+  - name: TypeSpecAzureRef
+    displayName: "Azure/typespec-azure branch to build the dev emitter from (dev mode only)"
+    type: string
+    default: main
+
+variables:
+  - template: /eng/pipelines/templates/variables/globals.yml
+  - template: /eng/pipelines/templates/variables/image.yml
+  - name: NodeVersion
+    value: "24.x"
+  # Compile-time paths so both layouts work: when only `self` is checked out
+  # (released mode) it lives at $(Build.SourcesDirectory); when typespec-azure is
+  # also checked out (dev mode) each repo lives under a named subfolder.
+  - ${{ if eq(parameters.UseDevPackage, true) }}:
+      - name: sdkRoot
+        value: $(Build.SourcesDirectory)/azure-sdk-for-go
+      - name: emitterRoot
+        value: $(Build.SourcesDirectory)/typespec-azure/packages/typespec-go
+  - ${{ else }}:
+      - name: sdkRoot
+        value: $(Build.SourcesDirectory)
+      - name: emitterRoot
+        value: ''
+
+pool:
+  name: $(LINUXPOOL)
+  demands: ImageOverride -equals $(LINUXVMIMAGE)
+
+resources:
+  repositories:
+    - repository: typespec-azure
+      type: github
+      name: Azure/typespec-azure
+      endpoint: azure
+      ref: refs/heads/${{ parameters.TypeSpecAzureRef }}
+
+jobs:
+  - job: Generate_SDK
+
+    timeoutInMinutes: 180
+
+    steps:
+      - checkout: self
+        fetchDepth: 1
+
+      # The emitter source is only needed to build a dev package.
+      - ${{ if eq(parameters.UseDevPackage, true) }}:
+          - checkout: typespec-azure
+            fetchDepth: 1
+            submodules: recursive
+
+      - task: NodeTool@0
+        displayName: 'Install Node.js $(NodeVersion)'
+        inputs:
+          versionSpec: '$(NodeVersion)'
+
+      - ${{ if eq(parameters.UseDevPackage, true) }}:
+          - script: |
+              npm i -g corepack@latest
+              corepack enable
+              corepack prepare pnpm@latest-10 --activate
+            displayName: Install pnpm
+
+          - script: pnpm install
+            displayName: pnpm install
+            workingDirectory: $(Build.SourcesDirectory)/typespec-azure
+
+          # Build the emitter together with its in-repo workspace dependencies
+          # (TCGC, compiler via the core submodule, azure-resource-manager, etc.).
+          - script: pnpm turbo run --filter "@azure-tools/typespec-go..." build
+            displayName: Build emitter
+            workingDirectory: $(Build.SourcesDirectory)/typespec-azure
+
+          - script: pnpm pack
+            displayName: Pack emitter
+            workingDirectory: $(Build.SourcesDirectory)/typespec-azure/packages/typespec-go
+
+      - task: GoTool@0
+        displayName: 'Use Go $(GO_VERSION_LATEST)'
+        inputs:
+          version: '$(GO_VERSION_LATEST)'
+
+      - script: npm install -g @azure-tools/typespec-client-generator-cli
+        displayName: 'Install tsp-client'
+
+      - script: |
+          python3 $(sdkRoot)/eng/scripts/sdk_regenerate.py --sdk-root=$(sdkRoot) --typespec-go-root="$(emitterRoot)" --use-latest-spec=${{ parameters.UseLatestSpec }} --service-filter="${{ parameters.ServiceFilter }}" --use-dev-package=${{ parameters.UseDevPackage }}
+        displayName: 'Generate SDK'
+        workingDirectory: $(sdkRoot)
+
+      - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
+        parameters:
+          WorkingDirectory: $(sdkRoot)
+          RepoOwner: Azure
+          RepoName: azure-sdk-for-go
+          PROwner: azure-sdk
+          BaseBranchName: 'refs/heads/main'
+          PRBranchName: typespec-go-regenerate-${{ parameters.TypeSpecAzureRef }}
+          CommitMsg: 'Regenerate SDK based on typespec-go (${{ parameters.TypeSpecAzureRef }})'
+          PRTitle: '[Automation] Regenerate SDK based on typespec-go (${{ parameters.TypeSpecAzureRef }})'
+          OpenAsDraft: true
+          PushArgs: '--force'

--- a/eng/scripts/sdk_regenerate.py
+++ b/eng/scripts/sdk_regenerate.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+from typing import Dict, List, Optional
+from pathlib import Path
+import subprocess
+from datetime import datetime
+from subprocess import check_call, check_output
+import argparse
+import logging
+import json
+import re
+import glob
+import urllib.request
+
+
+def get_latest_typespec_go_package_info():
+    """Get the latest version and dependencies of @azure-tools/typespec-go from npm registry."""
+    try:
+        logging.info("Fetching latest @azure-tools/typespec-go info from npm registry")
+        
+        # Get package info from npm registry
+        url = "https://registry.npmjs.org/@azure-tools/typespec-go/latest"
+        with urllib.request.urlopen(url) as response:
+            package_info = json.loads(response.read().decode())
+        
+        version = package_info.get("version")
+        dev_dependencies = package_info.get("devDependencies", {})
+        
+        logging.info(f"Latest @azure-tools/typespec-go version: {version}")
+        
+        return {
+            "version": version,
+            "devDependencies": dev_dependencies
+        }
+    except Exception as e:
+        logging.error(f"Failed to fetch latest typespec-go info: {e}")
+        raise
+
+
+def get_packed_tgz_deps(typespec_go_tgz: Path) -> dict:
+    """Read the packed .tgz's package.json and return a merged map of its
+    peerDependencies and dependencies.
+
+    When pnpm packs the emitter, `workspace:` specifiers are rewritten to
+    concrete published version ranges (for example `^0.69.1`). The emitter's
+    generation-time dependencies live under `peerDependencies` in the tgz, so
+    these ranges are the correct versions to pin the SDK's emitter-package.json
+    `devDependencies` to. Reading the source package.json instead would yield
+    `workspace:` specifiers, which are meaningless outside this monorepo."""
+    import tarfile
+
+    with tarfile.open(typespec_go_tgz, "r:gz") as tar:
+        member = tar.extractfile("package/package.json")
+        if member is None:
+            raise FileNotFoundError(f"package/package.json not found in {typespec_go_tgz}")
+        packed = json.load(member)
+
+    deps = {}
+    deps.update(packed.get("peerDependencies", {}))
+    deps.update(packed.get("dependencies", {}))
+    return deps
+
+
+def find_typespec_go_tgz(typespec_go_root: str) -> Path:
+    """Locate the packed @azure-tools/typespec-go .tgz in the emitter root."""
+    for item in Path(typespec_go_root).iterdir():
+        if "typespec-go" in item.name and item.name.endswith(".tgz"):
+            return item
+    logging.error("Cannot find .tgz for typespec-go")
+    raise FileNotFoundError("Cannot find .tgz for typespec-go")
+
+
+def update_dev_dependencies(emitter_package: dict, source_deps: dict):
+    """Update devDependencies in emitter_package with versions from source_deps."""
+    if "devDependencies" not in emitter_package:
+        return
+    for package_name in emitter_package["devDependencies"].keys():
+        if package_name in source_deps:
+            emitter_package["devDependencies"][package_name] = source_deps[package_name]
+            logging.info(f"Updated {package_name} to version {source_deps[package_name]}")
+        else:
+            logging.info(f"Package {package_name} not found in dependencies, keeping existing version")
+
+
+def update_emitter_package(sdk_root: str, typespec_go_root: str, use_dev_package: bool):
+    # Load existing emitter-package.json
+    emitter_package_path = Path(sdk_root) / "eng/emitter-package.json"
+    if not emitter_package_path.exists():
+        logging.error(f"emitter-package.json not found at {emitter_package_path}")
+        raise FileNotFoundError(f"emitter-package.json not found at {emitter_package_path}")
+    logging.info("Loading existing emitter-package.json")
+    with open(emitter_package_path, "r", encoding="utf-8") as f:
+        emitter_package = json.load(f)
+    
+    if use_dev_package:
+        logging.info("Using dev package mode")
+
+        # Find the locally packed typespec-go .tgz.
+        typespec_go_tgz = find_typespec_go_tgz(typespec_go_root)
+
+        # Read the emitter's generation-time dependencies from the packed tgz,
+        # where pnpm has rewritten `workspace:` specifiers to concrete ranges.
+        logging.info("Reading packed .tgz to get dependency versions")
+        dev_deps = get_packed_tgz_deps(typespec_go_tgz)
+
+        # Update devDependencies in emitter_package
+        update_dev_dependencies(emitter_package, dev_deps)
+
+        # Update emitter-package.json to use the dev package path
+        emitter_package["dependencies"]["@azure-tools/typespec-go"] = typespec_go_tgz.absolute().as_posix()
+    else:
+        logging.info("Using released package mode")
+
+        # Find the package.json in recent released typespec-go
+        package_info = get_latest_typespec_go_package_info()
+
+        # Update emitter-package.json to use the released package version
+        if "dependencies" not in emitter_package:
+            emitter_package["dependencies"] = {}
+        emitter_package["dependencies"]["@azure-tools/typespec-go"] = package_info["version"]
+        logging.info(f"Updated @azure-tools/typespec-go to version {package_info['version']}")
+
+        # Update devDependencies in emitter_package
+        dev_deps = package_info["devDependencies"]
+        update_dev_dependencies(emitter_package, dev_deps)
+    
+    # Print the complete emitter_package before writing
+    logging.info("Complete emitter-package.json content:")
+    logging.info(json.dumps(emitter_package, indent=2))
+    
+    # Write the updated emitter-package.json
+    with open(emitter_package_path, "w", encoding="utf-8") as f:
+        json.dump(emitter_package, f, indent=2)
+    
+    # Update emitter-package-lock.json
+    logging.info("Update emitter-package-lock.json")
+    try:
+        check_call(["tsp-client", "generate-lock-file"], cwd=sdk_root)
+    except Exception as e:
+        logging.error("Failed to update emitter-package-lock.json")
+        logging.error(e)
+        raise
+
+def get_latest_commit_id() -> str:
+    return (
+        check_output(
+            "git ls-remote https://github.com/Azure/azure-rest-api-specs.git HEAD | awk '{ print $1}'", shell=True
+        )
+        .decode("utf-8")
+        .split("\n")[0]
+        .strip()
+    )
+
+
+def get_typespec_go_commit_hash(typespec_go_root: str) -> str:
+    """Get the current commit hash of the typespec-go repository."""
+    try:
+        return (
+            check_output(
+                "git rev-parse HEAD", shell=True, cwd=typespec_go_root
+            )
+            .decode("utf-8")
+            .strip()
+        )
+    except Exception as e:
+        logging.warning(f"Failed to get typespec-go commit hash: {e}")
+        return "unknown"
+
+
+def update_commit_id(file: Path, commit_id: str):
+    with open(file, "r") as f:
+        content = f.readlines()
+    for idx in range(len(content)):
+        if "commit:" in content[idx]:
+            content[idx] = f"commit: {commit_id}\n"
+            break
+    with open(file, "w") as f:
+        f.writelines(content)
+
+
+def get_api_version_from_metadata(package_folder: Path) -> Optional[str]:
+    """Extract API version from metadata.json file if it exists."""
+    # Construct the metadata.json path based on the package folder structure
+    # {package_folder}/testdata/_metadata.json
+    metadata_path = package_folder / "testdata" / "_metadata.json"
+    
+    if metadata_path.exists():
+        try:
+            with open(metadata_path, "r") as f:
+                metadata = json.load(f)
+                api_version = metadata.get("apiVersion")
+                if api_version:
+                    logging.info(f"Found API version {api_version} in metadata.json for {package_folder.name}")
+                    return api_version
+        except (json.JSONDecodeError, FileNotFoundError) as e:
+            logging.warning(f"Failed to read metadata.json for {package_folder.name}: {e}")
+    
+    return None
+
+
+def get_api_version_from_client_files(package_folder: Path) -> Optional[str]:
+    """Extract API version from client Go files by searching for 'Generated from API version' comment."""
+    # Look for *_client.go files in the package folder
+    client_files_pattern = str(package_folder / "*_client.go")
+    client_files = glob.glob(client_files_pattern)
+    
+    api_version_pattern = re.compile(r"Generated from API version\s+([^\s,]+)")
+    
+    for client_file in client_files:
+        try:
+            with open(client_file, "r", encoding="utf-8") as f:
+                content = f.read()
+                match = api_version_pattern.search(content)
+                if match:
+                    api_version = match.group(1)
+                    logging.info(f"Found API version {api_version} in {Path(client_file).name} for {package_folder.name}")
+                    return api_version
+        except (FileNotFoundError, UnicodeDecodeError) as e:
+            logging.warning(f"Failed to read client file {client_file}: {e}")
+    
+    return None
+
+
+def get_api_version(package_folder: Path) -> Optional[str]:
+    """Get API version for a package, first trying metadata.json, then client files."""
+    # First, try to get from metadata.json
+    api_version = get_api_version_from_metadata(package_folder)
+    
+    if api_version:
+        return api_version
+    
+    # If not found in metadata, try client files
+    api_version = get_api_version_from_client_files(package_folder)
+    
+    if not api_version:
+        logging.warning(f"Could not find API version for {package_folder.name}")
+    
+    return api_version
+
+def regenerate_sdk(use_latest_spec: bool, service_filter: str, sdk_root: str, typespec_go_root: str) -> Dict[str, List[str]]:
+    result = {
+        "succeed_to_regenerate": [], 
+        "fail_to_regenerate": [], 
+        "not_found_api_version": [], 
+        "time_to_regenerate": str(datetime.now()),
+        "typespec_go_commit_hash": get_typespec_go_commit_hash(typespec_go_root)
+    }
+    # get all tsp-location.yaml
+    commit_id = get_latest_commit_id()
+    sdk_resourcemanager_path = Path(sdk_root) / "sdk" / "resourcemanager"
+    for item in sdk_resourcemanager_path.rglob("tsp-location.yaml"):
+        package_folder = item.parent
+        if len(service_filter) > 0 and re.match(service_filter, package_folder.name) is None:
+            continue
+        logging.info(f"Regenerating {package_folder.name}...")
+        if use_latest_spec:
+            logging.info("Using latest spec")
+            update_commit_id(item, commit_id)
+        try:
+            # Get API version for this package
+            api_version = get_api_version(package_folder)
+            
+            # Build the tsp-client command with optional API version
+            tsp_command = "tsp-client update"
+            if api_version:
+                tsp_command += f" --emitter-options api-version={api_version}"
+                logging.info(f"Using API version {api_version} for {package_folder.name}")
+            else:
+                logging.info(f"No API version specified for {package_folder.name}, using default behavior")
+                result["not_found_api_version"].append(package_folder.name)
+
+            # Use subprocess.run for better control over output
+            proc_result = subprocess.run(
+                tsp_command, 
+                shell=True, 
+                cwd=str(package_folder),
+                capture_output=True,
+                text=True,
+                check=True
+            )
+            
+            # Log the output for progress tracking
+            if proc_result.stdout:
+                logging.info(f"Output for {package_folder.name}:")
+                for line in proc_result.stdout.split('\n'):
+                    if line.strip():
+                        logging.info(f"  {line}")
+            
+            if proc_result.stderr:
+                logging.warning(f"Stderr for {package_folder.name}:")
+                for line in proc_result.stderr.split('\n'):
+                    if line.strip():
+                        logging.warning(f"  {line}")
+                        
+            # Check for errors in output
+            output_lines = proc_result.stdout.split('\n') if proc_result.stdout else []
+            errors = [line for line in output_lines if "- error " in line.lower()]
+            if errors:
+                raise Exception("Errors found in output:\n" + "\n".join(errors))
+                
+        except subprocess.CalledProcessError as e:
+            logging.error(f"Failed to regenerate {package_folder.name}")
+            logging.error(f"Command failed with exit code {e.returncode}")
+            if e.stdout:
+                logging.error(f"Stdout:\n{e.stdout}")
+            if e.stderr:
+                logging.error(f"Stderr:\n{e.stderr}")
+            result["fail_to_regenerate"].append(package_folder.name)
+        except Exception as e:
+            logging.error(f"Failed to regenerate {package_folder.name}")
+            logging.error(f"Error: {str(e)}")
+            result["fail_to_regenerate"].append(package_folder.name)
+        else:
+            logging.info(f"Successfully regenerated {package_folder.name}")
+            result["succeed_to_regenerate"].append(package_folder.name)
+            
+    result["succeed_to_regenerate"].sort()
+    result["fail_to_regenerate"].sort()
+    result["not_found_api_version"].sort()
+    return result
+
+
+def main(sdk_root: str, typespec_go_root: str, use_latest_spec: bool, service_filter: str, use_dev_package: bool):
+    # Configure logging for better pipeline visibility
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(levelname)s - %(message)s',
+        handlers=[
+            logging.StreamHandler(),  # Console output for pipeline
+        ]
+    )
+
+    # Branch management, committing, and PR creation are handled by the GitHub
+    # Actions workflow that invokes this script. This script is responsible only
+    # for updating eng/emitter-package.json and regenerating the SDKs, leaving the
+    # resulting changes in the working tree for the workflow to commit.
+    update_emitter_package(sdk_root, typespec_go_root, use_dev_package)
+    result = regenerate_sdk(use_latest_spec, service_filter, sdk_root, typespec_go_root)
+    with open("regenerate-sdk-result.json", "w") as f:
+        json.dump(result, f, indent=2)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="SDK regeneration")
+
+    parser.add_argument(
+        "--sdk-root",
+        help="SDK repo root folder",
+        type=str,
+    )
+
+    parser.add_argument(
+        "--typespec-go-root",
+        help="typespec-go emitter root folder (required only for --use-dev-package)",
+        type=str,
+        default="",
+    )
+
+    parser.add_argument(
+        "--use-latest-spec",
+        help="Whether to use the latest spec",
+        type=lambda x: x.lower() == 'true',
+        default=False,
+    )
+
+    parser.add_argument(
+        "--service-filter",
+        help="An regex filter to specify which service to regenerate. If not specified, all services will be regenerated.",
+        type=str,
+    )
+
+    parser.add_argument(
+        "--use-dev-package",
+        help="Whether to use dev package or released package",
+        type=lambda x: x.lower() == 'true',
+        default=False,
+    )
+
+    args = parser.parse_args()
+
+    main(args.sdk_root, args.typespec_go_root, args.use_latest_spec, args.service_filter, args.use_dev_package)

--- a/eng/scripts/sdk_regenerate.py
+++ b/eng/scripts/sdk_regenerate.py
@@ -324,7 +324,7 @@ def regenerate_sdk(use_latest_spec: bool, service_filter: str, sdk_root: str, ty
     return result
 
 
-def main(sdk_root: str, typespec_go_root: str, use_latest_spec: bool, service_filter: str, use_dev_package: bool):
+def main(sdk_root: str, typespec_go_root: str, use_latest_spec: bool, service_filter: str, use_dev_package: bool, result_file: str):
     # Configure logging for better pipeline visibility
     logging.basicConfig(
         level=logging.INFO,
@@ -334,14 +334,21 @@ def main(sdk_root: str, typespec_go_root: str, use_latest_spec: bool, service_fi
         ]
     )
 
-    # Branch management, committing, and PR creation are handled by the GitHub
-    # Actions workflow that invokes this script. This script is responsible only
-    # for updating eng/emitter-package.json and regenerating the SDKs, leaving the
-    # resulting changes in the working tree for the workflow to commit.
+    # Branch management, committing, and PR creation are handled by the pipeline
+    # that invokes this script. This script is responsible only for updating
+    # eng/emitter-package.json and regenerating the SDKs, leaving the resulting
+    # changes in the working tree for the pipeline to commit.
     update_emitter_package(sdk_root, typespec_go_root, use_dev_package)
     result = regenerate_sdk(use_latest_spec, service_filter, sdk_root, typespec_go_root)
-    with open("regenerate-sdk-result.json", "w") as f:
+    # The regeneration report is a build artifact, not part of the SDK change set.
+    # The pipeline points --result-file outside the SDK working tree so it is never
+    # picked up by the pull request; only fall back to the CWD for local runs.
+    result_path = Path(result_file)
+    if result_path.parent and str(result_path.parent) not in ("", "."):
+        result_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(result_path, "w") as f:
         json.dump(result, f, indent=2)
+    logging.info(f"Wrote regeneration report to {result_path}")
 
 
 if __name__ == "__main__":
@@ -380,6 +387,14 @@ if __name__ == "__main__":
         default=False,
     )
 
+    parser.add_argument(
+        "--result-file",
+        help="Path to write the regeneration report JSON to. Point this outside the "
+             "SDK working tree so it is not committed to the pull request.",
+        type=str,
+        default="regenerate-sdk-result.json",
+    )
+
     args = parser.parse_args()
 
-    main(args.sdk_root, args.typespec_go_root, args.use_latest_spec, args.service_filter, args.use_dev_package)
+    main(args.sdk_root, args.typespec_go_root, args.use_latest_spec, args.service_filter, args.use_dev_package, args.result_file)

--- a/eng/scripts/sdk_regenerate.py
+++ b/eng/scripts/sdk_regenerate.py
@@ -342,7 +342,10 @@ def regenerate_sdk(use_latest_spec: bool, service_filter: str, sdk_root: str, ty
         "typespec_go_commit_hash": get_typespec_go_commit_hash(typespec_go_root)
     }
     # get all tsp-location.yaml
-    commit_id = get_latest_commit_id()
+    # The latest azure-rest-api-specs commit is only needed to repoint each package
+    # at HEAD in latest-spec mode; skip the lookup otherwise so a released-emitter
+    # regeneration does not depend on an unrelated (and unused) GitHub request.
+    commit_id = get_latest_commit_id() if use_latest_spec else None
     sdk_resourcemanager_path = Path(sdk_root) / "sdk" / "resourcemanager"
     for item in sdk_resourcemanager_path.rglob("tsp-location.yaml"):
         package_folder = item.parent

--- a/eng/scripts/sdk_regenerate.py
+++ b/eng/scripts/sdk_regenerate.py
@@ -183,22 +183,52 @@ def update_commit_id(file: Path, commit_id: str):
 
 
 def get_api_version_from_metadata(package_folder: Path) -> Optional[str]:
-    """Extract API version from metadata.json file if it exists."""
+    """Return the api-version emitter option value from metadata.json, if any.
+
+    Supports the legacy ``{"apiVersion": "..."}`` string and the current
+    ``{"apiVersions": {namespace: version}}`` map. Returns a plain version when
+    all namespaces share one version, otherwise a compact JSON namespace->version
+    map that the emitter uses to regenerate each namespace at its own version.
+    """
     # Construct the metadata.json path based on the package folder structure
     # {package_folder}/testdata/_metadata.json
     metadata_path = package_folder / "testdata" / "_metadata.json"
-    
-    if metadata_path.exists():
-        try:
-            with open(metadata_path, "r") as f:
-                metadata = json.load(f)
-                api_version = metadata.get("apiVersion")
-                if api_version:
-                    logging.info(f"Found API version {api_version} in metadata.json for {package_folder.name}")
-                    return api_version
-        except (json.JSONDecodeError, FileNotFoundError) as e:
-            logging.warning(f"Failed to read metadata.json for {package_folder.name}: {e}")
-    
+
+    if not metadata_path.exists():
+        return None
+
+    try:
+        with open(metadata_path, "r") as f:
+            metadata = json.load(f)
+    except (json.JSONDecodeError, FileNotFoundError) as e:
+        logging.warning(f"Failed to read metadata.json for {package_folder.name}: {e}")
+        return None
+
+    # current format: a map of namespace -> API version
+    api_versions = metadata.get("apiVersions")
+    if isinstance(api_versions, dict):
+        # drop namespaces without a version, keeping the namespace->version map
+        versions = {ns: ver for ns, ver in api_versions.items() if ver}
+        if versions:
+            distinct = set(versions.values())
+            if len(distinct) == 1:
+                api_version = next(iter(distinct))
+                logging.info(f"Found API version {api_version} in metadata.json for {package_folder.name}")
+                return api_version
+            # multiple namespaces at different versions: pass the whole map so the
+            # emitter regenerates each service namespace at its recorded version
+            api_version = json.dumps(versions, separators=(",", ":"))
+            logging.info(
+                f"Found multiple API versions {versions} in metadata.json for "
+                f"{package_folder.name}, passing per-namespace versions"
+            )
+            return api_version
+
+    # legacy format: a single API version string
+    api_version = metadata.get("apiVersion")
+    if api_version:
+        logging.info(f"Found API version {api_version} in metadata.json for {package_folder.name}")
+        return api_version
     return None
 
 

--- a/eng/scripts/sdk_regenerate.py
+++ b/eng/scripts/sdk_regenerate.py
@@ -74,16 +74,76 @@ def find_typespec_go_tgz(typespec_go_root: str) -> Path:
     raise FileNotFoundError("Cannot find .tgz for typespec-go")
 
 
-def update_dev_dependencies(emitter_package: dict, source_deps: dict):
-    """Update devDependencies in emitter_package with versions from source_deps."""
+def update_dev_dependencies(emitter_package: dict, source_deps: dict) -> List[str]:
+    """Update devDependencies in emitter_package with versions from source_deps.
+
+    Returns the list of devDependency names that were not found in source_deps
+    (i.e. gen-time libraries outside the emitter's own dependency closure, such as
+    @azure-tools/typespec-azure-portal-core and @azure-tools/typespec-liftr-base),
+    so the caller can resolve their versions separately."""
+    unresolved: List[str] = []
     if "devDependencies" not in emitter_package:
-        return
+        return unresolved
     for package_name in emitter_package["devDependencies"].keys():
         if package_name in source_deps:
             emitter_package["devDependencies"][package_name] = source_deps[package_name]
             logging.info(f"Updated {package_name} to version {source_deps[package_name]}")
         else:
-            logging.info(f"Package {package_name} not found in dependencies, keeping existing version")
+            unresolved.append(package_name)
+    return unresolved
+
+
+def get_workspace_package_version(typespec_go_root: str, package_name: str) -> Optional[str]:
+    """In dev mode, read a sibling workspace package's version from the checked-out
+    typespec-azure monorepo. Workspace package directories drop the scope prefix, so
+    `@azure-tools/typespec-azure-portal-core` lives at
+    `packages/typespec-azure-portal-core`. Returns None if the package is not part of
+    the monorepo (for example the external @azure-tools/typespec-liftr-base)."""
+    if not typespec_go_root:
+        return None
+    dir_name = package_name.split("/", 1)[-1]
+    candidate = Path(typespec_go_root).parent / dir_name / "package.json"
+    if not candidate.exists():
+        return None
+    try:
+        with open(candidate, "r", encoding="utf-8") as f:
+            return json.load(f).get("version")
+    except Exception as e:
+        logging.warning(f"Could not read workspace version for {package_name} at {candidate}: {e}")
+        return None
+
+
+def get_registry_latest_version(package_name: str) -> Optional[str]:
+    """Return the latest published version of a package from the npm registry, or None."""
+    try:
+        url = f"https://registry.npmjs.org/{package_name}/latest"
+        with urllib.request.urlopen(url) as response:
+            info = json.loads(response.read().decode())
+        return info.get("version")
+    except Exception as e:
+        logging.warning(f"Could not fetch latest version of {package_name} from npm registry: {e}")
+        return None
+
+
+def resolve_extra_dependencies(emitter_package: dict, unresolved: List[str], use_dev_package: bool, typespec_go_root: str):
+    """Resolve versions for gen-time devDependencies that are not part of the emitter's
+    own dependency closure (for example @azure-tools/typespec-azure-portal-core and
+    @azure-tools/typespec-liftr-base). These libraries are imported directly by some
+    specs and released in lockstep with the rest of the typespec-azure wave, so pinning
+    them to a stale version breaks generation against the current wave. Prefer the
+    checked-out workspace version in dev mode and fall back to the latest published
+    version otherwise."""
+    for package_name in unresolved:
+        version = None
+        if use_dev_package:
+            version = get_workspace_package_version(typespec_go_root, package_name)
+        if version is None:
+            version = get_registry_latest_version(package_name)
+        if version is None:
+            logging.info(f"Package {package_name} not found in dependencies or registry, keeping existing version")
+            continue
+        emitter_package["devDependencies"][package_name] = version
+        logging.info(f"Resolved extra dependency {package_name} to version {version}")
 
 
 def update_emitter_package(sdk_root: str, typespec_go_root: str, use_dev_package: bool):
@@ -108,7 +168,8 @@ def update_emitter_package(sdk_root: str, typespec_go_root: str, use_dev_package
         dev_deps = get_packed_tgz_deps(typespec_go_tgz)
 
         # Update devDependencies in emitter_package
-        update_dev_dependencies(emitter_package, dev_deps)
+        unresolved = update_dev_dependencies(emitter_package, dev_deps)
+        resolve_extra_dependencies(emitter_package, unresolved, use_dev_package=True, typespec_go_root=typespec_go_root)
 
         # Update emitter-package.json to use the dev package path
         emitter_package["dependencies"]["@azure-tools/typespec-go"] = typespec_go_tgz.absolute().as_posix()
@@ -126,7 +187,8 @@ def update_emitter_package(sdk_root: str, typespec_go_root: str, use_dev_package
 
         # Update devDependencies in emitter_package
         dev_deps = package_info["devDependencies"]
-        update_dev_dependencies(emitter_package, dev_deps)
+        unresolved = update_dev_dependencies(emitter_package, dev_deps)
+        resolve_extra_dependencies(emitter_package, unresolved, use_dev_package=False, typespec_go_root=typespec_go_root)
     
     # Print the complete emitter_package before writing
     logging.info("Complete emitter-package.json content:")


### PR DESCRIPTION
Migrates the typespec-go SDK regeneration pipeline from the Azure DevOps `sdk-regenerate.yml` in Azure/autorest.go, relocated here next to the SDK it regenerates.

## What it does
Regenerates the resource manager SDKs produced by the `@azure-tools/typespec-go` emitter and opens a draft PR against Azure/azure-sdk-for-go using this repo's native `create-pull-request` ADO template. This replaces the real ARM service specs that were removed from typespec-go's local test set when the emitter moved into Azure/typespec-azure.

## Files
- `eng/pipelines/sdk-regenerate.yml` — Azure DevOps pipeline (trigger: none, weekly schedule, `workflow`-style parameters).
- `eng/scripts/sdk_regenerate.py` — updates `eng/emitter-package.json` and regenerates SDKs. Branch/commit/push/PR are handled by the `create-pull-request` template.

## Emitter modes (both preserved from the original)
- **released** (default): pin `eng/emitter-package.json` to the latest published `@azure-tools/typespec-go` from npm.
- **dev**: build the emitter from an `Azure/typespec-azure` branch (`UseDevPackage=true`, `TypeSpecAzureRef`), `pnpm pack` it, and point `eng/emitter-package.json` at the tarball. Dependency versions are read from the packed tarball (where pnpm rewrites `workspace:` specifiers to concrete published ranges) instead of the source `package.json`.

Compile-time path variables select the correct source layout for released (self only) vs dev (self + typespec-azure) runs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


**Waiting for https://github.com/Azure/typespec-azure/pull/4628 merge first.**