### PR TITLE
Remove redundant pipeline variable

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-go-release.yml
+++ b/eng/pipelines/templates/jobs/archetype-go-release.yml
@@ -69,10 +69,19 @@ stages:
       dependsOn:
         - CheckRelease
         - AutoReleasePrepare
-      condition: and(succeeded(), eq(dependencies.CheckRelease.outputs['CheckReleaseJob.Verify.NeedToRelease'], 'true'), eq(dependencies.AutoReleasePrepare.outputs['ResolveAutoReleasePackages.resolve.AutoReleaseLabelPresent'], 'true'), eq(dependencies.AutoReleasePrepare.outputs['ResolveAutoReleasePackages.resolve.HasAutoReleaseArtifacts'], 'true'))
+      condition: >-
+        and(
+          succeeded(),
+          eq(dependencies.CheckRelease.outputs['CheckReleaseJob.Verify.NeedToRelease'], 'true'),
+          eq(dependencies.AutoReleasePrepare.outputs['ResolveAutoReleasePackages.resolve.HasAutoReleaseArtifacts'], 'true')
+        )
     ${{ else }}:
       dependsOn: CheckRelease
-      condition: and(succeeded(), eq(dependencies.CheckRelease.outputs['CheckReleaseJob.Verify.NeedToRelease'], 'true'))
+      condition: >-
+        and(
+          succeeded(),
+          eq(dependencies.CheckRelease.outputs['CheckReleaseJob.Verify.NeedToRelease'], 'true')
+        )
     jobs:
       - deployment: ReleaseGate
         environment: package-publish


### PR DESCRIPTION
## Summary
- Remove a redundant pipeline variable from the Go release pipeline archetype.

## Validation
- Not run (pipeline template-only cleanup).

## Checklist
- [x] The purpose of this PR is explained in this or a referenced issue.
- [x] The PR does not update generated files.
- [x] Tests are included and/or updated for code changes. (N/A: pipeline template-only cleanup.)
- [x] Updates to module CHANGELOG.md are included. (N/A: no package changes.)
- [x] MIT license headers are included in each file. (N/A: no new files.)