### PR TITLE
Upgrade emitter and TypeSpec package versions

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -5,46 +5,48 @@
   "packages": {
     "": {
       "dependencies": {
-        "@azure-tools/typespec-go": "0.14.3"
+        "@azure-tools/typespec-go": "0.15.0"
       },
       "devDependencies": {
-        "@azure-tools/typespec-autorest": "0.69.1",
-        "@azure-tools/typespec-azure-core": "0.69.0",
-        "@azure-tools/typespec-azure-portal-core": "0.69.0",
-        "@azure-tools/typespec-azure-resource-manager": "0.69.2",
-        "@azure-tools/typespec-azure-rulesets": "0.69.2",
-        "@azure-tools/typespec-client-generator-core": "0.69.2",
+        "@azure-tools/typespec-autorest": "0.70.0",
+        "@azure-tools/typespec-azure-core": "0.70.0",
+        "@azure-tools/typespec-azure-portal-core": "0.70.0",
+        "@azure-tools/typespec-azure-resource-manager": "0.70.0",
+        "@azure-tools/typespec-azure-rulesets": "0.70.0",
+        "@azure-tools/typespec-client-generator-core": "0.70.0",
         "@azure-tools/typespec-liftr-base": "0.14.0",
-        "@typespec/compiler": "1.13.0",
-        "@typespec/events": "0.83.0",
-        "@typespec/http": "1.13.0",
-        "@typespec/openapi": "1.13.0",
-        "@typespec/rest": "0.83.0",
-        "@typespec/sse": "0.83.0",
-        "@typespec/streams": "0.83.0",
-        "@typespec/versioning": "0.83.0",
-        "@typespec/xml": "0.83.0"
+        "@typespec/compiler": "1.14.0",
+        "@typespec/events": "0.84.0",
+        "@typespec/http": "1.14.0",
+        "@typespec/openapi": "1.14.0",
+        "@typespec/rest": "0.84.0",
+        "@typespec/sse": "0.84.0",
+        "@typespec/streams": "0.84.0",
+        "@typespec/versioning": "0.84.0",
+        "@typespec/xml": "0.84.0"
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.69.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.69.1.tgz",
-      "integrity": "sha512-nbAsTagr4pyBO0ajlRnE5TW4tAXrYKFYSoWD+8bevXpe23bkVIJkDUJCZPSgWE7CBf3kxfw53lAb70a50oJmRA==",
-      "dev": true,
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.70.0.tgz",
+      "integrity": "sha512-OaxLkgMcuOXAbaqTNpezmFF24jtkiIH1+2PBwAeRo3ZG7C1r7Hf8xZwCK6KVtBEgMbqnrd5eCqxsPl1zy3y9/Q==",
       "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.3"
+      },
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.69.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.69.1",
-        "@azure-tools/typespec-client-generator-core": "^0.69.0",
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/http": "^1.13.0",
-        "@typespec/openapi": "^1.13.0",
-        "@typespec/rest": "^0.83.0",
-        "@typespec/versioning": "^0.83.0",
-        "@typespec/xml": "^0.83.0"
+        "@azure-tools/typespec-azure-core": "^0.70.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.70.0",
+        "@azure-tools/typespec-client-generator-core": "^0.70.0",
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/http": "^1.14.0",
+        "@typespec/openapi": "^1.14.0",
+        "@typespec/rest": "^0.84.0",
+        "@typespec/versioning": "^0.84.0",
+        "@typespec/xml": "^0.84.0"
       },
       "peerDependenciesMeta": {
         "@typespec/xml": {
@@ -53,35 +55,34 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.69.0.tgz",
-      "integrity": "sha512-UNdPb/DgMvXqwWk9hb54QOAumCJ6u6GGy+bj3RIIT1Sht6FR9rIn8AQ/UQ7WtrhbJBoqvQo5dxtS565a9/VRZw==",
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.70.0.tgz",
+      "integrity": "sha512-8MojHWRtTLKycJJ98IMoXX/5b9tTo3F0d3Iu20OKoCsORnSDG2NfjOWHJVW63oxA2t8VTlqC6J8BDcnRihygQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/http": "^1.13.0",
-        "@typespec/rest": "^0.83.0"
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/http": "^1.14.0",
+        "@typespec/rest": "^0.84.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-portal-core": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-portal-core/-/typespec-azure-portal-core-0.69.0.tgz",
-      "integrity": "sha512-f6S7wz2VdKessVkCIYTy9IFJpZakN2fvT9uQODD934Bq0tREUIeQQEbh53XWddUIJp0QFh7yJx8hTi4RWxAE9g==",
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-portal-core/-/typespec-azure-portal-core-0.70.0.tgz",
+      "integrity": "sha512-HZSSht0qu8B0Ara6Ni4iu5mfr43wjaq+tWXKuv5eMOSixxMrkZetiYdZDeyKaQpqK08vNTKS6D7OFNDotWuauQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@azure-tools/typespec-azure-resource-manager": "^0.69.0",
-        "@typespec/compiler": "^1.13.0"
+        "@azure-tools/typespec-azure-resource-manager": "^0.70.0",
+        "@typespec/compiler": "^1.14.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.69.2.tgz",
-      "integrity": "sha512-8Kcn68zKwRsAOc4LICYHOeGq9w5sCDLaXp2t0x0/DibVtYlKJI3ixQnUCW1P7et0nyKp92UZNKvjdUXC1kEINg==",
-      "dev": true,
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.70.0.tgz",
+      "integrity": "sha512-hVrbbsOhU3EQ2yQTppCqsGQwY/HcVZPOINtFkoUo+PUVBmCFXyqLkTO4jvUbsp/LvJEwoQ8aEA8Y35f7VWT5uw==",
       "license": "MIT",
       "dependencies": {
         "change-case": "^5.4.4",
@@ -91,34 +92,33 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.69.0",
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/http": "^1.13.0",
-        "@typespec/openapi": "^1.13.0",
-        "@typespec/rest": "^0.83.0",
-        "@typespec/versioning": "^0.83.0"
+        "@azure-tools/typespec-azure-core": "^0.70.0",
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/http": "^1.14.0",
+        "@typespec/openapi": "^1.14.0",
+        "@typespec/rest": "^0.84.0",
+        "@typespec/versioning": "^0.84.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-rulesets": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.69.2.tgz",
-      "integrity": "sha512-7FI2Fv4weFGAjAgUnbBkh1FPCW3SxcEQElIo3SHtc4YDXYbDgvs1qCpz+eyGKEdELPnrIFJFrLa/Mu32GxSrZw==",
-      "dev": true,
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.70.0.tgz",
+      "integrity": "sha512-Uxxl/18oryDwk2S+aYx6cIqiyjmoMeFDGmjuQ72a+aw6u8mZjgahMxNsY0ShvGLSchjsDqsVGaUlazXGXakVrw==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.69.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.69.2",
-        "@azure-tools/typespec-client-generator-core": "^0.69.2",
-        "@typespec/compiler": "^1.13.0"
+        "@azure-tools/typespec-azure-core": "^0.70.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.70.0",
+        "@azure-tools/typespec-client-generator-core": "^0.70.0",
+        "@typespec/compiler": "^1.14.0"
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.69.2.tgz",
-      "integrity": "sha512-Td+CUO9UNioD/k2aFnv7TcffGGSaxmodshonTwts3/ZBJLmFtZI06odXr0+7/QDM9K9koPDjCg0VwTbS2c6scA==",
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.70.0.tgz",
+      "integrity": "sha512-8yxOYJfID3wp3FLQYNIa3kbmR5YLWjYtpB+i4u66quHTTQWWANHV1/o9f8xymAf+8fO9jbLo5tw1JerumxISWg==",
       "license": "MIT",
       "dependencies": {
         "change-case": "^5.4.4",
@@ -129,34 +129,44 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.69.0",
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/events": "^0.83.0",
-        "@typespec/http": "^1.13.0",
-        "@typespec/openapi": "^1.13.0",
-        "@typespec/rest": "^0.83.0",
-        "@typespec/sse": "^0.83.0",
-        "@typespec/streams": "^0.83.0",
-        "@typespec/versioning": "^0.83.0",
-        "@typespec/xml": "^0.83.0"
+        "@azure-tools/typespec-azure-core": "^0.70.0",
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/events": "^0.84.0",
+        "@typespec/http": "^1.14.0",
+        "@typespec/openapi": "^1.14.0",
+        "@typespec/rest": "^0.84.0",
+        "@typespec/sse": "^0.84.0",
+        "@typespec/streams": "^0.84.0",
+        "@typespec/versioning": "^0.84.0",
+        "@typespec/xml": "^0.84.0"
       }
     },
     "node_modules/@azure-tools/typespec-go": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-go/-/typespec-go-0.14.3.tgz",
-      "integrity": "sha512-6RLrqg7Du299Rp5rtL1us20filNStcmlIPVK79p2ryCGeaPP4ip4alJqUcg8WmOjqzwNND7MkePwGusYuQXkSA==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-go/-/typespec-go-0.15.0.tgz",
+      "integrity": "sha512-asjcm5FI620poK4fIbscMZZyKIHWw7B1sERrkrMZGvzrWHZNP9XBQ45W3Jyoi0ijlTrSObisF9iatvQTRbFJpQ==",
       "license": "MIT",
       "dependencies": {
-        "semver": "^7.7.1",
-        "source-map-support": "0.5.21"
+        "semver": "^7.7.4"
       },
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-client-generator-core": "^0.69.0",
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/http": "^1.13.0"
+        "@azure-tools/typespec-autorest": "^0.70.0",
+        "@azure-tools/typespec-azure-core": "^0.70.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.70.0",
+        "@azure-tools/typespec-azure-rulesets": "^0.70.0",
+        "@azure-tools/typespec-client-generator-core": "^0.70.0",
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/events": "^0.84.0",
+        "@typespec/http": "^1.14.0",
+        "@typespec/openapi": "^1.14.0",
+        "@typespec/rest": "^0.84.0",
+        "@typespec/sse": "^0.84.0",
+        "@typespec/streams": "^0.84.0",
+        "@typespec/versioning": "^0.84.0",
+        "@typespec/xml": "^0.84.0"
       }
     },
     "node_modules/@azure-tools/typespec-liftr-base": {
@@ -529,9 +539,9 @@
       }
     },
     "node_modules/@typespec/compiler": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.13.0.tgz",
