### PR TITLE
Upgrade emitter and TypeSpec package versions to latest

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -5,46 +5,46 @@
   "packages": {
     "": {
       "dependencies": {
-        "@azure-tools/typespec-go": "0.14.2"
+        "@azure-tools/typespec-go": "0.14.3"
       },
       "devDependencies": {
-        "@azure-tools/typespec-autorest": "0.68.0",
-        "@azure-tools/typespec-azure-core": "0.68.0",
-        "@azure-tools/typespec-azure-portal-core": "0.68.0",
-        "@azure-tools/typespec-azure-resource-manager": "0.68.0",
-        "@azure-tools/typespec-azure-rulesets": "0.68.0",
-        "@azure-tools/typespec-client-generator-core": "0.68.4",
+        "@azure-tools/typespec-autorest": "0.69.1",
+        "@azure-tools/typespec-azure-core": "0.69.0",
+        "@azure-tools/typespec-azure-portal-core": "0.69.0",
+        "@azure-tools/typespec-azure-resource-manager": "0.69.2",
+        "@azure-tools/typespec-azure-rulesets": "0.69.2",
+        "@azure-tools/typespec-client-generator-core": "0.69.2",
         "@azure-tools/typespec-liftr-base": "0.14.0",
-        "@typespec/compiler": "1.12.0",
-        "@typespec/events": "0.82.0",
-        "@typespec/http": "1.12.0",
-        "@typespec/openapi": "1.12.0",
-        "@typespec/rest": "0.82.0",
-        "@typespec/sse": "0.82.0",
-        "@typespec/streams": "0.82.0",
-        "@typespec/versioning": "0.82.0",
-        "@typespec/xml": "0.82.0"
+        "@typespec/compiler": "1.13.0",
+        "@typespec/events": "0.83.0",
+        "@typespec/http": "1.13.0",
+        "@typespec/openapi": "1.13.0",
+        "@typespec/rest": "0.83.0",
+        "@typespec/sse": "0.83.0",
+        "@typespec/streams": "0.83.0",
+        "@typespec/versioning": "0.83.0",
+        "@typespec/xml": "0.83.0"
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.68.0.tgz",
-      "integrity": "sha512-ywcB68x0jOuplKg1u9ZpjOamHbIEEgAaMuXTP72cvWXE7q1eGLCN1DQx1Uk5ME8VLJKAX6cMOMHK4hcmg9tvuw==",
+      "version": "0.69.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.69.1.tgz",
+      "integrity": "sha512-nbAsTagr4pyBO0ajlRnE5TW4tAXrYKFYSoWD+8bevXpe23bkVIJkDUJCZPSgWE7CBf3kxfw53lAb70a50oJmRA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.68.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.68.0",
-        "@azure-tools/typespec-client-generator-core": "^0.68.0",
-        "@typespec/compiler": "^1.12.0",
-        "@typespec/http": "^1.12.0",
-        "@typespec/openapi": "^1.12.0",
-        "@typespec/rest": "^0.82.0",
-        "@typespec/versioning": "^0.82.0",
-        "@typespec/xml": "^0.82.0"
+        "@azure-tools/typespec-azure-core": "^0.69.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.69.1",
+        "@azure-tools/typespec-client-generator-core": "^0.69.0",
+        "@typespec/compiler": "^1.13.0",
+        "@typespec/http": "^1.13.0",
+        "@typespec/openapi": "^1.13.0",
+        "@typespec/rest": "^0.83.0",
+        "@typespec/versioning": "^0.83.0",
+        "@typespec/xml": "^0.83.0"
       },
       "peerDependenciesMeta": {
         "@typespec/xml": {
@@ -53,34 +53,34 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.68.0.tgz",
-      "integrity": "sha512-p0qUkRZav5fdQvGe2gSCvlgsvpM0y9xVhgH2GpXi5ZzpYfNGzxd8oZr8VOCP8mjMVfGQ3AtnowbmrHALEZgz7Q==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.69.0.tgz",
+      "integrity": "sha512-UNdPb/DgMvXqwWk9hb54QOAumCJ6u6GGy+bj3RIIT1Sht6FR9rIn8AQ/UQ7WtrhbJBoqvQo5dxtS565a9/VRZw==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.12.0",
-        "@typespec/http": "^1.12.0",
-        "@typespec/rest": "^0.82.0"
+        "@typespec/compiler": "^1.13.0",
+        "@typespec/http": "^1.13.0",
+        "@typespec/rest": "^0.83.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-portal-core": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-portal-core/-/typespec-azure-portal-core-0.68.0.tgz",
-      "integrity": "sha512-X/juDa+hDR4T/QKqD2IlRZEZiKJNhJmlWUcxHAv5BF/2csviN418/+49Wo33jSfrs6ci00E3F5/K87Zvpgmvrw==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-portal-core/-/typespec-azure-portal-core-0.69.0.tgz",
+      "integrity": "sha512-f6S7wz2VdKessVkCIYTy9IFJpZakN2fvT9uQODD934Bq0tREUIeQQEbh53XWddUIJp0QFh7yJx8hTi4RWxAE9g==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@azure-tools/typespec-azure-resource-manager": "^0.68.0",
-        "@typespec/compiler": "^1.12.0"
+        "@azure-tools/typespec-azure-resource-manager": "^0.69.0",
+        "@typespec/compiler": "^1.13.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.68.0.tgz",
-      "integrity": "sha512-1zgXpOb/fGfB7SrFqawKasSOTIi9cZPWyK8V3RHyNWFZVQclEMGBzSvBHi6an4AEChqcjCSMh5MEr4BSujW4Ew==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.69.2.tgz",
+      "integrity": "sha512-8Kcn68zKwRsAOc4LICYHOeGq9w5sCDLaXp2t0x0/DibVtYlKJI3ixQnUCW1P7et0nyKp92UZNKvjdUXC1kEINg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -91,34 +91,34 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.68.0",
-        "@typespec/compiler": "^1.12.0",
-        "@typespec/http": "^1.12.0",
-        "@typespec/openapi": "^1.12.0",
-        "@typespec/rest": "^0.82.0",
-        "@typespec/versioning": "^0.82.0"
+        "@azure-tools/typespec-azure-core": "^0.69.0",
+        "@typespec/compiler": "^1.13.0",
+        "@typespec/http": "^1.13.0",
+        "@typespec/openapi": "^1.13.0",
+        "@typespec/rest": "^0.83.0",
+        "@typespec/versioning": "^0.83.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-rulesets": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.68.0.tgz",
-      "integrity": "sha512-cXZ3jiDNqJgpBQLguNgXjvAsvYo7VwtlQxFMzTr96gpoAiuBViH+3eOhVd5HA4H96NgAWSddTMHXZJZzcsnE5A==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.69.2.tgz",
+      "integrity": "sha512-7FI2Fv4weFGAjAgUnbBkh1FPCW3SxcEQElIo3SHtc4YDXYbDgvs1qCpz+eyGKEdELPnrIFJFrLa/Mu32GxSrZw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.68.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.68.0",
-        "@azure-tools/typespec-client-generator-core": "^0.68.0",
-        "@typespec/compiler": "^1.12.0"
+        "@azure-tools/typespec-azure-core": "^0.69.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.69.2",
+        "@azure-tools/typespec-client-generator-core": "^0.69.2",
+        "@typespec/compiler": "^1.13.0"
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.68.4",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.68.4.tgz",
-      "integrity": "sha512-p32EXsrSC9giZUNdsQ2gmvDENFIEW2E0zto3FmjBZ3OeB5wCw1ZAZ+KnO0rsoKFovBvHSsQatNCKJvM/x89AgA==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.69.2.tgz",
+      "integrity": "sha512-Td+CUO9UNioD/k2aFnv7TcffGGSaxmodshonTwts3/ZBJLmFtZI06odXr0+7/QDM9K9koPDjCg0VwTbS2c6scA==",
       "license": "MIT",
       "dependencies": {
         "change-case": "^5.4.4",
@@ -129,22 +129,22 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.68.0",
-        "@typespec/compiler": "^1.12.0",
-        "@typespec/events": "^0.82.0",
-        "@typespec/http": "^1.12.0",
-        "@typespec/openapi": "^1.12.0",
-        "@typespec/rest": "^0.82.0",
-        "@typespec/sse": "^0.82.0",
-        "@typespec/streams": "^0.82.0",
-        "@typespec/versioning": "^0.82.0",
-        "@typespec/xml": "^0.82.0"
+        "@azure-tools/typespec-azure-core": "^0.69.0",
+        "@typespec/compiler": "^1.13.0",
+        "@typespec/events": "^0.83.0",
+        "@typespec/http": "^1.13.0",
+        "@typespec/openapi": "^1.13.0",
+        "@typespec/rest": "^0.83.0",
+        "@typespec/sse": "^0.83.0",
+        "@typespec/streams": "^0.83.0",
+        "@typespec/versioning": "^0.83.0",
+        "@typespec/xml": "^0.83.0"
       }
     },
     "node_modules/@azure-tools/typespec-go": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-go/-/typespec-go-0.14.2.tgz",
-      "integrity": "sha512-+JPy3SkxzDL88z4PvBoO4jBO5fOY6iGgmUZ6HArEPYn4aOLnXLTCdpuoRIb/iEvx4e4dzTfCtgmdsQBcH+2pww==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-go/-/typespec-go-0.14.3.tgz",
+      "integrity": "sha512-6RLrqg7Du299Rp5rtL1us20filNStcmlIPVK79p2ryCGeaPP4ip4alJqUcg8WmOjqzwNND7MkePwGusYuQXkSA==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.7.1",
@@ -154,9 +154,9 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-client-generator-core": "^0.68.3",
-        "@typespec/compiler": "^1.12.0",
-        "@typespec/http": "^1.12.0"
+        "@azure-tools/typespec-client-generator-core": "^0.69.0",
+        "@typespec/compiler": "^1.13.0",
+        "@typespec/http": "^1.13.0"
       }
     },
     "node_modules/@azure-tools/typespec-liftr-base": {
@@ -529,9 +529,9 @@
       }
     },
     "node_modules/@typespec/compiler": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.12.0.tgz",
