### PR TITLE
cosmos: Rename GetContRange API

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Breaking Changes
 
-* Removed the external query engine integration from `QueryOptions` and deleted the `sdk/data/azcosmos/queryengine` package for the 1.5.0 GA release. This feature will return in the upcoming 1.6.0 preview release.
+* Removed the external query engine integration from `QueryOptions` and deleted the `sdk/data/azcosmos/queryengine` package for the 1.5.0 GA release. This feature will return in the upcoming 1.6.0 preview release. See [PR 27134](https://github.com/Azure/azure-sdk-for-go/pull/27134).
+* Renamed `ChangeFeedResponse.GetContRanges()` to `ChangeFeedResponse.GetContinuationRange()`. This API was previously only present in a beta release. See [PR 27148](https://github.com/Azure/azure-sdk-for-go/pull/27148).
 
 ## 1.5.0-beta.7 (2026-06-02)
 

--- a/sdk/data/azcosmos/cosmos_change_feed_response.go
+++ b/sdk/data/azcosmos/cosmos_change_feed_response.go
@@ -64,8 +64,8 @@ func (c ChangeFeedResponse) GetContinuation() string {
 	return string(c.ETag)
 }
 
-// GetContRanges extracts the continuation token range from the ChangeFeedResponse.
-func (c ChangeFeedResponse) GetContRanges() (min string, max string, ok bool) {
+// GetContinuationRange extracts the continuation token range from the ChangeFeedResponse.
+func (c ChangeFeedResponse) GetContinuationRange() (min string, max string, ok bool) {
 	if c.FeedRange != nil {
 		return c.FeedRange.MinInclusive, c.FeedRange.MaxExclusive, true
 	}
@@ -80,7 +80,7 @@ func (c ChangeFeedResponse) GetContRanges() (min string, max string, ok bool) {
 // GetCompositeContinuationToken creates a composite continuation token from the response.
 // This token combines the feed range information with the ETag for use in subsequent requests.
 func (c ChangeFeedResponse) GetCompositeContinuationToken() (string, error) {
-	min, max, ok := c.GetContRanges()
+	min, max, ok := c.GetContinuationRange()
 	if !ok {
 		return "", nil
 	}


### PR DESCRIPTION
I was reviewing the APIView (which we need approved) for 1.5.0 and this API seemed inappropriately named. It's a public API that's ONLY been present in Beta releases until now, and it's not used anywhere in our code.