### PR TITLE
Cosmos: API Review Updates

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -8,14 +8,14 @@
 
 * Removed the external query engine integration from `QueryOptions` and deleted the `sdk/data/azcosmos/queryengine` package for the 1.5.0 GA release. This feature will return in the upcoming 1.6.0 preview release. See [PR 27134](https://github.com/Azure/azure-sdk-for-go/pull/27134).
 * Renamed `ChangeFeedResponse.GetContRanges()` to `ChangeFeedResponse.GetContinuationRange()`. This API was previously only present in a beta release. See [PR 27148](https://github.com/Azure/azure-sdk-for-go/pull/27148).
-* Renamed `ChangeFeedRangeOptions.EpkMinHeader` and `ChangeFeedRangeOptions.EpkMaxHeader` to `EPKMinHeader` and `EPKMaxHeader`. These fields were previously only present in a beta release.
-* `Diagnostics.StartTimeUTC()` now returns a `time.Time` (zero value when no diagnostics are present) instead of a `*time.Time`. This API was previously only present in a beta release.
-* Removed the `NewFeedRange` constructor. Construct a `FeedRange` directly using a struct initializer instead. This API was previously only present in a beta release.
-* Removed the `PriorityLevel.ToPtr` method. Use [`to.Ptr`](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azcore/to#Ptr) from `azcore` instead. This API was previously only present in a beta release.
+* Renamed `ChangeFeedRangeOptions.EpkMinHeader` and `ChangeFeedRangeOptions.EpkMaxHeader` to `EPKMinHeader` and `EPKMaxHeader`. These fields were previously only present in a beta release. See [PR 27166](https://github.com/Azure/azure-sdk-for-go/pull/27166).
+* `Diagnostics.StartTimeUTC()` now returns a `time.Time` (zero value when no diagnostics are present) instead of a `*time.Time`. This API was previously only present in a beta release. See [PR 27166](https://github.com/Azure/azure-sdk-for-go/pull/27166).
+* Removed the `NewFeedRange` constructor. Construct a `FeedRange` directly using a struct initializer instead. This API was previously only present in a beta release. See [PR 27166](https://github.com/Azure/azure-sdk-for-go/pull/27166).
+* Removed the `PriorityLevel.ToPtr` method. Use [`to.Ptr`](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azcore/to#Ptr) from `azcore` instead. This API was previously only present in a beta release. See [PR 27166](https://github.com/Azure/azure-sdk-for-go/pull/27166).
 
 ### Other Changes
 
-* The per-account metadata caches (the shared container-properties and partition-key-range caches, see [PR 26723](https://github.com/Azure/azure-sdk-for-go/pull/26723)) are now held in the process-wide registry via weak references. This lets the garbage collector reclaim a `Client`'s caches once the client is discarded, greatly reducing the memory retained when a `Client` is dropped without calling `Close`.
+* The per-account metadata caches (the shared container-properties and partition-key-range caches, see [PR 26723](https://github.com/Azure/azure-sdk-for-go/pull/26723)) are now held in the process-wide registry via weak references. This lets the garbage collector reclaim a `Client`'s caches once the client is discarded, greatly reducing the memory retained when a `Client` is dropped without calling `Close`. See [PR 27166](https://github.com/Azure/azure-sdk-for-go/pull/27166).
 
 ## 1.5.0-beta.7 (2026-06-02)
 

--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 <!-- cSpell:ignore documentdb unmarshalling -->
 
-## 1.5.0 (2026-07-07)
+## 1.5.0 (2026-07-13)
 
 ### Breaking Changes
 
 * Removed the external query engine integration from `QueryOptions` and deleted the `sdk/data/azcosmos/queryengine` package for the 1.5.0 GA release. This feature will return in the upcoming 1.6.0 preview release. See [PR 27134](https://github.com/Azure/azure-sdk-for-go/pull/27134).
 * Renamed `ChangeFeedResponse.GetContRanges()` to `ChangeFeedResponse.GetContinuationRange()`. This API was previously only present in a beta release. See [PR 27148](https://github.com/Azure/azure-sdk-for-go/pull/27148).
+* Renamed `ChangeFeedRangeOptions.EpkMinHeader` and `ChangeFeedRangeOptions.EpkMaxHeader` to `EPKMinHeader` and `EPKMaxHeader`. These fields were previously only present in a beta release.
+* `Diagnostics.StartTimeUTC()` now returns a `time.Time` (zero value when no diagnostics are present) instead of a `*time.Time`. This API was previously only present in a beta release.
+* Removed the `NewFeedRange` constructor. Construct a `FeedRange` directly using a struct initializer instead. This API was previously only present in a beta release.
+* Removed the `PriorityLevel.ToPtr` method. Use [`to.Ptr`](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azcore/to#Ptr) from `azcore` instead. This API was previously only present in a beta release.
 
 ## 1.5.0-beta.7 (2026-06-02)
 

--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -13,6 +13,10 @@
 * Removed the `NewFeedRange` constructor. Construct a `FeedRange` directly using a struct initializer instead. This API was previously only present in a beta release.
 * Removed the `PriorityLevel.ToPtr` method. Use [`to.Ptr`](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azcore/to#Ptr) from `azcore` instead. This API was previously only present in a beta release.
 
+### Other Changes
+
+* The per-account metadata caches (the shared container-properties and partition-key-range caches, see [PR 26723](https://github.com/Azure/azure-sdk-for-go/pull/26723)) are now held in the process-wide registry via weak references. This lets the garbage collector reclaim a `Client`'s caches once the client is discarded, greatly reducing the memory retained when a `Client` is dropped without calling `Close`.
+
 ## 1.5.0-beta.7 (2026-06-02)
 
 ### Features Added

--- a/sdk/data/azcosmos/cosmos_change_feed_range.go
+++ b/sdk/data/azcosmos/cosmos_change_feed_range.go
@@ -26,10 +26,10 @@ type changeFeedRange struct {
 type ChangeFeedRangeOptions struct {
 	// ContinuationToken is used to continue reading the change feed from a specific point.
 	ContinuationToken *azcore.ETag
-	// EpkMinHeader is the header for the minimum inclusive value of the partition key range.
-	EpkMinHeader *string
-	// EpkMaxHeader is the header for the maximum exclusive value of the partition key range.
-	EpkMaxHeader *string
+	// EPKMinHeader is the header for the minimum inclusive value of the partition key range.
+	EPKMinHeader *string
+	// EPKMaxHeader is the header for the maximum exclusive value of the partition key range.
+	EPKMaxHeader *string
 }
 
 // newChangeFeedRange creates a new changeFeedRange with the specified minimum inclusive and maximum exclusive values.
@@ -46,11 +46,11 @@ func newChangeFeedRange(minInclusive, maxExclusive string, options *ChangeFeedRa
 			continuationETag := *options.ContinuationToken
 			result.ContinuationToken = &continuationETag
 		}
-		if options.EpkMinHeader != nil {
-			result.epkMinHeader = *options.EpkMinHeader
+		if options.EPKMinHeader != nil {
+			result.epkMinHeader = *options.EPKMinHeader
 		}
-		if options.EpkMaxHeader != nil {
-			result.epkMaxHeader = *options.EpkMaxHeader
+		if options.EPKMaxHeader != nil {
+			result.epkMaxHeader = *options.EPKMaxHeader
 		}
 	}
 

--- a/sdk/data/azcosmos/cosmos_change_feed_range_test.go
+++ b/sdk/data/azcosmos/cosmos_change_feed_range_test.go
@@ -18,8 +18,8 @@ func TestNewChangeFeedRangeBasic(t *testing.T) {
 
 	options := &ChangeFeedRangeOptions{
 		ContinuationToken: &token,
-		EpkMinHeader:      &minHeader,
-		EpkMaxHeader:      &maxHeader,
+		EPKMinHeader:      &minHeader,
+		EPKMaxHeader:      &maxHeader,
 	}
 
 	cfr := newChangeFeedRange(min, max, options)

--- a/sdk/data/azcosmos/cosmos_feed_range.go
+++ b/sdk/data/azcosmos/cosmos_feed_range.go
@@ -44,14 +44,6 @@ type FeedRange struct {
 	MaxExclusive string
 }
 
-// NewFeedRange creates a new FeedRange with the specified minimum inclusive and maximum exclusive values.
-func NewFeedRange(minInclusive, maxExclusive string) FeedRange {
-	return FeedRange{
-		MinInclusive: minInclusive,
-		MaxExclusive: maxExclusive,
-	}
-}
-
 // overlappingPartitionKeyRanges returns the subset of partitionKeyRanges whose
 // boundaries overlap the given feedRange, preserving input order. Returns nil
 // on no overlap (no error).

--- a/sdk/data/azcosmos/cosmos_global_cache_registry.go
+++ b/sdk/data/azcosmos/cosmos_global_cache_registry.go
@@ -40,18 +40,38 @@ type cacheRegistryEntry struct {
 var globalCacheRegistry sync.Map // map[string]*cacheRegistryEntry
 
 // normalizeEndpoint returns a canonical form of the endpoint for use as a
-// registry key. It lowercases the host and strips ports and paths so that
-// endpoints like "https://account.documents.azure.com:443/" and
-// "https://account.documents.azure.com" resolve to the same key. Ports are
-// stripped entirely because the same account is the same account regardless
-// of the port used to reach it.
+// registry key. It lowercases the host and strips paths. The port is included
+// only when it is not the scheme's default (443 for https, 80 for http); a
+// port that matches the scheme default is removed so that
+// "https://account.documents.azure.com:443/" and
+// "https://account.documents.azure.com" resolve to the same key.
+//
+// Non-default ports are deliberately preserved so that distinct targets such
+// as multiple emulator instances or proxy/forwarding configurations are never
+// collapsed onto a single cache entry. Confusing two account endpoints for one
+// another would be a major failure, so we err on the side of keeping keys
+// distinct.
 func normalizeEndpoint(endpoint string) string {
 	u, err := url.Parse(strings.TrimSpace(endpoint))
 	if err != nil || u.Host == "" {
 		// Fallback for malformed input
 		return strings.TrimRight(strings.ToLower(endpoint), "/")
 	}
-	return u.Scheme + "://" + strings.ToLower(u.Hostname())
+
+	scheme := strings.ToLower(u.Scheme)
+	port := u.Port()
+	switch {
+	case scheme == "https" && port == "443":
+		port = ""
+	case scheme == "http" && port == "80":
+		port = ""
+	}
+
+	host := strings.ToLower(u.Hostname())
+	if port == "" {
+		return scheme + "://" + host
+	}
+	return scheme + "://" + host + ":" + port
 }
 
 // acquireCaches returns the shared cache set for the given endpoint, creating

--- a/sdk/data/azcosmos/cosmos_global_cache_registry.go
+++ b/sdk/data/azcosmos/cosmos_global_cache_registry.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
-	"sync/atomic"
+	"weak"
 )
 
 // sharedCacheSet groups the metadata caches that are shared across all Client
@@ -17,12 +17,27 @@ import (
 type sharedCacheSet struct {
 	containerCache *containerPropertiesCache
 	pkRangeCache   *partitionKeyRangeCache
-	refCount       atomic.Int64
+}
+
+// cacheRegistryEntry is the small, stable value kept strongly in the registry
+// map for a given endpoint. It holds only a weak reference to the potentially
+// large sharedCacheSet, so the caches become eligible for garbage collection
+// once the last Client holding a strong reference is discarded — even if the
+// user never calls Close. The entry itself (a mutex, a weak pointer, and an
+// int) is the only per-endpoint memory that leaks in that case.
+//
+// The mutex makes the refCount adjustment and the weak-pointer check atomic as
+// a unit. Client creation is not a hot path, so a per-endpoint lock is an
+// acceptable simplification over lock-free reference counting.
+type cacheRegistryEntry struct {
+	mu       sync.Mutex
+	weakRef  weak.Pointer[sharedCacheSet]
+	refCount int // guarded by mu
 }
 
 // globalCacheRegistry is a process-level registry of shared cache sets keyed
 // by normalized account endpoint. It ensures singleton caches per account.
-var globalCacheRegistry sync.Map // map[string]*sharedCacheSet
+var globalCacheRegistry sync.Map // map[string]*cacheRegistryEntry
 
 // normalizeEndpoint returns a canonical form of the endpoint for use as a
 // registry key. It lowercases the host and strips ports and paths so that
@@ -40,58 +55,68 @@ func normalizeEndpoint(endpoint string) string {
 }
 
 // acquireCaches returns the shared cache set for the given endpoint, creating
-// one if it doesn't exist. The caller must call releaseCaches when the Client
-// is closed to allow cleanup.
+// one if it doesn't exist. The returned pointer is a strong reference that the
+// caller (the Client) must retain; the registry keeps only a weak reference, so
+// the caches are reclaimed once every Client for the endpoint is discarded.
+// The caller should call releaseCaches when the Client is closed to
+// deterministically remove the (small) registry entry.
 //
-// The implementation uses a verify-after-increment pattern to prevent a TOCTOU
-// race with releaseCaches: after incrementing the refCount, it confirms the
-// entry is still in the registry. If a concurrent release evicted it, the
-// increment is undone and the loop retries.
+// A fresh cache set is created when the endpoint has no entry, when a previous
+// set was garbage collected (because all its Clients were discarded without
+// Close), or when a previous set was deterministically released. This covers
+// callers that frequently create and discard Clients for the same endpoint.
 func acquireCaches(endpoint string) *sharedCacheSet {
 	key := normalizeEndpoint(endpoint)
 
 	for {
-		if val, ok := globalCacheRegistry.Load(key); ok {
-			set := val.(*sharedCacheSet)
-			set.refCount.Add(1)
-			// Verify the entry is still registered after we incremented.
-			// A concurrent releaseCaches could have evicted it between our
-			// Load and Add, leaving us with an orphaned cache set.
-			if val2, ok2 := globalCacheRegistry.Load(key); ok2 && val2 == val {
-				return set
-			}
-			// Entry was evicted — undo our increment and retry.
-			set.refCount.Add(-1)
+		val, _ := globalCacheRegistry.LoadOrStore(key, &cacheRegistryEntry{})
+		entry := val.(*cacheRegistryEntry)
+
+		entry.mu.Lock()
+		// A concurrent releaseCaches may have removed this exact entry from the
+		// registry after our LoadOrStore. If so, retry so we don't attach to an
+		// orphaned entry that other callers can no longer find.
+		if cur, ok := globalCacheRegistry.Load(key); !ok || cur != val {
+			entry.mu.Unlock()
 			continue
 		}
 
-		// Slow path: create new and use LoadOrStore to avoid races
-		newSet := &sharedCacheSet{
+		if set := entry.weakRef.Value(); set != nil {
+			entry.refCount++
+			entry.mu.Unlock()
+			return set
+		}
+
+		// The endpoint was never populated, or its cache set was collected or
+		// released. Create a fresh set and reset the count.
+		set := &sharedCacheSet{
 			containerCache: newContainerPropertiesCache(),
 			pkRangeCache:   newPartitionKeyRangeCache(),
 		}
-		newSet.refCount.Store(1)
-
-		_, loaded := globalCacheRegistry.LoadOrStore(key, newSet)
-		if loaded {
-			// Another goroutine created it first — use theirs via the retry loop
-			// to get the verify-after-increment safety.
-			continue
-		}
-		return newSet
+		entry.weakRef = weak.Make(set)
+		entry.refCount = 1
+		entry.mu.Unlock()
+		return set
 	}
 }
 
 // releaseCaches decrements the reference count for the given endpoint's cache
-// set and removes it from the registry when no clients remain.
+// set and removes the entry from the registry when no clients remain.
 func releaseCaches(endpoint string) {
 	key := normalizeEndpoint(endpoint)
-	if val, ok := globalCacheRegistry.Load(key); ok {
-		set := val.(*sharedCacheSet)
-		if set.refCount.Add(-1) <= 0 {
-			globalCacheRegistry.CompareAndDelete(key, val)
-		}
+	val, ok := globalCacheRegistry.Load(key)
+	if !ok {
+		return
 	}
+	entry := val.(*cacheRegistryEntry)
+	entry.mu.Lock()
+	entry.refCount--
+	if entry.refCount <= 0 {
+		entry.refCount = 0
+		entry.weakRef = weak.Pointer[sharedCacheSet]{}
+		globalCacheRegistry.CompareAndDelete(key, val)
+	}
+	entry.mu.Unlock()
 }
 
 // resetGlobalCacheRegistry clears the global cache registry.

--- a/sdk/data/azcosmos/cosmos_global_cache_registry_test.go
+++ b/sdk/data/azcosmos/cosmos_global_cache_registry_test.go
@@ -5,12 +5,27 @@ package azcosmos
 
 import (
 	"context"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"weak"
 
 	"github.com/stretchr/testify/require"
 )
+
+// registryRefCount returns the current reference count recorded in the registry
+// entry for the given endpoint, or -1 if no entry exists. Test helper.
+func registryRefCount(endpoint string) int {
+	val, ok := globalCacheRegistry.Load(normalizeEndpoint(endpoint))
+	if !ok {
+		return -1
+	}
+	entry := val.(*cacheRegistryEntry)
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	return entry.refCount
+}
 
 func TestNormalizeEndpoint(t *testing.T) {
 	tests := []struct {
@@ -45,7 +60,7 @@ func TestAcquireCaches_SameEndpoint_ReturnsSameInstance(t *testing.T) {
 
 	require.Same(t, set1, set2, "same endpoint should return same cache set")
 	require.Same(t, set1, set3, "normalization should make these equivalent")
-	require.Equal(t, int64(3), set1.refCount.Load())
+	require.Equal(t, 3, registryRefCount("https://account1.documents.azure.com/"))
 }
 
 func TestAcquireCaches_DifferentEndpoints_ReturnDifferentInstances(t *testing.T) {
@@ -69,12 +84,12 @@ func TestReleaseCaches_RemovesEntryWhenZeroRefs(t *testing.T) {
 	_ = acquireCaches(endpoint) // refCount = 2
 
 	releaseCaches(endpoint) // refCount = 1
-	require.Equal(t, int64(1), set1.refCount.Load())
+	require.Equal(t, 1, registryRefCount(endpoint))
 
 	// Entry should still be in the registry
 	val, ok := globalCacheRegistry.Load(normalizeEndpoint(endpoint))
 	require.True(t, ok)
-	require.Same(t, set1, val.(*sharedCacheSet))
+	require.Same(t, set1, val.(*cacheRegistryEntry).weakRef.Value())
 
 	releaseCaches(endpoint) // refCount = 0 → removed
 	_, ok = globalCacheRegistry.Load(normalizeEndpoint(endpoint))
@@ -91,6 +106,80 @@ func TestReleaseCaches_NewAcquireAfterFullRelease_CreatesNew(t *testing.T) {
 
 	set2 := acquireCaches(endpoint) // new instance
 	require.NotSame(t, set1, set2, "should create a fresh cache set after full release")
+}
+
+func TestAcquireCaches_CollectedWhenClientDiscardedWithoutClose(t *testing.T) {
+	resetGlobalCacheRegistry()
+	defer resetGlobalCacheRegistry()
+
+	endpoint := "https://account1.documents.azure.com"
+
+	// Acquire a cache set the way a Client would, but never call releaseCaches
+	// (i.e. never call Close) and drop the only strong reference — simulating a
+	// discarded Client. The set escapes only through the weak registry entry.
+	weakRef := func() weak.Pointer[sharedCacheSet] {
+		set := acquireCaches(endpoint)
+		require.NotNil(t, set)
+		val, ok := globalCacheRegistry.Load(normalizeEndpoint(endpoint))
+		require.True(t, ok)
+		w := val.(*cacheRegistryEntry).weakRef
+		require.NotNil(t, w.Value())
+		return w
+	}()
+
+	// Because the registry holds only a weak reference, the cache set becomes
+	// eligible for collection once the discarded Client's strong reference is
+	// gone — even though Close was never called.
+	collected := false
+	for i := 0; i < 100; i++ {
+		runtime.GC()
+		if weakRef.Value() == nil {
+			collected = true
+			break
+		}
+	}
+	require.True(t, collected, "cache set should be reclaimed once the discarded client's strong ref is gone")
+
+	// The small registry entry remains, but reacquiring must build a fresh set.
+	set2 := acquireCaches(endpoint)
+	require.NotNil(t, set2)
+	val, ok := globalCacheRegistry.Load(normalizeEndpoint(endpoint))
+	require.True(t, ok)
+	require.Same(t, set2, val.(*cacheRegistryEntry).weakRef.Value())
+	releaseCaches(endpoint)
+}
+
+func TestAcquireCaches_ReacquireAfterCollectionResetsRefCount(t *testing.T) {
+	resetGlobalCacheRegistry()
+	defer resetGlobalCacheRegistry()
+
+	endpoint := "https://account1.documents.azure.com"
+
+	// Two acquires, no releases, then both strong refs discarded (leaked clients).
+	weakRef := func() weak.Pointer[sharedCacheSet] {
+		_ = acquireCaches(endpoint)
+		_ = acquireCaches(endpoint) // refCount = 2; both refs dropped on return
+		val, ok := globalCacheRegistry.Load(normalizeEndpoint(endpoint))
+		require.True(t, ok)
+		return val.(*cacheRegistryEntry).weakRef
+	}()
+	require.Equal(t, 2, registryRefCount(endpoint))
+
+	collected := false
+	for i := 0; i < 100; i++ {
+		runtime.GC()
+		if weakRef.Value() == nil {
+			collected = true
+			break
+		}
+	}
+	require.True(t, collected, "cache set should be reclaimed after both leaked refs are gone")
+
+	// A fresh acquire must reset the stale refCount to 1, not resume from 2.
+	set := acquireCaches(endpoint)
+	require.NotNil(t, set)
+	require.Equal(t, 1, registryRefCount(endpoint))
+	releaseCaches(endpoint)
 }
 
 func TestSharedCaches_CrossClientCacheHit(t *testing.T) {
@@ -265,7 +354,7 @@ func TestAcquireCaches_ConcurrentSafe(t *testing.T) {
 	for i := 1; i < goroutines; i++ {
 		require.Same(t, results[0], results[i], "concurrent acquires should return same instance")
 	}
-	require.Equal(t, int64(goroutines), results[0].refCount.Load())
+	require.Equal(t, goroutines, registryRefCount(endpoint))
 }
 
 func TestAcquireCaches_ResilientToInterleavedRelease(t *testing.T) {
@@ -284,7 +373,7 @@ func TestAcquireCaches_ResilientToInterleavedRelease(t *testing.T) {
 	// Now a new acquire should create a fresh set (the old one is gone)
 	set2 := acquireCaches(endpoint)
 	require.NotSame(t, set1, set2, "after full release, a new set should be created")
-	require.Equal(t, int64(1), set2.refCount.Load())
+	require.Equal(t, 1, registryRefCount(endpoint))
 
 	// Stress test: interleave acquires and releases concurrently
 	const goroutines = 100
@@ -297,7 +386,7 @@ func TestAcquireCaches_ResilientToInterleavedRelease(t *testing.T) {
 			// Verify the returned set is actually in the registry
 			val, ok := globalCacheRegistry.Load(normalizeEndpoint(endpoint))
 			require.True(t, ok, "acquired set must be in registry")
-			require.Same(t, s, val.(*sharedCacheSet), "acquired set must match registry entry")
+			require.Same(t, s, val.(*cacheRegistryEntry).weakRef.Value(), "acquired set must match registry entry")
 			releaseCaches(endpoint)
 		}()
 	}
@@ -306,8 +395,8 @@ func TestAcquireCaches_ResilientToInterleavedRelease(t *testing.T) {
 	// set2 should still be valid (we haven't released it)
 	val, ok := globalCacheRegistry.Load(normalizeEndpoint(endpoint))
 	require.True(t, ok)
-	require.Same(t, set2, val.(*sharedCacheSet))
-	require.Equal(t, int64(1), set2.refCount.Load())
+	require.Same(t, set2, val.(*cacheRegistryEntry).weakRef.Value())
+	require.Equal(t, 1, registryRefCount(endpoint))
 	releaseCaches(endpoint)
 }
 
@@ -326,10 +415,9 @@ func TestClientClose_Idempotent(t *testing.T) {
 	client.Close() // still idempotent
 
 	// RefCount should be 1 (the second acquire), not -1 or 0
-	val, ok := globalCacheRegistry.Load(normalizeEndpoint(endpoint))
+	_, ok := globalCacheRegistry.Load(normalizeEndpoint(endpoint))
 	require.True(t, ok, "entry should still exist — second reference is alive")
-	set := val.(*sharedCacheSet)
-	require.Equal(t, int64(1), set.refCount.Load())
+	require.Equal(t, 1, registryRefCount(endpoint))
 
 	// Clean up the second reference
 	releaseCaches(endpoint)

--- a/sdk/data/azcosmos/cosmos_global_cache_registry_test.go
+++ b/sdk/data/azcosmos/cosmos_global_cache_registry_test.go
@@ -38,9 +38,11 @@ func TestNormalizeEndpoint(t *testing.T) {
 		{"https://myaccount.documents.azure.com:443/", "https://myaccount.documents.azure.com"},
 		{"https://myaccount.documents.azure.com:443", "https://myaccount.documents.azure.com"},
 		{"http://myaccount.documents.azure.com:80", "http://myaccount.documents.azure.com"},
-		{"https://localhost:8081/", "https://localhost"},
-		{"https://localhost:8081", "https://localhost"},
+		{"https://localhost:8081/", "https://localhost:8081"},
+		{"https://localhost:8081", "https://localhost:8081"},
 		{"  https://myaccount.documents.azure.com  ", "https://myaccount.documents.azure.com"},
+		{"https://myaccount.documents.azure.com:8081", "https://myaccount.documents.azure.com:8081"},
+		{"http://localhost:8081", "http://localhost:8081"},
 	}
 
 	for _, tt := range tests {

--- a/sdk/data/azcosmos/cosmos_priority_level.go
+++ b/sdk/data/azcosmos/cosmos_priority_level.go
@@ -21,8 +21,3 @@ const (
 func PriorityLevelValues() []PriorityLevel {
 	return []PriorityLevel{PriorityLevelHigh, PriorityLevelLow}
 }
-
-// ToPtr returns a *PriorityLevel.
-func (p PriorityLevel) ToPtr() *PriorityLevel {
-	return &p
-}

--- a/sdk/data/azcosmos/cosmos_priority_level_test.go
+++ b/sdk/data/azcosmos/cosmos_priority_level_test.go
@@ -15,9 +15,3 @@ func TestPriorityLevelValues(t *testing.T) {
 	require.Equal(t, PriorityLevelHigh, values[0], "expected first value to be High")
 	require.Equal(t, PriorityLevelLow, values[1], "expected second value to be Low")
 }
-
-func TestPriorityLevelToPtr(t *testing.T) {
-	ptr := PriorityLevelHigh.ToPtr()
-	require.NotNil(t, ptr, "expected non-nil pointer")
-	require.Equal(t, PriorityLevelHigh, *ptr, "expected High")
-}

--- a/sdk/data/azcosmos/diagnostics.go
+++ b/sdk/data/azcosmos/diagnostics.go
@@ -58,13 +58,12 @@ func (d Diagnostics) ClientElapsedTime() time.Duration {
 }
 
 // StartTimeUTC returns the UTC start time of the request.
-func (d Diagnostics) StartTimeUTC() *time.Time {
+func (d Diagnostics) StartTimeUTC() time.Time {
 	if d.root == nil {
-		return nil
+		return time.Time{}
 	}
 
-	start := d.root.startTime
-	return &start
+	return d.root.startTime
 }
 
 // FailedRequestCount returns the number of failed backend attempts recorded for the request.

--- a/sdk/data/azcosmos/version.go
+++ b/sdk/data/azcosmos/version.go
@@ -7,5 +7,5 @@ const (
 	moduleName = "github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 
 	// serviceLibVersion is the semantic version (see http://semver.org) of this module.
-	serviceLibVersion = "v1.6.0-beta.1"
+	serviceLibVersion = "v1.5.0"
 )

--- a/sdk/data/azcosmos/version.go
+++ b/sdk/data/azcosmos/version.go
@@ -7,5 +7,5 @@ const (
 	moduleName = "github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 
 	// serviceLibVersion is the semantic version (see http://semver.org) of this module.
-	serviceLibVersion = "v1.5.0"
+	serviceLibVersion = "v1.6.0-beta.1"
 )


### PR DESCRIPTION
Some minor API review updates, as well as a change to use weak pointers in the global per-endpoint cache registry, to reduce the memory leak impact of failing to call `Close` on a `Client` instance. We should now only leak the map entry itself, not any of the actual caches. The leak risk is low, since it would only occur when failing to call Close **and** would only really become relevant when connecting and disconnecting from lots of accounts in the same process.