-      "integrity": "sha512-hKCkHEEDdCpXFyOU8ln+TzBBwonFMbkeUV0zIc+vBETyO8p/Upui3XvEyLOyB4CpKUReHzGeGm3gcFjNc73ygg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.13.0.tgz",
+      "integrity": "sha512-DonoHiyAMx0UjSmssqTrFtya+v97wny1aHcTLU5QF2wFzLATtcwUU9hbPC+eXhepuTunMOCHf8yk3pEsH6PZYA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -560,28 +560,28 @@
       }
     },
     "node_modules/@typespec/events": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.82.0.tgz",
-      "integrity": "sha512-4gxwWndMVmYF6e5ETrwW6b77h1DsSc2ZiIbNo98XePaynD6yz/ooHKKtNKacjC2gmWhfRz1ArPioYn0YHvQkxw==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.83.0.tgz",
+      "integrity": "sha512-3EP1EIjdLgwStgd2rGWaF/QqY7YRAt+DIYnnYG2VsdPwa8s2t6K6eJ9YJDXveeHImAkHs+cpFuwxnjKMl4hOyw==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.12.0"
+        "@typespec/compiler": "^1.13.0"
       }
     },
     "node_modules/@typespec/http": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.12.0.tgz",
-      "integrity": "sha512-3Bb1M6VSuEVPWOecXj3h3I/ddMpb9cmKRQQq34oq7LatiK4fwVBp+EdWbqzEzaRUGHm9mZtqsMsxZf5FndT8dg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.13.0.tgz",
+      "integrity": "sha512-tf8XFddU6g1MZSAVCLC/0Xa4fNfUO0CcHe6PWpmC3bvUojxMnpRcERI2DdoRJ+aycB9Q+Z8wN8bJO3up6u+sCw==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.12.0",
-        "@typespec/streams": "^0.82.0"
+        "@typespec/compiler": "^1.13.0",
+        "@typespec/streams": "^0.83.0"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -590,80 +590,80 @@
       }
     },
     "node_modules/@typespec/openapi": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.12.0.tgz",
