### PR TITLE
Conform central cspell word list ordering ***NO_CI***

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -3,11 +3,11 @@
     "language": "en",
     "languageId": "golang",
     "dictionaries": [
-      "powershell",
-      "golang",
-      "softwareTerms",
-      "en_US",
-      "en-gb"
+        "powershell",
+        "golang",
+        "softwareTerms",
+        "en_US",
+        "en-gb"
     ],
     "ignorePaths": [
         "eng/common/**",
@@ -19,30 +19,30 @@
         "**/recordings/**/*"
     ],
     "words": [
-        "azcore",
+        "AMQP",
+        "armiotsecurity",
+        "armkubernetesconfiguration",
+        "armkusto",
         "azappconfig",
+        "azblob",
+        "azcore",
+        "azcosmos",
         "azidentity",
-        "unpopulate",
+        "azruntime",
+        "azservicebus",
         "etag",
+        "Kubernetes",
+        "Kusto",
+        "mgmt",
+        "msix",
+        "nolint",
+        "odata",
+        "Reimage",
+        "skus",
         "stretchr",
         "Unmarshaller",
-        "AMQP",
-        "Kusto",
-        "azblob",
-        "Kubernetes",
-        "vnet",
-        "skus",
-        "azservicebus",
-        "azcosmos",
-        "Reimage",
-        "nolint",
-        "armkusto",
-        "msix",
-        "armiotsecurity",
-        "odata",
-        "mgmt",
-        "armkubernetesconfiguration",
-        "azruntime"
+        "unpopulate",
+        "vnet"
     ],
     "allowCompoundWords": true,
     "overrides": [
@@ -50,9 +50,9 @@
             "filename": "{*.sum,*.mod}",
             "words": [
                 "davecgh",
-                "pmezard",
                 "gover",
-                "objx"
+                "objx",
+                "pmezard"
             ]
         }
     ]


### PR DESCRIPTION
## What

Align `.vscode/cspell.json` with the latest Azure SDK spellcheck guidance by
alphabetizing (case-insensitive) and deduping the central word lists.

Go has no service-scoped `overrides` to redistribute into per-service
`cspell.yaml` files, so this is a **conformance-only** change (word ordering).

## Safety / validation

- **Conservation check:** the case-insensitive word union is identical before
  and after — **0 words lost**.
- Structure and existing overrides are unchanged; only ordering differs.

## CI

Config-only change, tagged **`***NO_CI***`** to avoid an unnecessary build.
Opened as a **draft**.
