### PR TITLE
Add paginated ListRanges with continuation token support for Azure Files

### DIFF
--- a/sdk/storage/azfile/CHANGELOG.md
+++ b/sdk/storage/azfile/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.7.1-beta.1 (Unreleased)
 
 ### Features Added
+* Added `NewListRangesPager` method on file `Client` for paginated range listing with continuation token and `MaxResults` support.
 
 ### Breaking Changes
 

--- a/sdk/storage/azfile/file/client.go
+++ b/sdk/storage/azfile/file/client.go
@@ -302,7 +302,7 @@ func (f *Client) GetRangeList(ctx context.Context, options *GetRangeListOptions)
 // and a continuation token for retrieving the next page. Set MaxResults on the options to control page size.
 // When PrevShareSnapshot is set, the pager returns ranges that have changed between the previous snapshot
 // and the target (diff mode).
-// For more information, see https://learn.microsoft.com/en-us/rest/api/storageservices/list-ranges.
+// For more information, see https://learn.microsoft.com/rest/api/storageservices/list-ranges.
 func (f *Client) NewListRangesPager(options *ListRangesOptions) *runtime.Pager[ListRangesSegmentResponse] {
 	listOptions := options.format(f.getClientOptions().FileRequestIntent, f.getClientOptions().AllowTrailingDot)
 	return runtime.NewPager(runtime.PagingHandler[ListRangesSegmentResponse]{

--- a/sdk/storage/azfile/file/client.go
+++ b/sdk/storage/azfile/file/client.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -295,6 +296,37 @@ func (f *Client) UploadRangeFromURL(ctx context.Context, copySource string, sour
 func (f *Client) GetRangeList(ctx context.Context, options *GetRangeListOptions) (GetRangeListResponse, error) {
 	opts := options.format(f.getClientOptions().FileRequestIntent, f.getClientOptions().AllowTrailingDot)
 	return f.generated().GetRangeList(ctx, opts)
+}
+
+// NewListRangesPager returns a pager for the valid ranges of a file. Each page contains a segment of ranges
+// and a continuation token for retrieving the next page. Set MaxResults on the options to control page size.
+// When PrevShareSnapshot is set, the pager returns ranges that have changed between the previous snapshot
+// and the target (diff mode).
+// For more information, see https://learn.microsoft.com/en-us/rest/api/storageservices/list-ranges.
+func (f *Client) NewListRangesPager(options *ListRangesOptions) *runtime.Pager[ListRangesSegmentResponse] {
+	listOptions := options.format(f.getClientOptions().FileRequestIntent, f.getClientOptions().AllowTrailingDot)
+	return runtime.NewPager(runtime.PagingHandler[ListRangesSegmentResponse]{
+		More: func(page ListRangesSegmentResponse) bool {
+			return page.NextMarker != nil && len(*page.NextMarker) > 0
+		},
+		Fetcher: func(ctx context.Context, page *ListRangesSegmentResponse) (ListRangesSegmentResponse, error) {
+			if page != nil {
+				listOptions.Marker = page.NextMarker
+			}
+			req, err := f.generated().ListAllRangesCreateRequest(ctx, &listOptions)
+			if err != nil {
+				return ListRangesSegmentResponse{}, err
+			}
+			resp, err := f.generated().InternalClient().Pipeline().Do(req)
+			if err != nil {
+				return ListRangesSegmentResponse{}, err
+			}
+			if !runtime.HasStatusCode(resp, http.StatusOK) {
+				return ListRangesSegmentResponse{}, runtime.NewResponseError(resp)
+			}
+			return f.generated().ListAllRangesHandleResponse(resp)
+		},
+	})
 }
 
 // ForceCloseHandles operation closes a handle or handles opened on a file.

--- a/sdk/storage/azfile/file/models.go
+++ b/sdk/storage/azfile/file/models.go
@@ -879,6 +879,47 @@ func (o *GetRangeListOptions) format(fileRequestIntent *generated.ShareTokenInte
 
 // ---------------------------------------------------------------------------------------------------------------------
 
+// ListRangesOptions contains the optional parameters for the Client.NewListRangesPager method.
+type ListRangesOptions struct {
+	// The previous snapshot parameter is an opaque DateTime value that, when present, specifies the previous snapshot.
+	// When set, the pager returns ranges that have changed between the previous snapshot and the target (diff mode).
+	PrevShareSnapshot *string
+	// Specifies the range of bytes over which to list ranges, inclusively.
+	Range HTTPRange
+	// The snapshot parameter is an opaque DateTime value that, when present, specifies the share snapshot to query.
+	ShareSnapshot *string
+	// LeaseAccessConditions contains optional parameters to access leased entity.
+	LeaseAccessConditions *LeaseAccessConditions
+	// SupportRename determines whether the changed ranges for a file should be listed when the file's location in the
+	// previous snapshot is different from the location in the Request URI, as a result of rename or move operations.
+	SupportRename *bool
+	// MaxResults specifies the maximum number of ranges to return per page. If not set, the service returns all ranges.
+	MaxResults *int32
+}
+
+func (o *ListRangesOptions) format(fileRequestIntent *generated.ShareTokenIntent, allowTrailingDot *bool) generated.FileClientListAllRangesOptions {
+	opts := generated.FileClientListAllRangesOptions{
+		FileRequestIntent: fileRequestIntent,
+		AllowTrailingDot:  allowTrailingDot,
+	}
+	if o == nil {
+		return opts
+	}
+
+	opts.Prevsharesnapshot = o.PrevShareSnapshot
+	opts.Range = exported.FormatHTTPRange(o.Range)
+	opts.Sharesnapshot = o.ShareSnapshot
+	opts.SupportRename = o.SupportRename
+	opts.Maxresults = o.MaxResults
+	if o.LeaseAccessConditions != nil {
+		opts.LeaseID = o.LeaseAccessConditions.LeaseID
+	}
+
+	return opts
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
 // GetSASURLOptions contains the optional parameters for the Client.GetSASURL method.
 type GetSASURLOptions struct {
 	StartTime *time.Time

--- a/sdk/storage/azfile/file/responses.go
+++ b/sdk/storage/azfile/file/responses.go
@@ -85,6 +85,9 @@ type UploadRangeFromURLResponse = generated.FileClientUploadRangeFromURLResponse
 // GetRangeListResponse contains the response from method Client.GetRangeList.
 type GetRangeListResponse = generated.FileClientGetRangeListResponse
 
+// ListRangesSegmentResponse contains the response from method Client.NewListRangesPager.
+type ListRangesSegmentResponse = generated.FileClientListAllRangesResponse
+
 // ForceCloseHandlesResponse contains the response from method Client.ForceCloseHandles.
 type ForceCloseHandlesResponse = generated.FileClientForceCloseHandlesResponse
 

--- a/sdk/storage/azfile/internal/generated/file_client.go
+++ b/sdk/storage/azfile/internal/generated/file_client.go
@@ -4,7 +4,11 @@
 package generated
 
 import (
+	"context"
+	"net/http"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
 func (client *FileClient) Endpoint() string {
@@ -18,6 +22,14 @@ func (client *FileClient) InternalClient() *azcore.Client {
 // NewFileClient creates a new instance of FileClient with the specified values.
 //   - endpoint - The URL of the service account, share, directory or file that is the target of the desired operation.
 //   - azClient - azcore.Client is a basic HTTP client.  It consists of a pipeline and tracing provider.
+func (client *FileClient) ListAllRangesCreateRequest(ctx context.Context, options *FileClientListAllRangesOptions) (*policy.Request, error) {
+	return client.listAllRangesCreateRequest(ctx, options)
+}
+
+func (client *FileClient) ListAllRangesHandleResponse(resp *http.Response) (FileClientListAllRangesResponse, error) {
+	return client.listAllRangesHandleResponse(resp)
+}
+
 func NewFileClient(endpoint string, azClient *azcore.Client) *FileClient {
 	client := &FileClient{
 		internal: azClient,


### PR DESCRIPTION
## Summary
- Added `NewListRangesPager` method on file `Client` for paginated range listing with continuation token (`marker`) and `MaxResults` support.
- When `PrevShareSnapshot` is set in options, the pager operates in diff mode (returns changed ranges).