-      "integrity": "sha512-DonoHiyAMx0UjSmssqTrFtya+v97wny1aHcTLU5QF2wFzLATtcwUU9hbPC+eXhepuTunMOCHf8yk3pEsH6PZYA==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.14.0.tgz",
+      "integrity": "sha512-RRN0LGVDlonG/IbB2b4mvRjdCo6LywwB9/J8lOp6UaH7vtaFnKe5FL+rpxhof4rXx/zI/4OWnQO6c01bTCz4/Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -545,8 +555,8 @@
         "prettier": "^3.8.1",
         "semver": "^7.7.4",
         "tar": "^7.5.13",
-        "temporal-polyfill": "^0.3.2",
-        "vscode-languageserver": "^9.0.1",
+        "temporal-polyfill": "^1.0.1",
+        "vscode-languageserver": "^10.0.0",
         "vscode-languageserver-textdocument": "^1.0.12",
         "yaml": "^2.8.3",
         "yargs": "^18.0.0"
@@ -560,28 +570,28 @@
       }
     },
     "node_modules/@typespec/events": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.83.0.tgz",
-      "integrity": "sha512-3EP1EIjdLgwStgd2rGWaF/QqY7YRAt+DIYnnYG2VsdPwa8s2t6K6eJ9YJDXveeHImAkHs+cpFuwxnjKMl4hOyw==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.84.0.tgz",
+      "integrity": "sha512-UroDIu6t6Z+cOLyX8I+GJWhSFmYGrp1L93F7ZVt0Ypmj0ndmC9YYa4cpeEyS5PDDIC8u49WfCIwfGegxt4rPVQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0"
+        "@typespec/compiler": "^1.14.0"
       }
     },
     "node_modules/@typespec/http": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.13.0.tgz",
