### PR TITLE
Bump aztemplate patch version to 0.6.5

### DIFF
--- a/sdk/template/aztemplate/CHANGELOG.md
+++ b/sdk/template/aztemplate/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.6.5 (2026-07-08)
+
+### Features Added
+
+* Template package validating release pipeline
+
 ## 0.6.4 (2026-07-08)
 
 ### Features Added

--- a/sdk/template/aztemplate/version.go
+++ b/sdk/template/aztemplate/version.go
@@ -9,5 +9,5 @@ const (
 	moduleName = "github.com/Azure/azure-sdk-for-go/sdk/template/aztemplate"
 
 	// moduleVersion is the semantic version (see http://semver.org) of this module.
-	moduleVersion = "v0.6.4"
+	moduleVersion = "v0.6.5"
 )


### PR DESCRIPTION
## Summary
- Bump sdk/template/aztemplate patch version to v0.6.5
- Add CHANGELOG.md entry for validating release pipeline

## Validation
- go test ./...