### PR TITLE
Regenerate azblob from swagger

### DIFF
--- a/sdk/storage/azblob/internal/generated/autorest.md
+++ b/sdk/storage/azblob/internal/generated/autorest.md
@@ -7,7 +7,7 @@ go: true
 clear-output-folder: false
 version: "^3.0.0"
 license-header: MICROSOFT_MIT_NO_VERSION
-input-file: "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/e1470c23ac1cb2a15cd5ef1e2b2dd187a3de13e9/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-06-06/blob.json"
+input-file: "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/71d693b624c8e5bfd8ccdb413807a28861103f23/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-12-06/blob.json"
 credential-scope: "https://storage.azure.com/.default"
 containing-module: github.com/Azure/azure-sdk-for-go/sdk/storage/azblob
 output-folder: ../generated
@@ -488,4 +488,15 @@ directive:
     return $.
       replace (/datetime\.RFC1123\((\*[^)]+)\)\.String\(\)/g, `($1).In(gmt).Format(time.RFC1123)`).
       replace (/\t"github\.com\/Azure\/azure-sdk-for-go\/sdk\/azcore\/runtime\/datetime"\n/g, ``);
+```
+
+### Remove x-ms-pageable from Apache Arrow hierarchy list (unsupported for binary responses)
+
+``` yaml
+directive:
+- from: swagger-document
+  where: $["x-ms-paths"]["/{containerName}?restype=container&comp=list&hierarchy&arrow"]["get"]
+  transform: >
+    delete $["x-ms-pageable"];
+```
 

--- a/sdk/storage/azblob/internal/generated/constants.go
+++ b/sdk/storage/azblob/internal/generated/constants.go
@@ -3,4 +3,4 @@
 
 package generated
 
-const ServiceVersion = "2026-06-06"
+const ServiceVersion = "2026-10-06"

--- a/sdk/storage/azblob/internal/generated/zz_blob_client.go
+++ b/sdk/storage/azblob/internal/generated/zz_blob_client.go
@@ -976,6 +976,23 @@ func (client *BlobClient) downloadHandleResponse(resp *http.Response) (BlobClien
 	if val := resp.Header.Get("Accept-Ranges"); val != "" {
 		result.AcceptRanges = &val
 	}
+	if val := resp.Header.Get("x-ms-access-tier"); val != "" {
+		result.AccessTier = &val
+	}
+	if val := resp.Header.Get("x-ms-access-tier-change-time"); val != "" {
+		accessTierChangeTime, err := time.Parse(time.RFC1123, val)
+		if err != nil {
+			return BlobClientDownloadResponse{}, err
+		}
+		result.AccessTierChangeTime = &accessTierChangeTime
+	}
+	if val := resp.Header.Get("x-ms-access-tier-inferred"); val != "" {
+		accessTierInferred, err := strconv.ParseBool(val)
+		if err != nil {
+			return BlobClientDownloadResponse{}, err
+		}
+		result.AccessTierInferred = &accessTierInferred
+	}
 	if val := resp.Header.Get("x-ms-blob-committed-block-count"); val != "" {
 		blobCommittedBlockCount32, err := strconv.ParseInt(val, 10, 32)
 		blobCommittedBlockCount := int32(blobCommittedBlockCount32)
@@ -1173,6 +1190,9 @@ func (client *BlobClient) downloadHandleResponse(resp *http.Response) (BlobClien
 	}
 	if val := resp.Header.Get("x-ms-request-id"); val != "" {
 		result.RequestID = &val
+	}
+	if val := resp.Header.Get("x-ms-smart-access-tier"); val != "" {
+		result.SmartAccessTier = &val
 	}
 	if val := resp.Header.Get("x-ms-structured-body"); val != "" {
 		result.StructuredBodyType = &val

--- a/sdk/storage/azblob/internal/generated/zz_blockblob_client.go
+++ b/sdk/storage/azblob/internal/generated/zz_blockblob_client.go
@@ -489,6 +489,13 @@ func (client *BlockBlobClient) putBlobFromURLHandleResponse(resp *http.Response)
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
+	if val := resp.Header.Get("x-ms-content-crc64"); val != "" {
+		contentCRC64, err := base64.StdEncoding.DecodeString(val)
+		if err != nil {
+			return BlockBlobClientPutBlobFromURLResponse{}, err
+		}
+		result.ContentCRC64 = contentCRC64
+	}
 	if val := resp.Header.Get("Content-MD5"); val != "" {
 		contentMD5, err := base64.StdEncoding.DecodeString(val)
 		if err != nil {

--- a/sdk/storage/azblob/internal/generated/zz_container_client.go
+++ b/sdk/storage/azblob/internal/generated/zz_container_client.go
@@ -913,6 +913,94 @@ func (client *ContainerClient) ListBlobFlatSegmentHandleResponse(resp *http.Resp
 	return result, nil
 }
 
+// ListBlobFlatSegmentApacheArrow - The List Blobs operation returns a list of the blobs under the specified container. This
+// operation is for Apache Arrow use case so response is returned as raw to be deserialized by the client.
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ContainerClientListBlobFlatSegmentApacheArrowOptions contains the optional parameters for the ContainerClient.ListBlobFlatSegmentApacheArrow
+//     method.
+func (client *ContainerClient) ListBlobFlatSegmentApacheArrow(ctx context.Context, options *ContainerClientListBlobFlatSegmentApacheArrowOptions) (ContainerClientListBlobFlatSegmentApacheArrowResponse, error) {
+	var err error
+	req, err := client.listBlobFlatSegmentApacheArrowCreateRequest(ctx, options)
+	if err != nil {
+		return ContainerClientListBlobFlatSegmentApacheArrowResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return ContainerClientListBlobFlatSegmentApacheArrowResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
+		err = runtime.NewResponseError(httpResp)
+		return ContainerClientListBlobFlatSegmentApacheArrowResponse{}, err
+	}
+	resp, err := client.listBlobFlatSegmentApacheArrowHandleResponse(httpResp)
+	return resp, err
+}
+
+// listBlobFlatSegmentApacheArrowCreateRequest creates the ListBlobFlatSegmentApacheArrow request.
+func (client *ContainerClient) listBlobFlatSegmentApacheArrowCreateRequest(ctx context.Context, options *ContainerClientListBlobFlatSegmentApacheArrowOptions) (*policy.Request, error) {
+	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("comp", "list")
+	if options != nil && options.EndBefore != nil {
+		reqQP.Set("endBefore", *options.EndBefore)
+	}
+	if options != nil && options.Include != nil {
+		reqQP.Set("include", strings.Join(strings.Fields(strings.Trim(fmt.Sprint(options.Include), "[]")), ","))
+	}
+	if options != nil && options.Marker != nil {
+		reqQP.Set("marker", *options.Marker)
+	}
+	if options != nil && options.Maxresults != nil {
+		reqQP.Set("maxresults", strconv.FormatInt(int64(*options.Maxresults), 10))
+	}
+	if options != nil && options.Prefix != nil {
+		reqQP.Set("prefix", *options.Prefix)
+	}
+	reqQP.Set("restype", "container")
+	if options != nil && options.StartFrom != nil {
+		reqQP.Set("startFrom", *options.StartFrom)
+	}
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
+	}
+	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+	runtime.SkipBodyDownload(req)
+	req.Raw().Header["Accept"] = []string{"application/vnd.apache.arrow.stream,application/xml"}
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
+	}
+	req.Raw().Header["x-ms-version"] = []string{client.version}
+	return req, nil
+}
+
+// listBlobFlatSegmentApacheArrowHandleResponse handles the ListBlobFlatSegmentApacheArrow response.
+func (client *ContainerClient) listBlobFlatSegmentApacheArrowHandleResponse(resp *http.Response) (ContainerClientListBlobFlatSegmentApacheArrowResponse, error) {
+	result := ContainerClientListBlobFlatSegmentApacheArrowResponse{Body: resp.Body}
+	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
+		result.ClientRequestID = &val
+	}
+	if val := resp.Header.Get("Content-Type"); val != "" {
+		result.ContentType = &val
+	}
+	if val := resp.Header.Get("Date"); val != "" {
+		date, err := time.Parse(time.RFC1123, val)
+		if err != nil {
+			return ContainerClientListBlobFlatSegmentApacheArrowResponse{}, err
+		}
+		result.Date = &date
+	}
+	if val := resp.Header.Get("x-ms-request-id"); val != "" {
+		result.RequestID = &val
+	}
+	if val := resp.Header.Get("x-ms-version"); val != "" {
+		result.Version = &val
+	}
+	return result, nil
+}
+
 // NewListBlobHierarchySegmentPager - [Update] The List Blobs operation returns a list of the blobs under the specified container
 //   - delimiter - When the request includes this parameter, the operation returns a BlobPrefix element in the response body that
 //     acts as a placeholder for all blobs whose names begin with the same substring up to the
@@ -1001,6 +1089,99 @@ func (client *ContainerClient) ListBlobHierarchySegmentHandleResponse(resp *http
 	}
 	if err := runtime.UnmarshalAsXML(resp, &result.ListBlobsHierarchySegmentResponse); err != nil {
 		return ContainerClientListBlobHierarchySegmentResponse{}, err
+	}
+	return result, nil
+}
+
+// ListBlobHierarchySegmentApacheArrow - [Update] The List Blobs operation returns a list of the blobs under the specified
+// container. This operation is for Apache Arrow use case so response is returned as raw to be deserialized by the
+// client.
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - delimiter - When the request includes this parameter, the operation returns a BlobPrefix element in the response body that
+//     acts as a placeholder for all blobs whose names begin with the same substring up to the
+//     appearance of the delimiter character. The delimiter may be a single character or a string.
+//   - options - ContainerClientListBlobHierarchySegmentApacheArrowOptions contains the optional parameters for the ContainerClient.ListBlobHierarchySegmentApacheArrow
+//     method.
+func (client *ContainerClient) ListBlobHierarchySegmentApacheArrow(ctx context.Context, delimiter string, options *ContainerClientListBlobHierarchySegmentApacheArrowOptions) (ContainerClientListBlobHierarchySegmentApacheArrowResponse, error) {
+	var err error
+	req, err := client.listBlobHierarchySegmentApacheArrowCreateRequest(ctx, delimiter, options)
+	if err != nil {
+		return ContainerClientListBlobHierarchySegmentApacheArrowResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return ContainerClientListBlobHierarchySegmentApacheArrowResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
+		err = runtime.NewResponseError(httpResp)
+		return ContainerClientListBlobHierarchySegmentApacheArrowResponse{}, err
+	}
+	resp, err := client.listBlobHierarchySegmentApacheArrowHandleResponse(httpResp)
+	return resp, err
+}
+
+// listBlobHierarchySegmentApacheArrowCreateRequest creates the ListBlobHierarchySegmentApacheArrow request.
+func (client *ContainerClient) listBlobHierarchySegmentApacheArrowCreateRequest(ctx context.Context, delimiter string, options *ContainerClientListBlobHierarchySegmentApacheArrowOptions) (*policy.Request, error) {
+	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("comp", "list")
+	reqQP.Set("delimiter", delimiter)
+	if options != nil && options.EndBefore != nil {
+		reqQP.Set("endBefore", *options.EndBefore)
+	}
+	if options != nil && options.Include != nil {
+		reqQP.Set("include", strings.Join(strings.Fields(strings.Trim(fmt.Sprint(options.Include), "[]")), ","))
+	}
+	if options != nil && options.Marker != nil {
+		reqQP.Set("marker", *options.Marker)
+	}
+	if options != nil && options.Maxresults != nil {
+		reqQP.Set("maxresults", strconv.FormatInt(int64(*options.Maxresults), 10))
+	}
+	if options != nil && options.Prefix != nil {
+		reqQP.Set("prefix", *options.Prefix)
+	}
+	reqQP.Set("restype", "container")
+	if options != nil && options.StartFrom != nil {
+		reqQP.Set("startFrom", *options.StartFrom)
+	}
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
+	}
+	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+	runtime.SkipBodyDownload(req)
+	req.Raw().Header["Accept"] = []string{"application/vnd.apache.arrow.stream,application/xml"}
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
+	}
+	req.Raw().Header["x-ms-version"] = []string{client.version}
+	return req, nil
+}
+
+// listBlobHierarchySegmentApacheArrowHandleResponse handles the ListBlobHierarchySegmentApacheArrow response.
+func (client *ContainerClient) listBlobHierarchySegmentApacheArrowHandleResponse(resp *http.Response) (ContainerClientListBlobHierarchySegmentApacheArrowResponse, error) {
+	result := ContainerClientListBlobHierarchySegmentApacheArrowResponse{Body: resp.Body}
+	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
+		result.ClientRequestID = &val
+	}
+	if val := resp.Header.Get("Content-Type"); val != "" {
+		result.ContentType = &val
+	}
+	if val := resp.Header.Get("Date"); val != "" {
+		date, err := time.Parse(time.RFC1123, val)
+		if err != nil {
+			return ContainerClientListBlobHierarchySegmentApacheArrowResponse{}, err
+		}
+		result.Date = &date
+	}
+	if val := resp.Header.Get("x-ms-request-id"); val != "" {
+		result.RequestID = &val
+	}
+	if val := resp.Header.Get("x-ms-version"); val != "" {
+		result.Version = &val
 	}
 	return result, nil
 }

--- a/sdk/storage/azblob/internal/generated/zz_options.go
+++ b/sdk/storage/azblob/internal/generated/zz_options.go
@@ -984,9 +984,87 @@ type ContainerClientGetPropertiesOptions struct {
 	Timeout *int32
 }
 
+// ContainerClientListBlobFlatSegmentApacheArrowOptions contains the optional parameters for the ContainerClient.ListBlobFlatSegmentApacheArrow
+// method.
+type ContainerClientListBlobFlatSegmentApacheArrowOptions struct {
+	// Specifies the relative path to end before list paths. (Exclusive)
+	EndBefore *string
+
+	// Include this parameter to specify one or more datasets to include in the response.
+	Include []ListBlobsIncludeItem
+
+	// A string value that identifies the portion of the list of containers to be returned with the next listing operation. The
+	// operation returns the NextMarker value within the response body if the listing
+	// operation did not return all containers remaining to be listed with the current page. The NextMarker value can be used
+	// as the value for the marker parameter in a subsequent call to request the next
+	// page of list items. The marker value is opaque to the client.
+	Marker *string
+
+	// Specifies the maximum number of containers to return. If the request does not specify maxresults, or specifies a value
+	// greater than 5000, the server will return up to 5000 items. Note that if the
+	// listing operation crosses a partition boundary, then the service will return a continuation token for retrieving the remainder
+	// of the results. For this reason, it is possible that the service will
+	// return fewer results than specified by maxresults, or than the default of 5000.
+	Maxresults *int32
+
+	// Filters the results to return only containers whose name begins with the specified prefix.
+	Prefix *string
+
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// Specifies the relative path to list paths from. For non-recursive list, only one entity level is supported; For recursive
+	// list, multiple entity levels are supported. (Inclusive)
+	StartFrom *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://learn.microsoft.com/rest/api/storageservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
 // ContainerClientListBlobFlatSegmentOptions contains the optional parameters for the ContainerClient.NewListBlobFlatSegmentPager
 // method.
 type ContainerClientListBlobFlatSegmentOptions struct {
+	// Include this parameter to specify one or more datasets to include in the response.
+	Include []ListBlobsIncludeItem
+
+	// A string value that identifies the portion of the list of containers to be returned with the next listing operation. The
+	// operation returns the NextMarker value within the response body if the listing
+	// operation did not return all containers remaining to be listed with the current page. The NextMarker value can be used
+	// as the value for the marker parameter in a subsequent call to request the next
+	// page of list items. The marker value is opaque to the client.
+	Marker *string
+
+	// Specifies the maximum number of containers to return. If the request does not specify maxresults, or specifies a value
+	// greater than 5000, the server will return up to 5000 items. Note that if the
+	// listing operation crosses a partition boundary, then the service will return a continuation token for retrieving the remainder
+	// of the results. For this reason, it is possible that the service will
+	// return fewer results than specified by maxresults, or than the default of 5000.
+	Maxresults *int32
+
+	// Filters the results to return only containers whose name begins with the specified prefix.
+	Prefix *string
+
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// Specifies the relative path to list paths from. For non-recursive list, only one entity level is supported; For recursive
+	// list, multiple entity levels are supported. (Inclusive)
+	StartFrom *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://learn.microsoft.com/rest/api/storageservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
+// ContainerClientListBlobHierarchySegmentApacheArrowOptions contains the optional parameters for the ContainerClient.ListBlobHierarchySegmentApacheArrow
+// method.
+type ContainerClientListBlobHierarchySegmentApacheArrowOptions struct {
+	// Specifies the relative path to end before list paths. (Exclusive)
+	EndBefore *string
+
 	// Include this parameter to specify one or more datasets to include in the response.
 	Include []ListBlobsIncludeItem
 

--- a/sdk/storage/azblob/internal/generated/zz_responses.go
+++ b/sdk/storage/azblob/internal/generated/zz_responses.go
@@ -346,6 +346,15 @@ type BlobClientDownloadResponse struct {
 	// AcceptRanges contains the information returned from the Accept-Ranges header response.
 	AcceptRanges *string
 
+	// AccessTier contains the information returned from the x-ms-access-tier header response.
+	AccessTier *string
+
+	// AccessTierChangeTime contains the information returned from the x-ms-access-tier-change-time header response.
+	AccessTierChangeTime *time.Time
+
+	// AccessTierInferred contains the information returned from the x-ms-access-tier-inferred header response.
+	AccessTierInferred *bool
+
 	// BlobCommittedBlockCount contains the information returned from the x-ms-blob-committed-block-count header response.
 	BlobCommittedBlockCount *int32
 
@@ -471,6 +480,9 @@ type BlobClientDownloadResponse struct {
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
+
+	// SmartAccessTier contains the information returned from the x-ms-smart-access-tier header response.
+	SmartAccessTier *string
 
 	// StructuredBodyType contains the information returned from the x-ms-structured-body header response.
 	StructuredBodyType *string
@@ -1095,6 +1107,9 @@ type BlockBlobClientPutBlobFromURLResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
+	// ContentCRC64 contains the information returned from the x-ms-content-crc64 header response.
+	ContentCRC64 []byte
+
 	// ContentMD5 contains the information returned from the Content-MD5 header response.
 	ContentMD5 []byte
 
@@ -1460,10 +1475,52 @@ type ContainerClientGetPropertiesResponse struct {
 	Version *string
 }
 
+// ContainerClientListBlobFlatSegmentApacheArrowResponse contains the response from method ContainerClient.ListBlobFlatSegmentApacheArrow.
+type ContainerClientListBlobFlatSegmentApacheArrowResponse struct {
+	// Body contains the streaming response.
+	Body io.ReadCloser
+
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// ContentType contains the information returned from the Content-Type header response.
+	ContentType *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
 // ContainerClientListBlobFlatSegmentResponse contains the response from method ContainerClient.NewListBlobFlatSegmentPager.
 type ContainerClientListBlobFlatSegmentResponse struct {
 	// An enumeration of blobs
 	ListBlobsFlatSegmentResponse
+
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// ContentType contains the information returned from the Content-Type header response.
+	ContentType *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
+// ContainerClientListBlobHierarchySegmentApacheArrowResponse contains the response from method ContainerClient.ListBlobHierarchySegmentApacheArrow.
+type ContainerClientListBlobHierarchySegmentApacheArrowResponse struct {
+	// Body contains the streaming response.
+	Body io.ReadCloser
 
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string


### PR DESCRIPTION
Update swagger source to 2026-12-06 spec and regenerate. Added directive to remove x-ms-pageable from Apache Arrow hierarchy list operation to work around autorest/go limitation with binary response pagination. 
Set ServiceVersion to 2026-10-06 because - 
[Sean]
We are removing the 2026-12-06 service version from the SDKs
Here is the .NET PR - [https://github.com/Azure/azure-sdk-for-net/pull/60828](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FAzure%2Fazure-sdk-for-net%2Fpull%2F60828&data=05%7C02%7Ctanyasethi%40microsoft.com%7C9bc0938acb1e4c0424e808deddf8252b%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C639192255081090249%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=lrc%2FwMZ4Xe45I0mXbrZVm4sUd%2BaXR8XX3iTDL934xYg%3D&reserved=0)
Now that NFS List V2 Files and Directories has been moved to 105, we don’t have any features that depend on the STG 104 x-ms-verison

<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - These files are managed by the codegen framework at [Azure/autorest.go][].
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go