-      "integrity": "sha512-XtkCMPpzXFfuIzmx/BQrCMUCCk7d37lkqZe5ubJmvJ02Fr7yvAbofrgtNUZ1BbFe3TBBUS2nB3E3mjT3tE4zCQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.13.0.tgz",
+      "integrity": "sha512-omPc9n+LM2WvjYwnIf31RCxmG17fFUOVLBRsWg4T1mbcsNCj4grnNP7Lwt+irIZCiKtmLKxq3ViE7jYixCkZ3g==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.12.0",
-        "@typespec/http": "^1.12.0"
+        "@typespec/compiler": "^1.13.0",
+        "@typespec/http": "^1.13.0"
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.82.0.tgz",
-      "integrity": "sha512-cKjKEd8lgE3EdU9b5xXLoSdKBcifITOhHS2n9LPbEG9w6APfWDWGdtUe4UKV3wxWq9HlT143wpECW7IjrPhjnA==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.83.0.tgz",
+      "integrity": "sha512-WMEwEe1kdaOdZ0c+ct5BVmTSBXkrPniUYDWCz3K52T4in2dNc7J6YGP6tL8bXgQz5B0CsP0VNO12N+UysQDsLw==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.12.0",
-        "@typespec/http": "^1.12.0"
+        "@typespec/compiler": "^1.13.0",
+        "@typespec/http": "^1.13.0"
       }
     },
     "node_modules/@typespec/sse": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.82.0.tgz",
