### PR TITLE
cosmos: CHANGELOG updates for 1.6.0-beta.1 release

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -2,17 +2,11 @@
 
 <!-- cSpell:ignore documentdb unmarshalling -->
 
-## 1.6.0-beta.1 (Unreleased)
+## 1.6.0-beta.1 (2026-07-16)
 
 ### Features Added
 
 * Restored the query engine feature originally present in 1.5.0-beta releases (but removed for the 1.5.0 GA release).
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 1.5.0 (2026-07-13)
 


### PR DESCRIPTION
Update changelog for 1.6.0-beta.1 release. This release is just a quick beta release to restore the query engine API for customers who are using that beta feature and want to update to latest.