### PR TITLE
Enable Go auto-release on main CI

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-go-release.yml
+++ b/eng/pipelines/templates/jobs/archetype-go-release.yml
@@ -43,13 +43,36 @@ stages:
             env:
               GH_TOKEN: $(GH_TOKEN)
 
+  # On a post-merge main CI build, resolve the merged PR and require the 'auto-release' label plus a
+  # direct change to this pipeline's package before releasing. Manual/scheduled runs skip this stage
+  # and keep releasing on the changelog/tag gate alone.
+  - ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
+    - template: /eng/common/pipelines/templates/stages/archetype-auto-release-prepare.yml
+      parameters:
+        DependsOn: ${{ parameters.DependsOn }}
+        Artifacts:
+          - ${{ if startsWith(parameters.ServiceDirectory, '../') }}:
+              name: ${{ replace(parameters.ServiceDirectory, '../', '') }}
+              safeName: ${{ replace(replace(parameters.ServiceDirectory, '../', ''), '/', '_') }}
+          - ${{ else }}:
+              name: sdk/${{ parameters.ServiceDirectory }}
+              safeName: ${{ replace(parameters.ServiceDirectory, '/', '_') }}
+
   - stage: Release
     variables:
       - template: /eng/pipelines/templates/variables/globals.yml
       - template: /eng/pipelines/templates/variables/image.yml
     displayName: 'Release: ${{ parameters.ServiceDirectory }}'
-    dependsOn: CheckRelease
-    condition: and(succeeded(), eq(dependencies.CheckRelease.outputs['CheckReleaseJob.Verify.NeedToRelease'], 'true'))
+    # On post-merge main CI, also require the auto-release label + changed-package signal from
+    # AutoReleasePrepare. Manual/scheduled runs release on the changelog/tag gate alone.
+    ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
+      dependsOn:
+        - CheckRelease
+        - AutoReleasePrepare
+      condition: and(succeeded(), eq(dependencies.CheckRelease.outputs['CheckReleaseJob.Verify.NeedToRelease'], 'true'), eq(dependencies.AutoReleasePrepare.outputs['ResolveAutoReleasePackages.resolve.AutoReleaseLabelPresent'], 'true'), eq(dependencies.AutoReleasePrepare.outputs['ResolveAutoReleasePackages.resolve.HasAutoReleaseArtifacts'], 'true'))
+    ${{ else }}:
+      dependsOn: CheckRelease
+      condition: and(succeeded(), eq(dependencies.CheckRelease.outputs['CheckReleaseJob.Verify.NeedToRelease'], 'true'))
     jobs:
       - deployment: ReleaseGate
         environment: package-publish

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -268,10 +268,10 @@ extends:
       # The Prerelease and Release stages are conditioned on:
       # 1. Internal trigger, not Pull Request trigger
       # 2. Not weekly build
-      # 3. Manual trigger or force IncludeRelease
+      # 3. Manual trigger, post-merge main CI (auto-release), or force IncludeRelease
       - ${{ if and(not(and(eq(parameters.SkipPrValidation, true), eq(variables['Build.Reason'], 'Manual'))), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal')) }}:
           - ${{ if not(contains(variables['Build.DefinitionName'], 'weekly')) }}:
-              - ${{ if or(in(variables['Build.Reason'], 'Manual', ''), eq(parameters.IncludeRelease, true)) }}:
+              - ${{ if or(in(variables['Build.Reason'], 'Manual', '', 'IndividualCI'), eq(parameters.IncludeRelease, true)) }}:
                   - template: archetype-go-release.yml
                     parameters:
                       DependsOn:


### PR DESCRIPTION
## Summary
- include Go release stages for internal post-merge `IndividualCI` builds so auto-release can run after a PR merges to `main`
- add the shared `AutoReleasePrepare` stage before `Release` on main CI builds
- require the existing `NeedToRelease` gate plus auto-release label and changed-package signals for main CI, while preserving the manual release path
