### PR TITLE
test(azservicebus): live coverage for ListSessions SessionStateUpdatedAfter mode

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added `Client.NewListSessionsForQueuePager()` and `Client.NewListSessionsForSubscriptionPager()` to list the IDs of sessions in session-enabled queues and subscriptions. By default they list sessions that have active messages; set `SessionStateUpdatedAfter` to instead list sessions whose session state was updated after a given time. (PR#26688)
+- Added `Client.NewListSessionsForQueuePager()` and `Client.NewListSessionsForSubscriptionPager()` to list the IDs of sessions in session-enabled queues and subscriptions. By default they list sessions that have active messages, as well as sessions that have session state set but no active messages; set `SessionStateUpdatedAfter` to instead list sessions whose session state was updated after a given time. (PR#26688)
 
 ### Breaking Changes
 

--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -403,9 +403,9 @@ const listSessionsPageSize = 100
 
 // NewListSessionsForQueuePager creates a pager that lists the IDs of sessions in a session-enabled queue.
 //
-// By default it lists sessions that have active messages in the queue. Sessions on the
-// dead-letter queue, and sessions that have only session state (but no messages), are not
-// listed. If options.SessionStateUpdatedAfter is set, the pager instead lists sessions whose
+// By default it lists sessions that have active messages in the queue, as well as sessions that
+// have session state set but no active messages. Sessions on the dead-letter queue are not
+// listed. If options.SessionStateUpdatedAfter is set, the pager instead lists only sessions whose
 // session state was updated after that time.
 //
 // The IDs are enumerated in pages; call [runtime.Pager.NextPage] until [runtime.Pager.More] returns false.
@@ -420,9 +420,9 @@ func (client *Client) NewListSessionsForQueuePager(queueName string, options *Li
 
 // NewListSessionsForSubscriptionPager creates a pager that lists the IDs of sessions in a session-enabled subscription.
 //
-// By default it lists sessions that have active messages in the subscription. Sessions on the
-// dead-letter queue, and sessions that have only session state (but no messages), are not
-// listed. If options.SessionStateUpdatedAfter is set, the pager instead lists sessions whose
+// By default it lists sessions that have active messages in the subscription, as well as sessions
+// that have session state set but no active messages. Sessions on the dead-letter queue are not
+// listed. If options.SessionStateUpdatedAfter is set, the pager instead lists only sessions whose
 // session state was updated after that time.
 //
 // The IDs are enumerated in pages; call [runtime.Pager.NextPage] until [runtime.Pager.More] returns false.

--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -391,7 +391,8 @@ type ListSessionsResponse struct {
 // and [Client.NewListSessionsForSubscriptionPager].
 type ListSessionsOptions struct {
 	// SessionStateUpdatedAfter, if set, lists only sessions whose session state was updated
-	// after this time. If nil, lists sessions that have active messages in the entity.
+	// after this time. If nil, lists sessions that have active messages in the entity, as
+	// well as sessions that have session state set but no active messages.
 	SessionStateUpdatedAfter *time.Time
 }
 

--- a/sdk/messaging/azservicebus/client_list_sessions_live_test.go
+++ b/sdk/messaging/azservicebus/client_list_sessions_live_test.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/recording"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/admin"
@@ -61,4 +63,84 @@ func TestClient_ListSessionsForQueue_Live(t *testing.T) {
 	}
 
 	require.ElementsMatch(t, want, got)
+}
+
+// TestClient_ListSessionsForQueue_SessionStateUpdatedAfter_Live exercises the
+// SessionStateUpdatedAfter filter (the second listing mode) end-to-end against a live
+// namespace. Unlike active-messages mode, this mode passes a real last-updated-time to the
+// service, so it can only be validated live. Listing with a cutoff on either side of the
+// state update must return opposite sets: a past cutoff lists the state sessions, a future
+// cutoff excludes them. That difference proves the service applies the real last-updated-time
+// rather than ignoring the filter.
+func TestClient_ListSessionsForQueue_SessionStateUpdatedAfter_Live(t *testing.T) {
+	if recording.GetRecordMode() == recording.PlaybackMode {
+		t.Skip("live-only: session-state-updated-time filtering is a service-side behavior and cannot be recorded")
+	}
+
+	queue, cleanup := createQueue(t, nil, &admin.QueueProperties{
+		RequiresSession: to.Ptr(true),
+	})
+	defer cleanup()
+
+	client := newServiceBusClientForTest(t, nil)
+	defer func() { require.NoError(t, client.Close(context.Background())) }()
+
+	ctx := context.Background()
+
+	// Three sessions that carry only session state (no active messages), plus one session
+	// that has an active message but no session state. Mode two must list the state sessions
+	// and must not list the message-only session.
+	stateSessions := []string{"state-0", "state-1", "state-2"}
+	const messageOnlySession = "msg-only-0"
+
+	sender, err := client.NewSender(queue, nil)
+	require.NoError(t, err)
+	require.NoError(t, sender.SendMessage(ctx, &Message{
+		Body:      []byte("hello"),
+		SessionID: to.Ptr(messageOnlySession),
+	}, nil))
+	require.NoError(t, sender.Close(ctx))
+
+	// A cutoff comfortably before the state updates, tolerant of client/service clock skew.
+	before := time.Now().Add(-1 * time.Hour)
+
+	for _, sessionID := range stateSessions {
+		sessionReceiver, err := client.AcceptSessionForQueue(ctx, queue, sessionID, nil)
+		require.NoError(t, err)
+		require.NoError(t, sessionReceiver.SetSessionState(ctx, []byte("state"), nil))
+		require.NoError(t, sessionReceiver.Close(ctx))
+	}
+
+	// A cutoff comfortably after the state updates.
+	after := time.Now().Add(1 * time.Hour)
+
+	// A past cutoff lists the three state sessions and excludes the message-only session
+	// (which has no session state).
+	gotBefore := collectAllSessions(t, ctx, client.NewListSessionsForQueuePager(queue,
+		&ListSessionsOptions{SessionStateUpdatedAfter: &before}))
+	for _, sessionID := range stateSessions {
+		require.Containsf(t, gotBefore, sessionID, "a past cutoff must list state session %s", sessionID)
+	}
+	require.NotContains(t, gotBefore, messageOnlySession,
+		"mode two must not list a session that has a message but no session state")
+
+	// A future cutoff excludes the same sessions, proving the filter is applied rather than
+	// ignored (if it were ignored, both cutoffs would return the same set).
+	gotAfter := collectAllSessions(t, ctx, client.NewListSessionsForQueuePager(queue,
+		&ListSessionsOptions{SessionStateUpdatedAfter: &after}))
+	for _, sessionID := range stateSessions {
+		require.NotContainsf(t, gotAfter, sessionID, "a future cutoff must not list state session %s", sessionID)
+	}
+}
+
+// collectAllSessions drains a session pager and returns every session ID across all pages.
+func collectAllSessions(t *testing.T, ctx context.Context, pager *runtime.Pager[ListSessionsResponse]) []string {
+	t.Helper()
+	var got []string
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		require.NoError(t, err)
+		got = append(got, page.Sessions...)
+	}
+	return got
 }

--- a/sdk/messaging/azservicebus/client_list_sessions_live_test.go
+++ b/sdk/messaging/azservicebus/client_list_sessions_live_test.go
@@ -38,22 +38,34 @@ func TestClient_ListSessionsForQueue_Live(t *testing.T) {
 	// One message to each of 120 distinct sessions forces skip/top pagination across
 	// two pages (100 + 20).
 	const sessionCount = 120
-	want := make([]string, sessionCount)
+	want := make([]string, 0, sessionCount+1)
 
 	sender, err := client.NewSender(queue, nil)
 	require.NoError(t, err)
 
 	for i := 0; i < sessionCount; i++ {
-		want[i] = fmt.Sprintf("session-%03d", i)
+		sessionID := fmt.Sprintf("session-%03d", i)
+		want = append(want, sessionID)
 		require.NoError(t, sender.SendMessage(ctx, &Message{
 			Body:      []byte("hello"),
-			SessionID: &want[i],
+			SessionID: &sessionID,
 		}, nil))
 	}
 	require.NoError(t, sender.Close(ctx))
 
-	// Active-messages mode (nil options => far-future sentinel): the service must return
-	// exactly the sessions that currently have active messages, across all pages.
+	// A session that has session state set but no active message. Active-messages mode must
+	// still list it: the default lists sessions with active messages as well as sessions that
+	// have session state set but no active messages. Without this session the ElementsMatch
+	// below would pass whether or not state-only sessions are included.
+	const stateOnlySession = "state-only-000"
+	stateReceiver, err := client.AcceptSessionForQueue(ctx, queue, stateOnlySession, nil)
+	require.NoError(t, err)
+	require.NoError(t, stateReceiver.SetSessionState(ctx, []byte("state"), nil))
+	require.NoError(t, stateReceiver.Close(ctx))
+	want = append(want, stateOnlySession)
+
+	// Active-messages mode (nil options => far-future sentinel): the service must return the
+	// sessions that have active messages plus the state-only session, across all pages.
 	var got []string
 	pager := client.NewListSessionsForQueuePager(queue, nil)
 	for pager.More() {

--- a/sdk/messaging/azservicebus/client_list_sessions_live_test.go
+++ b/sdk/messaging/azservicebus/client_list_sessions_live_test.go
@@ -126,23 +126,19 @@ func TestClient_ListSessionsForQueue_SessionStateUpdatedAfter_Live(t *testing.T)
 	// A cutoff comfortably after the state updates.
 	after := time.Now().Add(1 * time.Hour)
 
-	// A past cutoff lists the three state sessions and excludes the message-only session
-	// (which has no session state).
+	// A past cutoff lists exactly the three state sessions and excludes the message-only
+	// session (which has no session state).
 	gotBefore := collectAllSessions(t, ctx, client.NewListSessionsForQueuePager(queue,
 		&ListSessionsOptions{SessionStateUpdatedAfter: &before}))
-	for _, sessionID := range stateSessions {
-		require.Containsf(t, gotBefore, sessionID, "a past cutoff must list state session %s", sessionID)
-	}
-	require.NotContains(t, gotBefore, messageOnlySession,
-		"mode two must not list a session that has a message but no session state")
+	require.ElementsMatch(t, stateSessions, gotBefore,
+		"a past cutoff must list exactly the state sessions and not the message-only session")
 
-	// A future cutoff excludes the same sessions, proving the filter is applied rather than
-	// ignored (if it were ignored, both cutoffs would return the same set).
+	// A future cutoff returns nothing: the state sessions were updated before it, and the
+	// message-only session has no state, so mode two lists neither. If the filter were ignored,
+	// the state sessions would still appear.
 	gotAfter := collectAllSessions(t, ctx, client.NewListSessionsForQueuePager(queue,
 		&ListSessionsOptions{SessionStateUpdatedAfter: &after}))
-	for _, sessionID := range stateSessions {
-		require.NotContainsf(t, gotAfter, sessionID, "a future cutoff must not list state session %s", sessionID)
-	}
+	require.Empty(t, gotAfter, "a future cutoff must return no sessions")
 }
 
 // collectAllSessions drains a session pager and returns every session ID across all pages.

--- a/sdk/messaging/azservicebus/internal/mgmt.go
+++ b/sdk/messaging/azservicebus/internal/mgmt.go
@@ -557,7 +557,8 @@ func addAssociatedLinkName(linkName string, msg *amqp.Message) {
 
 // GetMessageSessions lists session IDs from an entity. The behavior depends on lastUpdatedTime:
 //   - Pass time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC) to list sessions with active
-//     messages. This encodes to 253402300800000 ms on the AMQP wire, which the service's
+//     messages, as well as sessions that have session state set but no active messages.
+//     This encodes to 253402300800000 ms on the AMQP wire, which the service's
 //     .NET AMQP decoder clamps to DateTime.MaxValue, triggering active-messages mode.
 //   - Pass a real timestamp to list sessions whose session state was updated after that time.
 //


### PR DESCRIPTION
## Follow-up to #26688

On #26688, the reviewer noted that `SessionStateUpdatedAfter` (the second listing mode) had never been exercised against a live namespace — only active-messages mode was covered by `client_list_sessions_live_test.go`. This adds live coverage for that mode and corrects a docstring the live run proved wrong.

### Live test

`TestClient_ListSessionsForQueue_SessionStateUpdatedAfter_Live` sets session state on three sessions (plus one message-only session), then lists with a cutoff on either side of the update:

| Cutoff | Result |
| --- | --- |
| `now - 1h` | the three state sessions (message-only session excluded) |
| `now + 1h` | empty |

Opposite sets for the same sessions prove the service applies the real `last-updated-time` rather than ignoring the filter. Verified live against a Standard namespace.

### Docstring fix

Verified live that default (active-messages) mode also lists sessions that have only session state and no active messages — a queue with `ActiveMessageCount=0` still returned the state-only session. The previous docstring claimed such sessions are not listed, which is wrong. Corrected on both `NewListSessionsForQueuePager` and `NewListSessionsForSubscriptionPager`. The dead-letter-queue exclusion is retained (a dead-lettered session was verified to not be listed).

### Testing

- New live test passes against a live Standard namespace.
- Existing list-sessions unit tests pass.
- `gofmt`, `go vet`, `go build` clean.

No public API change, so no CHANGELOG entry (test and doc-comment only).
