### PR TITLE
Revert "cosmos: Remove QueryEngine APIs for GA release (#27134)"

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 <!-- cSpell:ignore documentdb unmarshalling -->
 
-## 1.5.1-beta.1 (Unreleased)
+## 1.6.0-beta.1 (Unreleased)
 
 ### Features Added
+
+* Restored the query engine feature originally present in 1.5.0-beta releases (but removed for the 1.5.0 GA release).
 
 ### Breaking Changes
 

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -641,6 +641,13 @@ func (c *ContainerClient) NewQueryItemsPager(query string, partitionKey Partitio
 		headerOptionsOverride: &h,
 	}
 
+	// For now, we short-cut straight to the preview query engine if provided.
+	// In the future, we could consider running the normal pipeline until the Gateway fails due to an unsupported query and then switch over.
+	// However, this logic could also just be handled in the query engine itself.
+	if queryOptions.QueryEngine != nil {
+		return c.executeQueryWithEngine(queryOptions.QueryEngine, query, queryOptions, operationContext)
+	}
+
 	path, _ := generatePathForNameBased(resourceTypeDocument, operationContext.resourceAddress, true)
 
 	return runtime.NewPager(runtime.PagingHandler[QueryItemsResponse]{

--- a/sdk/data/azcosmos/cosmos_container_query_engine.go
+++ b/sdk/data/azcosmos/cosmos_container_query_engine.go
@@ -1,0 +1,365 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// cSpell:ignore Writef
+
+package azcosmos
+
+import (
+	"bytes"
+	"context"
+	"sync"
+
+	azlog "github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos/queryengine"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
+)
+
+// EventQueryEngine contains logs related to the query engine.
+const EventQueryEngine log.Event = "QueryEngine"
+
+func (c *ContainerClient) getQueryPlanFromGateway(ctx context.Context, query string, supportedFeatures string, queryOptions *QueryOptions, operationContext pipelineRequestOptions) ([]byte, error) {
+	path, _ := generatePathForNameBased(resourceTypeDocument, operationContext.resourceAddress, true)
+	azResponse, err := c.database.client.sendQueryRequest(
+		path,
+		ctx,
+		query,
+		queryOptions.QueryParameters,
+		operationContext,
+		queryOptions,
+		func(req *policy.Request) {
+			req.Raw().Header.Set(cosmosHeaderIsQueryPlanRequest, "True")
+			req.Raw().Header.Set(cosmosHeaderSupportedQueryFeatures, supportedFeatures)
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(azResponse.Body)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func (c *ContainerClient) getPartitionKeyRangesRaw(ctx context.Context, operationContext pipelineRequestOptions) ([]byte, error) {
+	path, _ := generatePathForNameBased(resourceTypePartitionKeyRange, operationContext.resourceAddress, true)
+	azResponse, err := c.database.client.sendGetRequest(
+		path,
+		ctx,
+		pipelineRequestOptions{
+			resourceType:          resourceTypePartitionKeyRange,
+			resourceAddress:       operationContext.resourceAddress,
+			headerOptionsOverride: operationContext.headerOptionsOverride,
+		},
+		nil,
+		nil)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(azResponse.Body)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// Executes a query using the provided query engine.
+func (c *ContainerClient) executeQueryWithEngine(queryEngine queryengine.QueryEngine, query string, queryOptions *QueryOptions, operationContext pipelineRequestOptions) *azruntime.Pager[QueryItemsResponse] {
+	// NOTE: The current interface for runtime.Pager means we're probably going to risk leaking the pipeline, if it's provided by a native query engine.
+	// There's no "Close" method, which means we can't call `queryengine.QueryPipeline.Close()` when we're done.
+	// We _do_ close the pipeline if the user iterates the entire pager, but if they don't we don't have a way to clean up.
+	// To mitigate that, we expect the queryengine.QueryPipeline to handle setting up a Go finalizer to clean up any native resources it holds.
+	// Finalizers aren't deterministic though, so we should consider making the pager "closable" in the future, so we have a clear signal to free the native resources.
+
+	var queryPipeline queryengine.QueryPipeline
+	var lastResponse Response
+	path, _ := generatePathForNameBased(resourceTypeDocument, operationContext.resourceAddress, true)
+	log.Writef(EventQueryEngine, "Executing query using query engine")
+	return azruntime.NewPager(azruntime.PagingHandler[QueryItemsResponse]{
+		More: func(page QueryItemsResponse) bool {
+			if queryPipeline == nil {
+				// We haven't started yet, so there's certainly more to do.
+				return true
+			}
+
+			if queryPipeline.IsComplete() {
+				// If it's not already closed, close the pipeline.
+				// Close is expected to be idempotent, so we can call it multiple times.
+				queryPipeline.Close()
+				return false
+			}
+
+			// The pipeline isn't complete, so we can keep going.
+			return true
+		},
+		Fetcher: func(ctx context.Context, page *QueryItemsResponse) (QueryItemsResponse, error) {
+			if queryPipeline == nil {
+				// First page, we need to fetch the query plan and PK ranges
+				// TODO: We could proactively try to run this query against the gateway and then fall back to the engine. That's what Python does.
+				plan, err := c.getQueryPlanFromGateway(ctx, query, queryEngine.SupportedFeatures(), queryOptions, operationContext)
+				if err != nil {
+					return QueryItemsResponse{}, err
+				}
+				pkranges, err := c.getPartitionKeyRangesRaw(ctx, operationContext)
+				if err != nil {
+					return QueryItemsResponse{}, err
+				}
+
+				// Create a query pipeline
+				queryPipeline, err = queryEngine.CreateQueryPipeline(query, string(plan), string(pkranges))
+				if err != nil {
+					return QueryItemsResponse{}, err
+				}
+				log.Writef(EventQueryEngine, "Created query pipeline")
+
+				// The gateway may have rewritten the query, which would be encoded in the query plan.
+				// The pipeline parsed the query plan, so we can ask it for the rewritten query.
+				query = queryPipeline.Query()
+			}
+
+			for {
+				if queryPipeline.IsComplete() {
+					log.Writef(EventQueryEngine, "Query pipeline is complete")
+					queryPipeline.Close()
+					return QueryItemsResponse{
+						Response: lastResponse,
+						Items:    nil,
+					}, nil
+				}
+				// Fetch more data from the pipeline
+				log.Writef(EventQueryEngine, "Fetching more data from query pipeline")
+				result, err := queryPipeline.Run()
+				if err != nil {
+					queryPipeline.Close()
+					return QueryItemsResponse{}, err
+				}
+
+				// If we got items, we can return them, and we should do so now, to avoid making unnecessary requests.
+				// Even if there are requests in the queue, the pipeline should return the same requests again on the next call to NextBatch.
+				if len(result.Items) > 0 {
+					log.Writef(EventQueryEngine, "Query pipeline returned %d items", len(result.Items))
+					return QueryItemsResponse{
+						Response: lastResponse,
+						Items:    result.Items,
+					}, nil
+				}
+
+				// If we didn't have any items to return, we need to make requests for the items in the queue.
+				// If there are no requests, the pipeline should return true for IsComplete, so we'll stop on the next iteration.
+				// Parallelize request execution using shared driver.
+				concurrency := determineConcurrency(nil)
+				charge, err := runEngineRequests(ctx, c, path, queryPipeline, operationContext, result.Requests, concurrency, func(qryRequest queryengine.QueryRequest) (string, []QueryParameter, bool) {
+					// Override query if present;
+					localQuery := query
+					if qryRequest.Query != "" {
+						localQuery = qryRequest.Query
+					}
+					var queryParameters []QueryParameter
+					if qryRequest.IncludeParameters || qryRequest.Query == "" {
+						// use query options parameters only if IncludeParameters is true or no override query is specified
+						queryParameters = queryOptions.QueryParameters
+					}
+					// Drain if request.Drain is true.
+					return localQuery, queryParameters, qryRequest.Drain
+				})
+				_ = charge // totalRequestCharge currently unused for query path;
+				if err != nil {
+					queryPipeline.Close()
+					return QueryItemsResponse{}, err
+				}
+				// Loop again to attempt to produce items.
+			}
+		},
+	})
+}
+
+// runEngineRequests concurrently executes per-partition QueryRequests for either query or readMany pipelines.
+// prepareFn returns the query text, parameters, and a drain flag for each request.
+// Collects all results and calls ProvideData once with a single batch to reduce CGo overhead.
+func runEngineRequests(
+	ctx context.Context,
+	c *ContainerClient,
+	path string,
+	pipeline queryengine.QueryPipeline,
+	operationContext pipelineRequestOptions,
+	requests []queryengine.QueryRequest,
+	concurrency int,
+	prepareFn func(req queryengine.QueryRequest) (query string, params []QueryParameter, drain bool),
+) (float32, error) {
+	if len(requests) == 0 {
+		return 0, nil
+	}
+
+	jobs := make(chan queryengine.QueryRequest, len(requests))
+	errCh := make(chan error, 1)
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Adjust concurrency.
+	workerCount := concurrency
+	if workerCount > len(requests) {
+		workerCount = len(requests)
+	}
+	if workerCount < 1 {
+		workerCount = 1
+	}
+
+	// Per-worker request charge slots and result slices (lock-free updates)
+	charges := make([]float32, workerCount)
+	resultsSlices := make([][]queryengine.QueryResult, workerCount)
+
+	for w := 0; w < workerCount; w++ {
+		wg.Add(1)
+		go func(workerIndex int) {
+			defer wg.Done()
+			localResults := make([]queryengine.QueryResult, 0, 8)
+			for {
+				select {
+				case <-done:
+					return
+				case <-ctx.Done():
+					return
+				case req, ok := <-jobs:
+					if !ok {
+						// jobs exhausted
+						resultsSlices[workerIndex] = localResults
+						return
+					}
+					log.Writef(azlog.EventRequest, "Engine pipeline requested data for PKRange: %s", req.PartitionKeyRangeID)
+					queryText, params, drain := prepareFn(req)
+					fetchMorePages := true
+					for fetchMorePages {
+						qr := queryRequest(req)
+						azResponse, err := c.database.client.sendQueryRequest(
+							path,
+							ctx,
+							queryText,
+							params,
+							operationContext,
+							&qr,
+							nil,
+						)
+						if err != nil {
+							select {
+							case errCh <- err:
+							default:
+							}
+							return
+						}
+						qResp, err := newQueryResponse(azResponse)
+						if err != nil {
+							select {
+							case errCh <- err:
+							default:
+							}
+							return
+						}
+						charges[workerIndex] += qResp.RequestCharge
+						buf := new(bytes.Buffer)
+						if _, err := buf.ReadFrom(azResponse.Body); err != nil {
+							select {
+							case errCh <- err:
+							default:
+							}
+							return
+						}
+						continuation := azResponse.Header.Get(cosmosHeaderContinuationToken)
+						data := buf.Bytes()
+						fetchMorePages = continuation != "" && drain
+						localResults = append(localResults, queryengine.QueryResult{
+							PartitionKeyRangeID: req.PartitionKeyRangeID,
+							NextContinuation:    continuation,
+							Data:                data,
+							RequestId:           req.Id,
+						})
+						log.Writef(EventQueryEngine, "Received response for PKRange: %s. Continuation present: %v", req.PartitionKeyRangeID, continuation != "")
+					}
+				}
+			}
+		}(w)
+	}
+
+	// Feed jobs
+	go func() {
+		for _, r := range requests {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			jobs <- r
+		}
+		close(jobs)
+	}()
+
+	// Wait for workers to finish (or error/cancel)
+	workersDone := make(chan struct{})
+	go func() { wg.Wait(); close(workersDone) }()
+
+	// Helper to sum charges
+	sumCharges := func() float32 {
+		var total float32
+		for _, cval := range charges {
+			total += cval
+		}
+		return total
+	}
+
+	// Wait for completion / error / cancellation
+	select {
+	case e := <-errCh:
+		select {
+		case <-done:
+		default:
+			close(done)
+		}
+		return sumCharges(), e
+	case <-ctx.Done():
+		select {
+		case <-done:
+		default:
+			close(done)
+		}
+		return sumCharges(), ctx.Err()
+	case <-workersDone:
+	}
+
+	totalCharge := sumCharges()
+
+	// Merge per-worker result slices deterministically
+	// Pre-size combined slice for efficiency
+	var combinedCount int
+	for _, rs := range resultsSlices {
+		combinedCount += len(rs)
+	}
+	if combinedCount > 0 {
+		all := make([]queryengine.QueryResult, 0, combinedCount)
+		for _, rs := range resultsSlices {
+			all = append(all, rs...)
+		}
+		if err := pipeline.ProvideData(all); err != nil {
+			return totalCharge, err
+		}
+	}
+
+	return totalCharge, nil
+}
+
+// Wrapper type because we can't define 'toHeaders' on DataRequest directly, nor can we define it in the queryengine package (because it's not a public method).
+type queryRequest queryengine.QueryRequest
+
+func (r *queryRequest) toHeaders() *map[string]string {
+	headers := make(map[string]string)
+
+	if r.Continuation != "" {
+		headers[cosmosHeaderContinuationToken] = r.Continuation
+	}
+	headers[cosmosHeaderPartitionKeyRangeId] = r.PartitionKeyRangeID
+	return &headers
+}

--- a/sdk/data/azcosmos/cosmos_container_query_engine_test.go
+++ b/sdk/data/azcosmos/cosmos_container_query_engine_test.go
@@ -1,0 +1,273 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azcosmos
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos/internal/mock"
+)
+
+const (
+	// These keys have been tested to ensure they end up in separate PK ranges for a 40000 RU container with the test data inserted.
+	// Conveniently, they also have descriptive names.
+
+	partition1Key string = "partition1"
+	partition2Key string = "partition2"
+	partition3Key string = "partition3"
+
+	ruCountForMultiplePartitions int32 = 40000
+
+	partitionCount    int = 3
+	itemsPerPartition int = 10
+)
+
+var partitionKeys = [...]string{partition1Key, partition2Key, partition3Key}
+
+func generateMockItem(partitionIndex int, itemIndex int) mock.MockItem {
+	// Reuse the partitionKeys defined above so generated items match the test partition names.
+	pk := partitionKeys[partitionIndex]
+	return mock.MockItem{
+		// make sure id and merge order are not the same
+		ID:           strconv.Itoa(partitionIndex*itemsPerPartition + itemIndex + 1),
+		PartitionKey: pk,
+		// The merge order should alternate between partitions
+		MergeOrder: partitionIndex + itemIndex*partitionCount,
+	}
+}
+
+func generateMockItems(partitions int, itemsPerPartition int) []mock.MockItem {
+	items := make([]mock.MockItem, 0, partitions*itemsPerPartition)
+	for i := 0; i < partitions; i++ {
+		for j := 0; j < itemsPerPartition; j++ {
+			items = append(items, generateMockItem(i, j))
+		}
+	}
+	return items
+}
+
+func createTestItems(t *testing.T, database *DatabaseClient, items []mock.MockItem) (*ContainerClient, error) {
+	properties := ContainerProperties{
+		ID: "TestContainer",
+		PartitionKeyDefinition: PartitionKeyDefinition{
+			Paths: []string{"/partitionKey"},
+		},
+	}
+
+	// Force the creation of a container with multiple physical partitions
+	throughput := NewManualThroughputProperties(ruCountForMultiplePartitions)
+	_, err := database.CreateContainer(context.TODO(), properties, &CreateContainerOptions{
+		ThroughputProperties: &throughput,
+	})
+	if err != nil {
+		t.Fatalf("failed to create container: %v", err)
+	}
+
+	container, err := database.NewContainer("TestContainer")
+	if err != nil {
+		t.Fatalf("failed to create container client: %v", err)
+	}
+	for _, item := range items {
+		serializedItem, err := json.Marshal(item)
+		if err != nil {
+			return nil, err
+		}
+		_, err = container.UpsertItem(context.TODO(), NewPartitionKeyString(item.PartitionKey), serializedItem, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return container, nil
+}
+
+func TestQueryViaQueryEngine(t *testing.T) {
+	emulatorTests := newEmulatorTests(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{}))
+	database := emulatorTests.createDatabase(t, context.TODO(), client, "TestQueryViaQueryEngine")
+	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
+	// generate items and create the container with them
+	items := generateMockItems(3, 10)
+	container, err := createTestItems(t, database, items)
+	if err != nil {
+		t.Fatalf("Failed to create test items: %v", err)
+	}
+
+	options := &QueryOptions{
+		QueryEngine: mock.NewMockQueryEngine(),
+	}
+	pager := container.NewQueryItemsPager("SELECT * FROM c ORDER BY c.mergeOrder", NewPartitionKey(), options)
+
+	expectedPartitionId := 0
+	expectedMergeOrder := 0
+	itemCount := 0
+	for pager.More() {
+		response, err := pager.NextPage(context.TODO())
+		if err != nil {
+			t.Fatalf("Failed to get next page: %v", err)
+		}
+		for i, item := range response.Items {
+			itemCount++
+			var testItem mock.MockItem
+			if err := json.Unmarshal(item, &testItem); err != nil {
+				t.Fatalf("Failed to unmarshal item: %v", err)
+			}
+
+			if testItem.PartitionKey != partitionKeys[expectedPartitionId] {
+				t.Fatalf("Expected partition key of item #%d with ID %s to be %s, got %s", i, testItem.ID, partitionKeys[expectedPartitionId], testItem.PartitionKey)
+			}
+
+			if testItem.MergeOrder != expectedMergeOrder {
+				t.Fatalf("Expected merge order of item #%d with ID %s to be %d, got %d", i, testItem.ID, expectedMergeOrder, testItem.MergeOrder)
+			}
+
+			expectedPartitionId = (expectedPartitionId + 1) % partitionCount
+			expectedMergeOrder++
+		}
+	}
+
+	if itemCount != partitionCount*itemsPerPartition {
+		t.Fatalf("Expected %d items, got %d", partitionCount*itemsPerPartition, itemCount)
+	}
+}
+
+func TestQueryOverrideWithoutParameters(t *testing.T) {
+	emulatorTests := newEmulatorTests(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{}))
+	database := emulatorTests.createDatabase(t, context.TODO(), client, "TestQueryOverrideWithoutParameters")
+	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
+	items := generateMockItems(3, 5)
+	container, err := createTestItems(t, database, items)
+	if err != nil {
+		t.Fatalf("Failed to create test items: %v", err)
+	}
+
+	override := "SELECT * FROM c WHERE c.id = 'override'"
+	cfg := &mock.QueryRequestConfig{Query: &override, IncludeParameters: false}
+	engine := mock.WithQueryRequestConfig(cfg)
+
+	options := &QueryOptions{QueryEngine: engine}
+	pager := container.NewQueryItemsPager("SELECT * FROM c WHERE c.id = @param1", NewPartitionKey(), options)
+
+	resultItems := make([]mock.MockItem, 0)
+	for pager.More() {
+		resp, err := pager.NextPage(context.TODO())
+		if err != nil {
+			t.Fatalf("failed to get next page: %v", err)
+		}
+		for _, it := range resp.Items {
+			var mi mock.MockItem
+			if err := json.Unmarshal(it, &mi); err != nil {
+				t.Fatalf("failed to unmarshal item: %v", err)
+			}
+			resultItems = append(resultItems, mi)
+		}
+	}
+
+	if len(resultItems) != 0 {
+		t.Fatalf("expected 0 results for override query without parameters, got %d", len(resultItems))
+	}
+}
+
+func TestQueryOverrideWithParameters(t *testing.T) {
+	emulatorTests := newEmulatorTests(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{}))
+	database := emulatorTests.createDatabase(t, context.TODO(), client, "TestQueryOverrideWithParameters")
+	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
+	items := generateMockItems(3, 5)
+	container, err := createTestItems(t, database, items)
+	if err != nil {
+		t.Fatalf("Failed to create test items: %v", err)
+	}
+
+	override := "SELECT * FROM c WHERE c.mergeOrder = @targetOrder"
+	cfg := &mock.QueryRequestConfig{Query: &override, IncludeParameters: true}
+	engine := mock.WithQueryRequestConfig(cfg)
+
+	// choose a target merge order present in the test data: use the first item's merge order (0)
+	if strconv.Itoa(items[0].MergeOrder) == items[0].ID {
+		t.Fatalf("Test data generation error: item ID and MergeOrder should not match")
+	}
+	target := items[0].MergeOrder
+
+	// Build original query that uses a parameter which should be forwarded to the override when includeParameters=true
+	options := &QueryOptions{QueryEngine: engine, QueryParameters: []QueryParameter{{Name: "@targetOrder", Value: target}}}
+	pager := container.NewQueryItemsPager("SELECT * FROM c WHERE c.id = @targetOrder", NewPartitionKey(), options)
+
+	resultItems := make([]mock.MockItem, 0)
+	for pager.More() {
+		resp, err := pager.NextPage(context.TODO())
+		if err != nil {
+			t.Fatalf("failed to get next page: %v", err)
+		}
+		for _, it := range resp.Items {
+			var mi mock.MockItem
+			if err := json.Unmarshal(it, &mi); err != nil {
+				t.Fatalf("failed to unmarshal item: %v", err)
+			}
+			resultItems = append(resultItems, mi)
+		}
+	}
+
+	// Expect items whose MergeOrder == target
+	expected := 0
+	for _, it := range resultItems {
+		if it.MergeOrder == target {
+			expected++
+		}
+	}
+	if expected == 0 {
+		t.Fatalf("expected at least one matching item for target merge order %d", target)
+	}
+}
+
+func TestNoQueryOverrideUsesOriginal(t *testing.T) {
+	emulatorTests := newEmulatorTests(t)
+	client := emulatorTests.getClient(t, newSpanValidator(t, &spanMatcher{}))
+	database := emulatorTests.createDatabase(t, context.TODO(), client, "TestNoQueryOverrideUsesOriginal")
+	defer emulatorTests.deleteDatabase(t, context.TODO(), database)
+	items := generateMockItems(3, 5)
+	container, err := createTestItems(t, database, items)
+	if err != nil {
+		t.Fatalf("Failed to create test items: %v", err)
+	}
+
+	// No override: Query = nil
+	cfg := &mock.QueryRequestConfig{Query: nil, IncludeParameters: false}
+	engine := mock.WithQueryRequestConfig(cfg)
+
+	// We will query by mergeOrder using a parameter
+	target := 0
+	options := &QueryOptions{QueryEngine: engine, QueryParameters: []QueryParameter{{Name: "@targetOrder", Value: target}}}
+	pager := container.NewQueryItemsPager("SELECT * FROM c WHERE c.mergeOrder = @targetOrder", NewPartitionKey(), options)
+
+	resultItems := make([]mock.MockItem, 0)
+	for pager.More() {
+		resp, err := pager.NextPage(context.TODO())
+		if err != nil {
+			t.Fatalf("failed to get next page: %v", err)
+		}
+		for _, it := range resp.Items {
+			var mi mock.MockItem
+			if err := json.Unmarshal(it, &mi); err != nil {
+				t.Fatalf("failed to unmarshal item: %v", err)
+			}
+			resultItems = append(resultItems, mi)
+		}
+	}
+
+	// Expect items whose MergeOrder == target
+	expected := 0
+	for _, it := range resultItems {
+		if it.MergeOrder == target {
+			expected++
+		}
+	}
+	if expected == 0 {
+		t.Fatalf("expected at least one matching item for target merge order %d", target)
+	}
+}

--- a/sdk/data/azcosmos/cosmos_query_request_options.go
+++ b/sdk/data/azcosmos/cosmos_query_request_options.go
@@ -6,6 +6,8 @@ package azcosmos
 import (
 	"fmt"
 	"strconv"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos/queryengine"
 )
 
 // QueryOptions includes options for query operations on items.
@@ -44,6 +46,9 @@ type QueryOptions struct {
 	// If set to false, cross-partition queries will be rejected.
 	// The default value, if this is not set, is true.
 	EnableCrossPartitionQuery *bool
+	// QueryEngine can be set to enable the use of an external query engine for processing cross-partition queries.
+	// This is a preview feature, which is NOT SUPPORTED in production, and is subject to breaking changes.
+	QueryEngine queryengine.QueryEngine
 	// PriorityLevel overrides the client-level default priority for this operation.
 	// Valid values are PriorityLevelHigh and PriorityLevelLow.
 	PriorityLevel *PriorityLevel

--- a/sdk/data/azcosmos/internal/mock/mock_query_engine.go
+++ b/sdk/data/azcosmos/internal/mock/mock_query_engine.go
@@ -1,0 +1,309 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package mock
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos/queryengine"
+)
+
+type PartitionKeyRange struct {
+	ID           string `json:"id"`
+	MinInclusive string `json:"minInclusive"`
+	MaxExclusive string `json:"maxExclusive"`
+}
+
+type pkRanges struct {
+	PartitionKeyRanges []PartitionKeyRange `json:"PartitionKeyRanges"`
+}
+
+type documentPayload[T any] struct {
+	Documents []T `json:"Documents"`
+}
+
+// MockItem is the type of an item in the "mock" pipeline.
+// The "mock" pipeline just merges items from each partition according to their MergeOrder value.
+type MockItem struct {
+	// ID is the ID of the item.
+	ID string `json:"id"`
+
+	// PKRangeId is the partition key range ID of the item.
+	PartitionKey string `json:"partitionKey"`
+
+	// MergeOrder is the universal cross-partition order in which the item should be merged.
+	MergeOrder int `json:"mergeOrder"`
+}
+
+// QueryRequestConfig controls what QueryRequest values the pipeline should return.
+type QueryRequestConfig struct {
+	// Optional query override to return in the per-partition QueryRequest
+	Query             *string
+	IncludeParameters bool
+}
+
+// MockQueryEngine is a mock implementation of the QueryEngine interface.
+// This is a VERY rudimentary implementation that emulates the handling of the following query:
+// `SELECT * FROM c ORDER BY c.mergeOrder`
+// The intent here is to test how the Go SDK interacts with the query engine, not to test the query engine itself.
+type MockQueryEngine struct {
+	CreateError        error
+	QueryRequestConfig *QueryRequestConfig
+}
+
+// NewMockQueryEngine creates a new MockQueryEngine.
+func NewMockQueryEngine() *MockQueryEngine {
+	return &MockQueryEngine{}
+}
+
+// WithQueryRequestConfig returns an engine preconfigured to return the specified query request override.
+func WithQueryRequestConfig(cfg *QueryRequestConfig) *MockQueryEngine {
+	return &MockQueryEngine{QueryRequestConfig: cfg}
+}
+
+// CreateQueryPipeline creates a new query pipeline for the specified query and partition topology.
+func (m *MockQueryEngine) CreateQueryPipeline(query string, plan string, pkranges string) (queryengine.QueryPipeline, error) {
+	// capture config for this pipeline
+	var cfg *QueryRequestConfig
+	if m.QueryRequestConfig != nil {
+		c := *m.QueryRequestConfig
+		cfg = &c
+	}
+
+	var ranges pkRanges
+	if err := json.Unmarshal([]byte(pkranges), &ranges); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal partition key ranges: %w", err)
+	}
+	return newMockQueryPipeline(query, ranges.PartitionKeyRanges, cfg), nil
+}
+
+// CreateReadManyPipeline satisfies the QueryEngine interface. The SDK no longer
+// calls this method for ReadMany operations, but the interface still declares it
+// for backward compatibility with external implementations.
+func (m *MockQueryEngine) CreateReadManyPipeline(_ []queryengine.ItemIdentity, _ string, _ string, _ uint8, _ []string) (queryengine.QueryPipeline, error) {
+	return nil, fmt.Errorf("CreateReadManyPipeline is not supported by MockQueryEngine")
+}
+
+func (m *MockQueryEngine) SupportedFeatures() string {
+	// We need to return whatever is necessary for the gateway to return a query plan for the query `SELECT * FROM c ORDER BY c.mergeOrder`
+	return "OrderBy"
+}
+
+type partitionState struct {
+	PartitionKeyRange
+	started          bool
+	queue            []MockItem
+	nextContinuation string
+	nextIndex        uint64
+}
+
+// IsExhausted returns true if the partition is exhausted.
+// A partition is considered exhausted if all the below are true:
+// 1. The queue is empty (no more items to return).
+// 2. The partition has started (we've received at least one response for it from the server).
+// 3. The next continuation token is empty (the last response indicated that there are no more items on the server).
+func (m *partitionState) IsExhausted() bool {
+	return len(m.queue) == 0 && m.started && m.nextContinuation == ""
+}
+
+// ProvideData inserts new items into the queue, and updates the current continuation token.
+func (p *partitionState) ProvideData(items []MockItem, continuation string) {
+	p.started = true
+	p.nextContinuation = continuation
+	p.queue = append(p.queue, items...)
+}
+
+// PopItem removes the first item from the queue and returns it as a serialized JSON object.
+func (p *partitionState) PopItem() ([]byte, error) {
+	if len(p.queue) == 0 {
+		return nil, fmt.Errorf("no items in queue")
+	}
+	item := p.queue[0]
+	p.queue = p.queue[1:]
+	serialized, err := json.Marshal(item)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize item: %w", err)
+	}
+	return serialized, nil
+}
+
+type MockQueryPipeline struct {
+	query              string
+	completed          bool
+	IsClosed           bool
+	partitionState     []partitionState
+	queryRequestConfig *QueryRequestConfig
+}
+
+func newMockQueryPipeline(query string, partitions []PartitionKeyRange, cfg *QueryRequestConfig) *MockQueryPipeline {
+	partState := make([]partitionState, 0, len(partitions))
+	for _, partition := range partitions {
+		partState = append(partState, partitionState{
+			PartitionKeyRange: partition,
+			started:           false,
+			queue:             nil,
+			nextContinuation:  "",
+			nextIndex:         0,
+		})
+	}
+
+	return &MockQueryPipeline{
+		query:              query,
+		IsClosed:           false,
+		partitionState:     partState,
+		queryRequestConfig: cfg,
+	}
+}
+
+func (m *MockQueryPipeline) Close() {
+	m.IsClosed = true
+}
+
+func (m *MockQueryPipeline) IsComplete() bool {
+	return m.completed
+}
+
+// NextBatch returns the next batch of items from the pipeline, as well as any requests needed to collect more data.
+func (m *MockQueryPipeline) Run() (*queryengine.PipelineResult, error) {
+	if m.IsClosed {
+		return nil, fmt.Errorf("pipeline is closed")
+	}
+
+	items := make([][]byte, 0)
+
+	// Loop, merging items from each partition, until all partitions are exhausted, or we need more data to continue.
+	for {
+		// Iterate through each partition to find the item with the lowest MergeOrder.
+		var lowestMergeOrder int
+		var lowestPartition *partitionState
+		for i := range m.partitionState {
+			// If any partition hasn't started yet, we can't return any items.
+			if !m.partitionState[i].started {
+				return &queryengine.PipelineResult{
+					IsCompleted: false,
+					Items:       nil,
+					Requests:    m.getRequests(),
+				}, nil
+			}
+
+			if m.partitionState[i].IsExhausted() {
+				// If this partition is exhausted, it won't contribute any more items, so we can skip it.
+				continue
+			}
+
+			if len(m.partitionState[i].queue) > 0 && (lowestPartition == nil || m.partitionState[i].queue[0].MergeOrder < lowestMergeOrder) {
+				lowestMergeOrder = m.partitionState[i].queue[0].MergeOrder
+				lowestPartition = &m.partitionState[i]
+			}
+		}
+
+		if lowestPartition == nil {
+			// All partitions are either exhausted or have no items in the queue, so we need to make requests to get more data.
+			break
+		} else {
+			// Add the item to the result set and remove it from the queue.
+			item, err := lowestPartition.PopItem()
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, item)
+		}
+
+		// If we got here, we added an item to the result set, and we need to go back and check all the partitions again.
+	}
+
+	requests := m.getRequests()
+
+	if len(items) == 0 && len(requests) == 0 {
+		// If we didn't get any items and have no requests, we're done.
+		m.completed = true
+	}
+
+	return &queryengine.PipelineResult{
+		IsCompleted: m.completed,
+		Items:       items,
+		Requests:    requests,
+	}, nil
+}
+
+// getRequests returns a list of all the QueryRequests that are needed to get the next batch of items.
+func (m *MockQueryPipeline) getRequests() []queryengine.QueryRequest {
+	requests := make([]queryengine.QueryRequest, 0, len(m.partitionState))
+	for i := range m.partitionState {
+		if m.partitionState[i].IsExhausted() {
+			// If this partition is exhausted, we can't return any items.
+			continue
+		}
+
+		continuation := ""
+		if m.partitionState[i].started {
+			continuation = m.partitionState[i].nextContinuation
+		}
+
+		// Respect any per-pipeline override for the query and include-parameters flag.
+		q := ""
+		includeParams := false
+		if m.queryRequestConfig != nil {
+			if m.queryRequestConfig.Query != nil {
+				q = *m.queryRequestConfig.Query
+			}
+			includeParams = m.queryRequestConfig.IncludeParameters
+		}
+
+		requests = append(requests, queryengine.QueryRequest{
+			PartitionKeyRangeID: m.partitionState[i].ID,
+			Id:                  m.partitionState[i].nextIndex,
+			Continuation:        continuation,
+			Query:               q,
+			IncludeParameters:   includeParams,
+			Drain:               false,
+		})
+	}
+	return requests
+}
+
+// ProvideData is used by the SDK to provide incoming single-partition results to the pipeline.
+// The items are expected to be ordered by the query's ORDER BY clause.
+func (m *MockQueryPipeline) ProvideData(data []queryengine.QueryResult) error {
+	if m.IsClosed {
+		return fmt.Errorf("pipeline is closed")
+	}
+
+	for _, d := range data {
+		// Parse the items
+		var payload documentPayload[MockItem]
+		if err := json.Unmarshal(d.Data, &payload); err != nil {
+			return fmt.Errorf("failed to unmarshal items: %w", err)
+		}
+
+		// Find the partition state for the given partition key range ID and insert the items.
+		found := false
+		for i := range m.partitionState {
+			if m.partitionState[i].ID == d.PartitionKeyRangeID {
+				// Validate request ordering: the provided result must match the expected nextIndex.
+				if m.partitionState[i].nextIndex != d.RequestId {
+					return fmt.Errorf("out of order data provided for partition key range %s: expected index %d, got %d", d.PartitionKeyRangeID, m.partitionState[i].nextIndex, d.RequestId)
+				}
+				// advance expected index for next request
+				m.partitionState[i].nextIndex++
+				m.partitionState[i].ProvideData(payload.Documents, d.NextContinuation)
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("no partition found with ID %s", d.PartitionKeyRangeID)
+		}
+	}
+
+	return nil
+}
+
+func (m *MockQueryPipeline) Query() string {
+	return m.query
+}
+
+var _ queryengine.QueryPipeline = &MockQueryPipeline{}

--- a/sdk/data/azcosmos/queryengine/cosmos_query_engine.go
+++ b/sdk/data/azcosmos/queryengine/cosmos_query_engine.go
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package queryengine
+
+// QueryEngine is an interface that defines the methods for a query engine.
+type QueryEngine interface {
+	CreateQueryPipeline(query string, plan string, pkranges string) (QueryPipeline, error)
+	CreateReadManyPipeline(items []ItemIdentity, pkranges string, pkKind string, pkVersion uint8, pkPaths []string) (QueryPipeline, error)
+	SupportedFeatures() string
+}
+
+// ItemIdentity contains the unique identifiers for an item in a container.
+type ItemIdentity struct {
+	// json string representation of the partition key value
+	PartitionKeyValue string
+	// ID of the item to read
+	ID string
+}
+
+// QueryRequest describes a request from the pipeline for data from a specific partition key range.
+type QueryRequest struct {
+	// PartitionKeyRangeID is the ID of the partition key range from which data is requested.
+	PartitionKeyRangeID string
+	// The ID of this request, within the partition key range.
+	//
+	// Opaque identifier that must be provided back to the pipeline when providing data.
+	Id uint64
+	// Continuation is the continuation token to use in the request.
+	Continuation string
+	// The query to execute for this partition key range, if different from the original query.
+	Query string
+	// If a query is specified, this flag indicates if the query parameters should be included with that query.
+	//
+	// Sometimes, when an override query is specified, it differs in structure from the original query, and the original parameters are not valid.
+	IncludeParameters bool
+	// If specified, indicates that the SDK should IMMEDIATELY drain all remaining results from this partition key range, following continuation tokens, until no more results are available.
+	// All the data from this partition key range should be provided BEFORE any new items will be made available.
+	// The data may be provided in multiple QueryResults, but every result correlated to this request should have the same RequestId value.
+	//
+	// This allows engines to optimize for non-streaming scenarios, where the entire result set must be provided to the engine before it can make progress.
+	Drain bool
+}
+
+// QueryResult contains the result of a query for a specific partition key range.
+type QueryResult struct {
+	// The ID of the partition key range that was queried.
+	PartitionKeyRangeID string
+	// The ID of the QueryRequest that generated this result.
+	RequestId uint64
+	// The continuation token to be used for the next request, if any.
+	NextContinuation string
+	// The raw body of the response from the query.
+	Data []byte
+}
+
+// NewQueryRequest creates a new QueryRequest with the specified partition key range ID, continuation token, and data.
+func NewQueryResult(partitionKeyRangeID string, data []byte, continuation string) QueryResult {
+	return QueryResult{
+		PartitionKeyRangeID: partitionKeyRangeID,
+		Data:                data,
+		NextContinuation:    continuation,
+	}
+}
+
+// NewQueryRequestString creates a new QueryRequest with the specified partition key range ID, continuation token, and data (as a string).
+func NewQueryResultString(partitionKeyRangeID string, data string, continuation string) QueryResult {
+	return NewQueryResult(partitionKeyRangeID, []byte(data), continuation)
+}
+
+// PipelineResult contains the result of running a single turn of the query pipeline.
+type PipelineResult struct {
+	// IsCompleted indicates if the pipeline has completed processing.
+	IsCompleted bool
+
+	// Items contains the items returned by the pipeline.
+	Items [][]byte
+
+	// Requests contains the requests made by the pipeline for more data.
+	Requests []QueryRequest
+}
+
+// QueryPipeline is an interface that defines the methods for a query pipeline.
+type QueryPipeline interface {
+	// Query returns the query text, possibly rewritten by the gateway, which will be used for per-partition queries.
+	Query() string
+	// IsComplete gets a boolean indicating if the pipeline has concluded
+	IsComplete() bool
+	// Run executes a single turn of the pipeline, yielding a PipelineResult containing the items and requests for more data.
+	Run() (*PipelineResult, error)
+	// Data from multiple partition ranges may be provided at once.
+	// However, each page of data must be provided in order.
+	// So, for any given partition key range, page n's results must be earlier in the `data` slice than page n+1's results.
+	// Data from different partition key ranges may be interleaved, as long as each partition key range's pages are in order.
+	//
+	// The pipeline will use the QueryResult.RequestId field to validate this.
+	//
+	// When providing data from a draining request (i.e. a request with Drain set to true), all pages for that draining request can share the same QueryResult.RequestId.
+	ProvideData(data []QueryResult) error
+	// Close frees the resources associated with the pipeline.
+	Close()
+}

--- a/sdk/data/azcosmos/version.go
+++ b/sdk/data/azcosmos/version.go
@@ -7,5 +7,5 @@ const (
 	moduleName = "github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 
 	// serviceLibVersion is the semantic version (see http://semver.org) of this module.
-	serviceLibVersion = "v1.5.1-beta.1"
+	serviceLibVersion = "v1.6.0-beta.1"
 )


### PR DESCRIPTION
Reverts #27134 which removed support for the external query engine introduced during 1.5.0 beta releases. That feature wasn't ready for release but we had a need to release a 1.5.0 GA for other features, so we removed it temporarily. This restores it for the 1.6.0 beta series.