-      "integrity": "sha512-tf8XFddU6g1MZSAVCLC/0Xa4fNfUO0CcHe6PWpmC3bvUojxMnpRcERI2DdoRJ+aycB9Q+Z8wN8bJO3up6u+sCw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.14.0.tgz",
+      "integrity": "sha512-W+heCzu8K63AVcoX8MachVWaRxSAMFWOI1yBTc2Kq8QHaJeDiLL5JbU8VfTZ4tL/6EoGSdKfIT5ZNRW7oVCzhg==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/streams": "^0.83.0"
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/streams": "^0.84.0"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -590,80 +600,80 @@
       }
     },
     "node_modules/@typespec/openapi": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.13.0.tgz",
-      "integrity": "sha512-omPc9n+LM2WvjYwnIf31RCxmG17fFUOVLBRsWg4T1mbcsNCj4grnNP7Lwt+irIZCiKtmLKxq3ViE7jYixCkZ3g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.14.0.tgz",
+      "integrity": "sha512-KL7kImPhCXRmxpHVt1k7TWaa4bb3NbSeUx2rxyxeq7lYZFllI6/NYRCTOI/5JOrbElWmmSxrajU9K9IAKI6PkQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/http": "^1.13.0"
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/http": "^1.14.0"
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.83.0.tgz",
-      "integrity": "sha512-WMEwEe1kdaOdZ0c+ct5BVmTSBXkrPniUYDWCz3K52T4in2dNc7J6YGP6tL8bXgQz5B0CsP0VNO12N+UysQDsLw==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.84.0.tgz",
+      "integrity": "sha512-9s5dDfRoHRPdtbVvkBasUx/RnMvwWMTuXRieSQDEji4gWGgxVu4Zt4MiEEKSfQrkMr3Aw0QjRCSxBxjMCHIOmA==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/http": "^1.13.0"
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/http": "^1.14.0"
       }
     },
     "node_modules/@typespec/sse": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.83.0.tgz",