-      "integrity": "sha512-4jBByfLsS7yQAIqmbLkfrw4XoPm9kOqawvW5gVXmKtnMMDYR0RmfBhsnAXBqhUXGbnFq0bDJGEw3GX+6k3mKnA==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.83.0.tgz",
+      "integrity": "sha512-04WNaju2rwBbcF5pG+HrKQtdcrmSGuTVziLHNA9XOqj1qM7Uon3+wo2g+ZZ3Z6tngfqQoTCPyDcRHqZtGRdNuw==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.12.0",
-        "@typespec/events": "^0.82.0",
-        "@typespec/http": "^1.12.0",
-        "@typespec/streams": "^0.82.0"
+        "@typespec/compiler": "^1.13.0",
+        "@typespec/events": "^0.83.0",
+        "@typespec/http": "^1.13.0",
+        "@typespec/streams": "^0.83.0"
       }
     },
     "node_modules/@typespec/streams": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.82.0.tgz",
-      "integrity": "sha512-cr/6h6VV/6OJeG8RNcSd0SDes5iEXiuGUcKGrMN6wF8qKTTrY2hXNhfqCCn3lamDOg00wbi7ke+laz6pHWN3tg==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.83.0.tgz",
+      "integrity": "sha512-wbO6sdH1Uf+UwjxxsWdHQkjJ3wwiYsAKI+L66qnDYVXAFe02sUdMKd0mxH5o9ipGXE52MZ+yvZ52vHAD+g3RFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.12.0"
+        "@typespec/compiler": "^1.13.0"
       }
     },
     "node_modules/@typespec/versioning": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.82.0.tgz",
-      "integrity": "sha512-s8giuYQTQPniy2YxNfKXYpAU2Vm4L74TdOsbFWe0tG+jnOy/9tt7kKTH4QF1sB8nRvmjv8h31EoHtZYOPe1GvA==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.83.0.tgz",
+      "integrity": "sha512-nE66ta0ixpHB6FQpSzqnj8QnVfgFsxeK/4Xv+DxYx2nB/w18f6VjkF+hW+A/zs1tZIYvBZVbCNa/Rcr8zM6fhg==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.12.0"
+        "@typespec/compiler": "^1.13.0"
       }
     },
     "node_modules/@typespec/xml": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.82.0.tgz",
