### PR TITLE
Avoid infinite loops for Pager[T].More()

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-* Fixed an issue where `runtime.Pager[T].More` could return `true` indefinitely after `NextPage` failed to retrieve the first page, causing `for pager.More()` loops to spin. `More` now returns `false` after a page fetch returns an error; a subsequent successful `NextPage` call clears the error and resumes iteration.
+* Fixed an issue where `runtime.Pager[T].More` could return `true` indefinitely after `NextPage` failed to retrieve the first page, causing `for pager.More()` loops to spin. After a page fetch returns an error the `Pager` now enters a terminal state: `More` returns `false` and subsequent `NextPage` calls return the same error without invoking the fetcher again.
 
 ### Other Changes
 

--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Release History
 
-## 1.22.1-beta.1 (Unreleased)
+## 1.22.1 (Unreleased)
 
 ### Features Added
 
 ### Breaking Changes
 
 ### Bugs Fixed
+
+* Fixed an issue where `runtime.Pager[T].More` could return `true` indefinitely after `NextPage` failed to retrieve the first page, causing `for pager.More()` loops to spin. `More` now returns `false` after a page fetch returns an error; a subsequent successful `NextPage` call clears the error and resumes iteration.
 
 ### Other Changes
 

--- a/sdk/azcore/internal/shared/constants.go
+++ b/sdk/azcore/internal/shared/constants.go
@@ -37,5 +37,5 @@ const (
 	Module = "azcore"
 
 	// Version is the semantic version (see http://semver.org) of this module.
-	Version = "v1.22.1-beta.1"
+	Version = "v1.22.1"
 )