-      "integrity": "sha512-04WNaju2rwBbcF5pG+HrKQtdcrmSGuTVziLHNA9XOqj1qM7Uon3+wo2g+ZZ3Z6tngfqQoTCPyDcRHqZtGRdNuw==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.84.0.tgz",
+      "integrity": "sha512-9joNgVisRCWDFfV1d79iTAuR1W/6r+AKJrKUfcjsaTrq5A8OWW3v5TTsfxbHAZArn7n2WxQkqhNGgNyc8LjEng==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0",
-        "@typespec/events": "^0.83.0",
-        "@typespec/http": "^1.13.0",
-        "@typespec/streams": "^0.83.0"
+        "@typespec/compiler": "^1.14.0",
+        "@typespec/events": "^0.84.0",
+        "@typespec/http": "^1.14.0",
+        "@typespec/streams": "^0.84.0"
       }
     },
     "node_modules/@typespec/streams": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.83.0.tgz",
-      "integrity": "sha512-wbO6sdH1Uf+UwjxxsWdHQkjJ3wwiYsAKI+L66qnDYVXAFe02sUdMKd0mxH5o9ipGXE52MZ+yvZ52vHAD+g3RFQ==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.84.0.tgz",
+      "integrity": "sha512-SDneR8+zY+ueOpzg9yJtttfDe/ikB99JgddZSXKPwiDPlAIEeEvI8auipcYfB58EEOB21h8Oq0tEm8HqiAAWdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0"
+        "@typespec/compiler": "^1.14.0"
       }
     },
     "node_modules/@typespec/versioning": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.83.0.tgz",
-      "integrity": "sha512-nE66ta0ixpHB6FQpSzqnj8QnVfgFsxeK/4Xv+DxYx2nB/w18f6VjkF+hW+A/zs1tZIYvBZVbCNa/Rcr8zM6fhg==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.84.0.tgz",
+      "integrity": "sha512-ZoDasTDj4z0mgFK+0cJL2+7DduCaTjvICHL2nQ/RBWc7nLgObaIYCjvXLno8WneDXnpxCAr7larN4/nlHEv9fg==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0"
+        "@typespec/compiler": "^1.14.0"
       }
     },
     "node_modules/@typespec/xml": {
-      "version": "0.83.0",
-      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.83.0.tgz",
-      "integrity": "sha512-2/dtAD8jGPkIdwpQ1G1P+5+qdMPeafQiIKCd8NdAnOo0w9OZ59Io52jINm9HdN8+FcbOrqK8+B2N9rlPRj7PqA==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.84.0.tgz",
+      "integrity": "sha512-3x0spgIrr4u3azkYaOxrlumtjoqPiUnJ/G5RwGBmUCAeE5F413MHf/AeIkmZ2ULT1gY3myabfZp8bOijTbMk7A==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.13.0"
+        "@typespec/compiler": "^1.14.0"
       }
     },
     "node_modules/ajv": {
@@ -705,12 +715,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT"
     },
     "node_modules/change-case": {
       "version": "5.4.4",
@@ -960,9 +964,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
-      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -1013,25 +1017,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
@@ -1065,9 +1050,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -1081,49 +1066,56 @@
       }
     },
     "node_modules/temporal-polyfill": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
