### PR TITLE
cosmos: Rename ChangeFeedResponse.Documents to Items and align with data types in other responses

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * Removed the external query engine integration from `QueryOptions` and deleted the `sdk/data/azcosmos/queryengine` package for the 1.5.0 GA release. This feature will return in the upcoming 1.6.0 preview release. See [PR 27134](https://github.com/Azure/azure-sdk-for-go/pull/27134).
 * Renamed `ChangeFeedResponse.GetContRanges()` to `ChangeFeedResponse.GetContinuationRange()`. This API was previously only present in a beta release. See [PR 27148](https://github.com/Azure/azure-sdk-for-go/pull/27148).
+* Renamed `ChangeFeedResponse.Documents` to `ChangeFeedResponse.Items` and changed its type from `[]json.RawMessage` to `[][]byte`. This API was previously only present in a beta release. See [PR 27175](https://github.com/Azure/azure-sdk-for-go/pull/27175).
+* Added a `*GetFeedRangesOptions` parameter to `ContainerClient.GetFeedRanges`. This API was previously only present in a beta release. See [PR 27175](https://github.com/Azure/azure-sdk-for-go/pull/27175).
 * Renamed `ChangeFeedRangeOptions.EpkMinHeader` and `ChangeFeedRangeOptions.EpkMaxHeader` to `EPKMinHeader` and `EPKMaxHeader`. These fields were previously only present in a beta release. See [PR 27166](https://github.com/Azure/azure-sdk-for-go/pull/27166).
 * `Diagnostics.StartTimeUTC()` now returns a `time.Time` (zero value when no diagnostics are present) instead of a `*time.Time`. This API was previously only present in a beta release. See [PR 27166](https://github.com/Azure/azure-sdk-for-go/pull/27166).
 * Removed the `NewFeedRange` constructor. Construct a `FeedRange` directly using a struct initializer instead. This API was previously only present in a beta release. See [PR 27166](https://github.com/Azure/azure-sdk-for-go/pull/27166).

--- a/sdk/data/azcosmos/cosmos_change_feed_response.go
+++ b/sdk/data/azcosmos/cosmos_change_feed_response.go
@@ -15,8 +15,8 @@ import (
 type ChangeFeedResponse struct {
 	// ResourceID is the unique identifier for the resource.
 	ResourceID string `json:"_rid"`
-	// Documents is a list of changed documents returned in the change feed.
-	Documents []json.RawMessage `json:"Documents"`
+	// Items is a list of changed documents returned in the change feed.
+	Items [][]byte `json:"-"`
 	// Count is the number of documents returned in this page.
 	Count int `json:"_count"`
 
@@ -43,7 +43,7 @@ func newChangeFeedResponse(resp *http.Response) (ChangeFeedResponse, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotModified {
-		response.Documents = []json.RawMessage{}
+		response.Items = [][]byte{}
 		response.Count = 0
 		return response, nil
 	}
@@ -52,8 +52,23 @@ func newChangeFeedResponse(resp *http.Response) (ChangeFeedResponse, error) {
 	if err != nil {
 		return response, wrapResponseError(err, response.Response)
 	}
-	if err := json.Unmarshal(body, &response); err != nil {
+
+	// Documents are decoded as raw messages because the JSON payload contains
+	// document objects, which cannot be decoded directly into [][]byte.
+	aux := struct {
+		ResourceID string            `json:"_rid"`
+		Documents  []json.RawMessage `json:"Documents"`
+		Count      int               `json:"_count"`
+	}{}
+	if err := json.Unmarshal(body, &aux); err != nil {
 		return response, wrapResponseError(err, response.Response)
+	}
+
+	response.ResourceID = aux.ResourceID
+	response.Count = aux.Count
+	response.Items = make([][]byte, len(aux.Documents))
+	for i, doc := range aux.Documents {
+		response.Items[i] = doc
 	}
 
 	return response, nil

--- a/sdk/data/azcosmos/cosmos_change_feed_response_test.go
+++ b/sdk/data/azcosmos/cosmos_change_feed_response_test.go
@@ -81,19 +81,19 @@ func TestNewChangeFeedResponse(t *testing.T) {
 		t.Fatalf("unexpected Count: got %d, want 2", parsedResponse.Count)
 	}
 
-	if len(parsedResponse.Documents) != 2 {
-		t.Fatalf("unexpected number of Documents: got %d, want 2", len(parsedResponse.Documents))
+	if len(parsedResponse.Items) != 2 {
+		t.Fatalf("unexpected number of Documents: got %d, want 2", len(parsedResponse.Items))
 	}
 
 	var doc0, doc1 map[string]interface{}
-	if err := json.Unmarshal(parsedResponse.Documents[0], &doc0); err != nil {
+	if err := json.Unmarshal(parsedResponse.Items[0], &doc0); err != nil {
 		t.Fatalf("failed to unmarshal first document: %v", err)
 	}
 	if doc0["id"] != "Erewhon" {
 		t.Errorf("unexpected first document id: got %v, want Erewhon", doc0["id"])
 	}
 
-	if err := json.Unmarshal(parsedResponse.Documents[1], &doc1); err != nil {
+	if err := json.Unmarshal(parsedResponse.Items[1], &doc1); err != nil {
 		t.Fatalf("failed to unmarshal second document: %v", err)
 	}
 	if doc1["id"] != "TraderJoes" {

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -524,7 +524,9 @@ func (c *ContainerClient) ReadManyItems(
 
 // GetFeedRanges retrieves all the feed ranges for which changefeed could be fetched.
 // ctx - The context for the request.
-func (c *ContainerClient) GetFeedRanges(ctx context.Context) ([]FeedRange, error) {
+// o - Options for the operation. nil to use default options. Currently no options are
+// defined and the parameter is ignored; it exists for future use.
+func (c *ContainerClient) GetFeedRanges(ctx context.Context, o *GetFeedRangesOptions) ([]FeedRange, error) {
 	// Get the partition key ranges from the container
 	response, err := c.getPartitionKeyRanges(ctx, nil)
 	if err != nil {

--- a/sdk/data/azcosmos/cosmos_container_change_feed.go
+++ b/sdk/data/azcosmos/cosmos_container_change_feed.go
@@ -402,11 +402,11 @@ func (c *ContainerClient) getChangeFeedForQueue(
 		lastResp = response
 
 		// 200 with a non-empty page → return immediately so the caller can
-		// process. The Documents-length belt covers the (shouldn't-happen)
+		// process. The Items-length belt covers the (shouldn't-happen)
 		// case where the server omits _count but still ships docs.
 		if response.RawResponse != nil &&
 			response.RawResponse.StatusCode == http.StatusOK &&
-			(response.Count > 0 || len(response.Documents) > 0) {
+			(response.Count > 0 || len(response.Items) > 0) {
 			return finalize(response)
 		}
 

--- a/sdk/data/azcosmos/cosmos_container_test.go
+++ b/sdk/data/azcosmos/cosmos_container_test.go
@@ -865,8 +865,8 @@ func TestContainerGetChangeFeedWithStartFrom(t *testing.T) {
 	if resp.Count != 2 {
 		t.Errorf("Expected Count 2, got %v", resp.Count)
 	}
-	if len(resp.Documents) != 2 {
-		t.Errorf("Expected 2 documents, got %v", len(resp.Documents))
+	if len(resp.Items) != 2 {
+		t.Errorf("Expected 2 documents, got %v", len(resp.Items))
 	}
 
 	// With caches pre-wired, only the change-feed request hits the wire.
@@ -947,12 +947,12 @@ func TestContainerGetChangeFeedWithStartFromFiltering(t *testing.T) {
 	if allDocsResp.Count != 3 {
 		t.Errorf("Expected 3 documents in first response, got %d", allDocsResp.Count)
 	}
-	if len(allDocsResp.Documents) != 3 {
-		t.Errorf("Expected 3 documents in first response, got %d", len(allDocsResp.Documents))
+	if len(allDocsResp.Items) != 3 {
+		t.Errorf("Expected 3 documents in first response, got %d", len(allDocsResp.Items))
 	}
 
 	var allDocs []map[string]interface{}
-	for i, docBytes := range allDocsResp.Documents {
+	for i, docBytes := range allDocsResp.Items {
 		var doc map[string]interface{}
 		if err := json.Unmarshal(docBytes, &doc); err != nil {
 			t.Fatalf("Failed to unmarshal document %d: %v", i, err)
@@ -1011,12 +1011,12 @@ func TestContainerGetChangeFeedWithStartFromFiltering(t *testing.T) {
 	if filteredResp.Count != 1 {
 		t.Errorf("Expected 1 document in filtered response, got %d", filteredResp.Count)
 	}
-	if len(filteredResp.Documents) != 1 {
-		t.Errorf("Expected 1 document in filtered response, got %d", len(filteredResp.Documents))
+	if len(filteredResp.Items) != 1 {
+		t.Errorf("Expected 1 document in filtered response, got %d", len(filteredResp.Items))
 	}
 
 	var filteredDoc map[string]interface{}
-	if err := json.Unmarshal(filteredResp.Documents[0], &filteredDoc); err != nil {
+	if err := json.Unmarshal(filteredResp.Items[0], &filteredDoc); err != nil {
 		t.Fatalf("Failed to unmarshal filtered document: %v", err)
 	}
 	if filteredDoc["id"] != "doc3" {
@@ -1085,8 +1085,8 @@ func TestContainerGetChangeFeedForEPKRange(t *testing.T) {
 		t.Errorf("unexpected Count: got %d, want 2", resp.Count)
 	}
 
-	if len(resp.Documents) != 2 {
-		t.Errorf("unexpected number of Documents: got %d, want 2", len(resp.Documents))
+	if len(resp.Items) != 2 {
+		t.Errorf("unexpected number of Documents: got %d, want 2", len(resp.Items))
 	}
 
 	if len(verifier.requests) != 1 {

--- a/sdk/data/azcosmos/cosmos_feed_range_test.go
+++ b/sdk/data/azcosmos/cosmos_feed_range_test.go
@@ -83,7 +83,7 @@ func TestContainerGetFeedRanges(t *testing.T) {
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)
 
-	feedRanges, err := container.GetFeedRanges(context.TODO())
+	feedRanges, err := container.GetFeedRanges(context.TODO(), nil)
 	if err != nil {
 		t.Fatalf("GetFeedRanges failed: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestContainerGetFeedRangesEmpty(t *testing.T) {
 	database, _ := newDatabase("databaseId", client)
 	container, _ := newContainer("containerId", database)
 
-	feedRanges, err := container.GetFeedRanges(context.TODO())
+	feedRanges, err := container.GetFeedRanges(context.TODO(), nil)
 	if err != nil {
 		t.Fatalf("GetFeedRanges failed: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestContainerGetFeedRanges_UsesCache(t *testing.T) {
 	container, _ := newContainer("containerId", database)
 
 	// First call: populates caches, makes 2 HTTP requests
-	feedRanges, err := container.GetFeedRanges(context.TODO())
+	feedRanges, err := container.GetFeedRanges(context.TODO(), nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(feedRanges))
 	require.Equal(t, "", feedRanges[0].MinInclusive)
@@ -231,7 +231,7 @@ func TestContainerGetFeedRanges_UsesCache(t *testing.T) {
 
 	// Second call: should use caches, no additional HTTP requests
 	// (no more responses queued — would panic if a request was made)
-	feedRanges2, err := container.GetFeedRanges(context.TODO())
+	feedRanges2, err := container.GetFeedRanges(context.TODO(), nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(feedRanges2))
 	require.Equal(t, feedRanges[0], feedRanges2[0])

--- a/sdk/data/azcosmos/cosmos_get_feed_ranges_options.go
+++ b/sdk/data/azcosmos/cosmos_get_feed_ranges_options.go
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+// GetFeedRangesOptions includes options for the GetFeedRanges operation.
+// It currently has no fields and is reserved for future use.
+type GetFeedRangesOptions struct {
+	// for future use
+}

--- a/sdk/data/azcosmos/emulator_cosmos_change_feed_split_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_change_feed_split_test.go
@@ -116,7 +116,7 @@ func TestEmulatorChangeFeed_F1_WideRangeMultiDrain(t *testing.T) {
 		require.Equal(t, cosmosCompositeContinuationTokenVersion, ct.Version)
 		require.GreaterOrEqual(t, len(ct.Continuation), 1, "composite token must carry at least one range")
 
-		for _, raw := range resp.Documents {
+		for _, raw := range resp.Items {
 			var d map[string]interface{}
 			require.NoError(t, json.Unmarshal(raw, &d))
 			if id, ok := d["id"].(string); ok {

--- a/sdk/data/azcosmos/emulator_cosmos_container_test.go
+++ b/sdk/data/azcosmos/emulator_cosmos_container_test.go
@@ -633,7 +633,7 @@ func TestEmulatorContainerPartitionKeyRangesAndFeedRanges(t *testing.T) {
 	}
 
 	// Get Feed Ranges (which internally calls getPartitionKeyRanges)
-	feedRanges, err := container.GetFeedRanges(context.TODO())
+	feedRanges, err := container.GetFeedRanges(context.TODO(), nil)
 	if err != nil {
 		t.Fatalf("Failed to get feed ranges: %v", err)
 	}
@@ -718,7 +718,7 @@ func TestEmulatorContainerChangeFeed(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// Get Feed Ranges (which internally calls getPartitionKeyRanges)
-	feedRanges, err := container.GetFeedRanges(context.TODO())
+	feedRanges, err := container.GetFeedRanges(context.TODO(), nil)
 	if err != nil {
 		t.Fatalf("Failed to get feed ranges: %v", err)
 	}
@@ -852,7 +852,7 @@ func TestEmulatorContainerChangeFeed(t *testing.T) {
 
 		// Should find at least the new item
 		foundNewItem := false
-		for _, doc := range resp.Documents {
+		for _, doc := range resp.Items {
 			var item map[string]interface{}
 			err := json.Unmarshal(doc, &item)
 			if err != nil {
@@ -892,7 +892,7 @@ func TestEmulatorContainerChangeFeed(t *testing.T) {
 			t.Log("This might be a limitation of the emulator's change feed implementation")
 
 			// Let's verify what items were returned
-			for i, doc := range futureResp.Documents {
+			for i, doc := range futureResp.Items {
 				var item map[string]interface{}
 				if err := json.Unmarshal(doc, &item); err == nil {
 					t.Logf("  Unexpected document %d: id=%v, pk=%v", i, item["id"], item["pk"])


### PR DESCRIPTION
This was raised in an API review: ChangeFeedResponse.Documents is a `[]json.RawMessage`, whereas elsewhere we return `[][]byte`. The data types are equivalent but we should be consistent. Also, `Documents` is a legacy term, `Items` is the preferred term now. These are APIs added in a beta release, so it's safe to make this renames.