### PR TITLE
Added ExpirationTime field to Role Assignment response DTO for version 2026-07-01-preview

### DIFF
--- a/sdk/security/keyvault/azadmin/CHANGELOG.md
+++ b/sdk/security/keyvault/azadmin/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 1.6.0-beta.2 (Unreleased)
 
 #### Features Added
+* Added the `ExpirationTime` field to `RoleAssignmentPropertiesWithScope`, exposing the expiration time of a role assignment in the get and list role assignment responses.
 
 #### Breaking Changes
 

--- a/sdk/security/keyvault/azadmin/rbac/models.go
+++ b/sdk/security/keyvault/azadmin/rbac/models.go
@@ -61,6 +61,9 @@ type RoleAssignmentProperties struct {
 
 // RoleAssignmentPropertiesWithScope - Role assignment properties with scope.
 type RoleAssignmentPropertiesWithScope struct {
+	// The expiration time of the role assignment.
+	ExpirationTime *string
+
 	// The principal ID.
 	PrincipalID *string
 

--- a/sdk/security/keyvault/azadmin/rbac/models_serde.go
+++ b/sdk/security/keyvault/azadmin/rbac/models_serde.go
@@ -181,6 +181,7 @@ func (r *RoleAssignmentProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type RoleAssignmentPropertiesWithScope.
 func (r RoleAssignmentPropertiesWithScope) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
+	populate(objectMap, "expirationTime", r.ExpirationTime)
 	populate(objectMap, "principalId", r.PrincipalID)
 	populate(objectMap, "roleDefinitionId", r.RoleDefinitionID)
 	populate(objectMap, "scope", r.Scope)
@@ -196,6 +197,9 @@ func (r *RoleAssignmentPropertiesWithScope) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
+		case "expirationTime":
+			err = unpopulate(val, "ExpirationTime", &r.ExpirationTime)
+			delete(rawMsg, key)
 		case "principalId":
 			err = unpopulate(val, "PrincipalID", &r.PrincipalID)
 			delete(rawMsg, key)


### PR DESCRIPTION
Added ExpirationTime field to Role Assignment response DTO for version 2026-07-01-preview

https://github.com/Azure/azure-rest-api-specs/pull/44421

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [ ] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [ ] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
- [ ] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