-      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.1.tgz",
+      "integrity": "sha512-N2SoI9olnW7BUsU8RosDphZQl9s+WJ8O7PoJMFCr/e5/1rFkVI4GNOWaSeySG+UoP04foPYsnLWbJmbXOiShZg==",
       "license": "MIT",
       "dependencies": {
-        "temporal-spec": "0.3.1"
+        "temporal-spec": "1.0.0",
+        "temporal-utils": "1.0.1"
       }
     },
     "node_modules/temporal-spec": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
-      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
-      "license": "ISC"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.0.tgz",
+      "integrity": "sha512-00Ahj1e1ifaERTMOIIGpOCdOo9IEk2m6GGSMedsn9a2SIsGLdOTbmME1Htv6IM82b6VHrzSUTIVc7YHy6hdhFQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/temporal-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-utils/-/temporal-utils-1.0.1.tgz",
+      "integrity": "sha512-HAixuesxFQIUaQk3ptX2jhfO/FsOkgVkDDMawvp6n/fkB1q6BKfs3lURw9I+pK/2e2e/q/vrLrxmeqauBoyGMQ==",
+      "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageserver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-10.1.0.tgz",
+      "integrity": "sha512-9gEWpXkYGXoqG7pBnE8O8hx/yP7+Aabn4+peQ3KDicQv6qunHSWyLTud3OF0w4S2+HfDD+5HqYKiXQW9HAU6mA==",
       "license": "MIT",
       "dependencies": {
-        "vscode-languageserver-protocol": "3.17.5"
+        "vscode-languageserver-protocol": "3.18.2"
       },
       "bin": {
         "installServerIntoExtension": "bin/installServerIntoExtension"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
       "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
+        "vscode-jsonrpc": "9.0.1",
+        "vscode-languageserver-types": "3.18.0"
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
@@ -1133,9 +1125,9 @@
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -1,24 +1,24 @@
 {
   "main": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/typespec-go": "0.14.3"
+    "@azure-tools/typespec-go": "0.15.0"
   },
   "devDependencies": {
-    "@azure-tools/typespec-autorest": "0.69.1",
-    "@azure-tools/typespec-azure-core": "0.69.0",
-    "@azure-tools/typespec-azure-portal-core": "0.69.0",
-    "@azure-tools/typespec-azure-resource-manager": "0.69.2",
-    "@azure-tools/typespec-azure-rulesets": "0.69.2",
-    "@azure-tools/typespec-client-generator-core": "0.69.2",
+    "@azure-tools/typespec-autorest": "0.70.0",
+    "@azure-tools/typespec-azure-core": "0.70.0",
+    "@azure-tools/typespec-azure-portal-core": "0.70.0",
+    "@azure-tools/typespec-azure-resource-manager": "0.70.0",
+    "@azure-tools/typespec-azure-rulesets": "0.70.0",
+    "@azure-tools/typespec-client-generator-core": "0.70.0",
     "@azure-tools/typespec-liftr-base": "0.14.0",
-    "@typespec/compiler": "1.13.0",
-    "@typespec/events": "0.83.0",
-    "@typespec/http": "1.13.0",
-    "@typespec/openapi": "1.13.0",
-    "@typespec/rest": "0.83.0",
-    "@typespec/sse": "0.83.0",
-    "@typespec/streams": "0.83.0",
-    "@typespec/versioning": "0.83.0",
-    "@typespec/xml": "0.83.0"
+    "@typespec/compiler": "1.14.0",
+    "@typespec/events": "0.84.0",
+    "@typespec/http": "1.14.0",
+    "@typespec/openapi": "1.14.0",
+    "@typespec/rest": "0.84.0",
+    "@typespec/sse": "0.84.0",
+    "@typespec/streams": "0.84.0",
+    "@typespec/versioning": "0.84.0",
+    "@typespec/xml": "0.84.0"
   }
 }


### PR DESCRIPTION
Upgrades the Go emitter and TypeSpec packages in `eng/emitter-package.json` to their latest versions and regenerates `eng/emitter-package-lock.json`.

### Version bumps
- `@azure-tools/typespec-go`: 0.14.3 → 0.15.0
- `@azure-tools/typespec-*` (autorest, azure-core, azure-portal-core, azure-resource-manager, azure-rulesets, client-generator-core): 0.69.x → 0.70.0
- `@typespec/compiler`, `http`, `openapi`: 1.13.0 → 1.14.0
- `@typespec/events`, `rest`, `sse`, `streams`, `versioning`, `xml`: 0.83.0 → 0.84.0