--- a/sdk/azcore/runtime/pager.go
+++ b/sdk/azcore/runtime/pager.go
@@ -53,10 +53,8 @@ func NewPager[T any](handler PagingHandler[T]) *Pager[T] {
 // More returns true if there are more pages to retrieve.
 //
 // If a prior call to [Pager.NextPage] returned an error while fetching a page,
-// More returns false so that a for loop over the pager terminates instead of
-// retrying indefinitely. Calling NextPage again after such an error will retry
-// the failed page; if that retry succeeds, More resumes reporting whether
-// additional pages are available.
+// the Pager enters a terminal state and More returns false so that a for loop
+// over the pager terminates instead of retrying indefinitely.
 func (p *Pager[T]) More() bool {
 	// a failed fetch puts the Pager in a terminal state; there are no more pages
 	// to retrieve regardless of whether it was the first or a subsequent page.
@@ -71,11 +69,16 @@ func (p *Pager[T]) More() bool {
 
 // NextPage advances the pager to the next page.
 //
-// If fetching the page returns an error, the pager is left unchanged: the error
-// is recorded so that [Pager.More] returns false, and the same page can be
-// retried by calling NextPage again. A successful call clears any recorded
-// error and advances the pager.
+// If fetching the page returns an error, the Pager enters a terminal state:
+// [Pager.More] returns false and every subsequent call to NextPage returns the
+// same error without invoking the fetcher again.
 func (p *Pager[T]) NextPage(ctx context.Context) (T, error) {
+	if p.fetchErr != nil {
+		// a prior fetch failed; the Pager is in a terminal state. return the
+		// stored error rather than re-invoking the fetcher, which may not be
+		// safe to retry (e.g. stateful handlers that latch into a done state).
+		return *new(T), p.fetchErr
+	}
 	if p.current != nil {
 		if p.firstPage {
 			// we get here if it's an LRO-pager, we already have the first page
@@ -98,9 +101,6 @@ func (p *Pager[T]) NextPage(ctx context.Context) (T, error) {
 		p.fetchErr = err
 		return *new(T), err
 	}
-	// the fetch succeeded, clear any prior error so a caller that retries a
-	// failed page can resume iterating instead of being permanently blocked.
-	p.fetchErr = nil
 	p.current = &resp
 	return *p.current, nil
 }

--- a/sdk/azcore/runtime/pager.go
+++ b/sdk/azcore/runtime/pager.go
@@ -35,6 +35,9 @@ type Pager[T any] struct {
 	handler   PagingHandler[T]
 	tracer    tracing.Tracer
 	firstPage bool
+	// fetchErr is set when Fetcher returns an error, placing the Pager in a
+	// terminal state so that More returns false.
+	fetchErr error
 }
 
 // NewPager creates an instance of Pager using the specified PagingHandler.
@@ -48,7 +51,18 @@ func NewPager[T any](handler PagingHandler[T]) *Pager[T] {
 }
 
 // More returns true if there are more pages to retrieve.
+//
+// If a prior call to [Pager.NextPage] returned an error while fetching a page,
+// More returns false so that a for loop over the pager terminates instead of
+// retrying indefinitely. Calling NextPage again after such an error will retry
+// the failed page; if that retry succeeds, More resumes reporting whether
+// additional pages are available.
 func (p *Pager[T]) More() bool {
+	// a failed fetch puts the Pager in a terminal state; there are no more pages
+	// to retrieve regardless of whether it was the first or a subsequent page.
+	if p.fetchErr != nil {
+		return false
+	}
 	if p.current != nil {
 		return p.handler.More(*p.current)
 	}
@@ -56,6 +70,11 @@ func (p *Pager[T]) More() bool {
 }
 
 // NextPage advances the pager to the next page.
+//
+// If fetching the page returns an error, the pager is left unchanged: the error
+// is recorded so that [Pager.More] returns false, and the same page can be
+// retried by calling NextPage again. A successful call clears any recorded
+// error and advances the pager.
 func (p *Pager[T]) NextPage(ctx context.Context) (T, error) {
 	if p.current != nil {
 		if p.firstPage {
@@ -76,8 +95,12 @@ func (p *Pager[T]) NextPage(ctx context.Context) (T, error) {
 
 	resp, err := p.handler.Fetcher(ctx, p.current)
 	if err != nil {
+		p.fetchErr = err
 		return *new(T), err
 	}
+	// the fetch succeeded, clear any prior error so a caller that retries a
+	// failed page can resume iterating instead of being permanently blocked.
+	p.fetchErr = nil
 	p.current = &resp
 	return *p.current, nil
 }

--- a/sdk/azcore/runtime/pager_test.go
+++ b/sdk/azcore/runtime/pager_test.go
@@ -195,38 +195,34 @@ func TestPagerPipelineError(t *testing.T) {
 	require.False(t, pager.More())
 }
 
-func TestPagerRetryAfterError(t *testing.T) {
+func TestPagerTerminalAfterError(t *testing.T) {
 	attempts := 0
+	sentinel := errors.New("transient failure")
 	pager := NewPager(PagingHandler[PageResponse]{
 		More: func(current PageResponse) bool {
 			return current.NextPage
 		},
 		Fetcher: func(ctx context.Context, current *PageResponse) (PageResponse, error) {
 			attempts++
-			if attempts == 1 {
-				return PageResponse{}, errors.New("transient failure")
-			}
-			// the recovered page advertises another page so that More can only
-			// return true if the recorded error was cleared.
-			return PageResponse{Values: []int{1, 2, 3}, NextPage: true}, nil
+			return PageResponse{}, sentinel
 		},
 	})
 	require.True(t, pager.More())
 
 	// the first fetch fails, placing the pager in a terminal state
 	page, err := pager.NextPage(context.Background())
-	require.Error(t, err)
+	require.ErrorIs(t, err, sentinel)
 	require.Empty(t, page)
 	require.False(t, pager.More())
+	require.Equal(t, 1, attempts)
 
-	// a manual retry succeeds, clearing the error and recovering the pager.
-	// because the recovered page reports another page, More must return true;
-	// if fetchErr weren't cleared, More would remain false.
+	// the pager is terminal: NextPage returns the stored error without
+	// re-invoking the fetcher, so stateful handlers can't be corrupted.
 	page, err = pager.NextPage(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, []int{1, 2, 3}, page.Values)
-	require.True(t, pager.More())
-	require.Equal(t, 2, attempts)
+	require.ErrorIs(t, err, sentinel)
+	require.Empty(t, page)
+	require.False(t, pager.More())
+	require.Equal(t, 1, attempts)
 }
 
 func TestPagerSecondPageError(t *testing.T) {

--- a/sdk/azcore/runtime/pager_test.go
+++ b/sdk/azcore/runtime/pager_test.go
@@ -206,7 +206,9 @@ func TestPagerRetryAfterError(t *testing.T) {
 			if attempts == 1 {
 				return PageResponse{}, errors.New("transient failure")
 			}
-			return PageResponse{Values: []int{1, 2, 3}}, nil
+			// the recovered page advertises another page so that More can only
+			// return true if the recorded error was cleared.
+			return PageResponse{Values: []int{1, 2, 3}, NextPage: true}, nil
 		},
 	})
 	require.True(t, pager.More())
@@ -217,11 +219,13 @@ func TestPagerRetryAfterError(t *testing.T) {
 	require.Empty(t, page)
 	require.False(t, pager.More())
 
-	// a manual retry succeeds, clearing the error and recovering the pager
+	// a manual retry succeeds, clearing the error and recovering the pager.
+	// because the recovered page reports another page, More must return true;
+	// if fetchErr weren't cleared, More would remain false.
 	page, err = pager.NextPage(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, []int{1, 2, 3}, page.Values)
-	require.False(t, pager.More())
+	require.True(t, pager.More())
 	require.Equal(t, 2, attempts)
 }
 

--- a/sdk/azcore/runtime/pager_test.go
+++ b/sdk/azcore/runtime/pager_test.go
@@ -164,10 +164,12 @@ func TestPagerFetcherError(t *testing.T) {
 		},
 	})
 	require.True(t, pager.firstPage)
+	require.True(t, pager.More())
 
 	page, err := pager.NextPage(context.Background())
 	require.Error(t, err)
 	require.Empty(t, page)
+	require.False(t, pager.More())
 }
 
 func TestPagerPipelineError(t *testing.T) {
@@ -185,10 +187,42 @@ func TestPagerPipelineError(t *testing.T) {
 		},
 	})
 	require.True(t, pager.firstPage)
+	require.True(t, pager.More())
 
 	page, err := pager.NextPage(context.Background())
 	require.Error(t, err)
 	require.Empty(t, page)
+	require.False(t, pager.More())
+}
+
+func TestPagerRetryAfterError(t *testing.T) {
+	attempts := 0
+	pager := NewPager(PagingHandler[PageResponse]{
+		More: func(current PageResponse) bool {
+			return current.NextPage
+		},
+		Fetcher: func(ctx context.Context, current *PageResponse) (PageResponse, error) {
+			attempts++
+			if attempts == 1 {
+				return PageResponse{}, errors.New("transient failure")
+			}
+			return PageResponse{Values: []int{1, 2, 3}}, nil
+		},
+	})
+	require.True(t, pager.More())
+
+	// the first fetch fails, placing the pager in a terminal state
+	page, err := pager.NextPage(context.Background())
+	require.Error(t, err)
+	require.Empty(t, page)
+	require.False(t, pager.More())
+
+	// a manual retry succeeds, clearing the error and recovering the pager
+	page, err = pager.NextPage(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3}, page.Values)
+	require.False(t, pager.More())
+	require.Equal(t, 2, attempts)
 }
 
 func TestPagerSecondPageError(t *testing.T) {
@@ -227,10 +261,11 @@ func TestPagerSecondPageError(t *testing.T) {
 			var respErr *exported.ResponseError
 			require.True(t, errors.As(err, &respErr))
 			require.Equal(t, "PageError", respErr.ErrorCode)
-			goto ExitLoop
+			// a subsequent-page error puts the pager in a terminal state, so
+			// More returns false and the loop terminates on its own.
+			require.False(t, pager.More())
 		}
 	}
-ExitLoop:
 	require.Equal(t, 2, pageCount)
 }
 


### PR DESCRIPTION
## Problem
When `NextPage()` failed on the first page, the current page stayed nil and `More()` always returned `true`, so a `for pager.More() {}` loop that didn't break spun forever. Later-page failures were unaffected (the last good page is retained), leaving the two paths inconsistent.

## Fix
A fetch error now makes the pager terminal:

The error is stored in a new `fetchErr` field.
`More()` returns `false` once set (first or subsequent page).
Subsequent `NextPage()` calls return the same stored error without re-invoking the fetcher.

## Why terminal (not retry-recovery)
We considered clearing the error on a successful retry, but the paging handler's `Fetcher` gives no idempotency-on-failure guarantee, and several hand-written handlers latch state on error — e.g. the `azservicebus/admin` `entityPager` sets `eof=true` then returns `nil, nil`, which retry-recovery would turn into a silent truncated "success." Since released handlers can't be retrofitted, terminal-on-error is the only safe choice. (This matches `Poller[T]`, which caches terminal outcomes and re-returns the stored error.)

## Audit
Scanned all non-generated pager handlers (excluding generated `/sdk/resourcemanager` clients and the stateless `FetcherForNextLink` pagers):
- No handler returns partial data with a non-nil error — all return the zero value on error, so nothing is dropped.
- Token/marker pagers (cosmos, tables, storage) are non-latching: the change removes an implicit in-loop retry and fixes their first-page infinite loop. Idiomatic callers are unaffected; the pipeline retry policy still covers transient failures.
- Two state-mutating handlers (cosmos Close(), azappconfig matchConditions pop) are made safer by terminal (never re-entered).

## Compatibility
Only observable change: `More()` returns `false` after a `NextPage()` error. Callers that check the error and break/return are unaffected; a loop that ignored the error and relied on implicit retry now stops instead of spinning (noted in CHANGELOG)

Fixes https://github.com/Azure/azure-sdk-for-go/issues/27219