-      "integrity": "sha512-/Bwlt7HwSltojSbalkh7hGRh/lB5aMJllnb7gAAf3xRPMlnmu5VJqDFFcbZKqDvkwgGXZX/xHo458c4kott5Ug==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.83.0.tgz",
+      "integrity": "sha512-2/dtAD8jGPkIdwpQ1G1P+5+qdMPeafQiIKCd8NdAnOo0w9OZ59Io52jINm9HdN8+FcbOrqK8+B2N9rlPRj7PqA==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.12.0"
+        "@typespec/compiler": "^1.13.0"
       }
     },
     "node_modules/ajv": {

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -1,24 +1,24 @@
 {
   "main": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/typespec-go": "0.14.2"
+    "@azure-tools/typespec-go": "0.14.3"
   },
   "devDependencies": {
-    "@azure-tools/typespec-autorest": "0.68.0",
-    "@azure-tools/typespec-azure-core": "0.68.0",
-    "@azure-tools/typespec-azure-portal-core": "0.68.0",
-    "@azure-tools/typespec-azure-resource-manager": "0.68.0",
-    "@azure-tools/typespec-azure-rulesets": "0.68.0",
-    "@azure-tools/typespec-client-generator-core": "0.68.4",
+    "@azure-tools/typespec-autorest": "0.69.1",
+    "@azure-tools/typespec-azure-core": "0.69.0",
+    "@azure-tools/typespec-azure-portal-core": "0.69.0",
+    "@azure-tools/typespec-azure-resource-manager": "0.69.2",
+    "@azure-tools/typespec-azure-rulesets": "0.69.2",
+    "@azure-tools/typespec-client-generator-core": "0.69.2",
     "@azure-tools/typespec-liftr-base": "0.14.0",
-    "@typespec/compiler": "1.12.0",
-    "@typespec/events": "0.82.0",
-    "@typespec/http": "1.12.0",
-    "@typespec/openapi": "1.12.0",
-    "@typespec/rest": "0.82.0",
-    "@typespec/sse": "0.82.0",
-    "@typespec/streams": "0.82.0",
-    "@typespec/versioning": "0.82.0",
-    "@typespec/xml": "0.82.0"
+    "@typespec/compiler": "1.13.0",
+    "@typespec/events": "0.83.0",
+    "@typespec/http": "1.13.0",
+    "@typespec/openapi": "1.13.0",
+    "@typespec/rest": "0.83.0",
+    "@typespec/sse": "0.83.0",
+    "@typespec/streams": "0.83.0",
+    "@typespec/versioning": "0.83.0",
+    "@typespec/xml": "0.83.0"
   }
 }


### PR DESCRIPTION
Upgrades the Go emitter package and TypeSpec-related packages in `eng/emitter-package.json` to their latest versions and regenerates `eng/emitter-package-lock.json`.

### Version changes

| Package | From | To |
| --- | --- | --- |
| `@azure-tools/typespec-go` | 0.14.2 | 0.14.3 |
| `@azure-tools/typespec-autorest` | 0.68.0 | 0.69.1 |
| `@azure-tools/typespec-azure-core` | 0.68.0 | 0.69.0 |
| `@azure-tools/typespec-azure-portal-core` | 0.68.0 | 0.69.0 |
| `@azure-tools/typespec-azure-resource-manager` | 0.68.0 | 0.69.2 |
| `@azure-tools/typespec-azure-rulesets` | 0.68.0 | 0.69.2 |
| `@azure-tools/typespec-client-generator-core` | 0.68.4 | 0.69.2 |
| `@typespec/compiler` | 1.12.0 | 1.13.0 |
| `@typespec/http` | 1.12.0 | 1.13.0 |
| `@typespec/openapi` | 1.12.0 | 1.13.0 |
| `@typespec/events` | 0.82.0 | 0.83.0 |
| `@typespec/rest` | 0.82.0 | 0.83.0 |
| `@typespec/sse` | 0.82.0 | 0.83.0 |
| `@typespec/streams` | 0.82.0 | 0.83.0 |
| `@typespec/versioning` | 0.82.0 | 0.83.0 |
| `@typespec/xml` | 0.82.0 | 0.83.0 |

`@azure-tools/typespec-liftr-base` remains at 0.14.0 (already latest).