### PR TITLE
Add blob access tier headers to download response

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features Added
 * Added support for Structured Message CRC64 content validation on upload and download operations using `TransferValidationTypeComputeStructuredMessageCRC64`.
+* Added `AccessTier`, `AccessTierInferred`, `AccessTierChangeTime`, and `SmartAccessTier` fields to blob download response.
 
 ### Breaking Changes
 

--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_5461f135f4"
+  "Tag": "go/storage/azblob_0f20a8b3ca"
 }

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -3891,6 +3891,31 @@ func (s *BlobRecordedTestsSuite) TestBlobSetTierInvalidAndValid() {
 	}
 }
 
+func (s *BlobRecordedTestsSuite) TestDownloadStreamAccessTierHeaders() {
+	_require := require.New(s.T())
+	testName := s.T().Name()
+	svcClient, err := testcommon.GetServiceClient(s.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	containerName := testcommon.GenerateContainerName(testName)
+	containerClient := testcommon.CreateNewContainer(context.Background(), _require, containerName, svcClient)
+	defer testcommon.DeleteContainer(context.Background(), _require, containerClient)
+
+	blockBlobName := testcommon.GenerateBlobName(testName)
+	bbClient := testcommon.CreateNewBlockBlob(context.Background(), _require, blockBlobName, containerClient)
+
+	_, err = bbClient.SetTier(context.Background(), blob.AccessTierCool, nil)
+	_require.NoError(err)
+
+	downloadResp, err := bbClient.DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+	_ = downloadResp.Body.Close()
+
+	_require.NotNil(downloadResp.AccessTier)
+	_require.Equal(*downloadResp.AccessTier, string(blob.AccessTierCool))
+	_require.NotNil(downloadResp.AccessTierChangeTime)
+}
+
 func (s *BlobRecordedTestsSuite) TestBlobClientPartsSASQueryTimes() {
 	_require := require.New(s.T())
 	StartTimesInputs := []string{


### PR DESCRIPTION
## Summary
- Added test and changelog for `AccessTier`, `AccessTierInferred`, `AccessTierChangeTime`, and `SmartAccessTier` fields in blob download response
- These fields were added to the generated code via swagger regeneration in PR #27171
- Matches existing behavior in `GetPropertiesResponse` and `ListBlobs`
- Addresses ODSP team requirement to get tier data without extra API calls

## Test plan
- [x] `TestDownloadStreamAccessTierHeaders` — recorded test that sets tier to Cool, downloads blob, and verifies access tier headers are returned
- [x] Passes in both record and playback modes
- [x] `go build ./...` passes