### PR TITLE
Add CFSClean enforcement

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -43,7 +43,7 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      networkIsolationPolicy: Permissive,CFSClean2
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'go - azcore'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:

--- a/eng/scripts/Verify-NeedToRelease.ps1
+++ b/eng/scripts/Verify-NeedToRelease.ps1
@@ -5,6 +5,8 @@ param (
 )
 
 . (Join-Path $PSScriptRoot .. common scripts common.ps1)
+. (Join-Path $PSScriptRoot .. common scripts Helpers PSModule-Helpers.ps1)
+InstallAndImport-ModuleIfNotInstalled "powershell-yaml" "0.4.7"
 
 $apiUrl = "https://api.github.com/repos/$repoId"
 Write-Host "Using API URL $apiUrl"

--- a/sdk/template/aztemplate/CHANGELOG.md
+++ b/sdk/template/aztemplate/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.6.6 (2026-07-16)
+
+### Features Added
+
+* Template package validating release pipeline
+
 ## 0.6.5 (2026-07-08)
 
 ### Features Added

--- a/sdk/template/aztemplate/version.go
+++ b/sdk/template/aztemplate/version.go
@@ -9,5 +9,5 @@ const (
 	moduleName = "github.com/Azure/azure-sdk-for-go/sdk/template/aztemplate"
 
 	// moduleVersion is the semantic version (see http://semver.org) of this module.
-	moduleVersion = "v0.6.5"
+	moduleVersion = "v0.6.6"
 )


### PR DESCRIPTION
This pull request makes a minor update to the `eng/pipelines/templates/stages/1es-redirect.yml` file. The change updates the `networkIsolationPolicy` setting to include `CFSClean` in addition to the existing policies.

- Pipeline configuration:
  * Updated the `networkIsolationPolicy` in `1es-redirect.yml` to include `CFSClean` alongside `Permissive` and `CFSClean2` for improved network isolation settings.
 
[go - aztemplate](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6576010&view=results)
[go - mgmt auto release](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6573971&view=results)