### PR TITLE
docs(azcore): define the Pager contract when NextPage returns an error

### DIFF
--- a/documentation/development/ARM/new-version-guideline.md
+++ b/documentation/development/ARM/new-version-guideline.md
@@ -31,7 +31,7 @@ var resourceGroups []*armresources.ResourceGroup
 for pager.More() {
     nextResult, err := pager.NextPage(ctx)
     if err != nil {
-        // handle error...
+        log.Fatalf("failed to advance page: %v", err)
     }
     if nextResult.ResourceGroupListResult.Value != nil {
         resourceGroups = append(resourceGroups, nextResult.ResourceGroupListResult.Value...)

--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+* Documented the behavior of `runtime.Pager` when `NextPage` returns an error: the pager does not advance, `More` continues to return `true`, and a later call to `NextPage` retries the failed page. Callers that do not want a retry must exit the paging loop on error.
+
 ## 1.22.0 (2026-06-04)
 
 ### Features Added

--- a/sdk/azcore/doc.go
+++ b/sdk/azcore/doc.go
@@ -190,7 +190,12 @@ and determining if there are more pages to fetch.  No IO calls are made until th
 	pager := widgetClient.NewListWidgetsPager(nil)
 	for pager.More() {
 		page, err := pager.NextPage(context.TODO())
-		// handle err
+		if err != nil {
+			// The pager does not advance on error, and More continues to return true.
+			// A later call to NextPage retries the failed page.  Exit the loop if you
+			// do not want a retry.
+			break
+		}
 		for _, widget := range page.Values {
 			// process widget
 		}

--- a/sdk/azcore/runtime/pager.go
+++ b/sdk/azcore/runtime/pager.go
@@ -22,6 +22,10 @@ type PagingHandler[T any] struct {
 	More func(T) bool
 
 	// Fetcher fetches the first and subsequent pages.
+	// When Fetcher returns an error, the Pager does not advance, and
+	// NextPage can call Fetcher again with the same arguments.
+	// A Fetcher that must not repeat a failed request has to record
+	// that state itself and return an error on later calls.
 	Fetcher func(context.Context, *T) (T, error)
 
 	// Tracer contains the Tracer from the client that's creating the Pager.
@@ -29,6 +33,8 @@ type PagingHandler[T any] struct {
 }
 
 // Pager provides operations for iterating over paged responses.
+// An error from NextPage does not end iteration. Call NextPage again
+// to retry the failed page, or stop calling NextPage to end iteration.
 // Methods on this type are not safe for concurrent use.
 type Pager[T any] struct {
 	current   *T
@@ -48,6 +54,9 @@ func NewPager[T any](handler PagingHandler[T]) *Pager[T] {
 }
 
 // More returns true if there are more pages to retrieve.
+// An error from NextPage does not change the result of More.
+// When NextPage returns an error, exit the paging loop, or call
+// NextPage again to retry the failed page.
 func (p *Pager[T]) More() bool {
 	if p.current != nil {
 		return p.handler.More(*p.current)
@@ -56,6 +65,10 @@ func (p *Pager[T]) More() bool {
 }
 
 // NextPage advances the pager to the next page.
+// When it returns an error, the pager does not advance. More returns
+// the same value as before the failed call, and a later call to
+// NextPage sends the same request again. Exit the paging loop when
+// NextPage returns an error if you do not want a retry.
 func (p *Pager[T]) NextPage(ctx context.Context) (T, error) {
 	if p.current != nil {
 		if p.firstPage {

--- a/sdk/azcore/runtime/pager_test.go
+++ b/sdk/azcore/runtime/pager_test.go
@@ -234,6 +234,77 @@ ExitLoop:
 	require.Equal(t, 2, pageCount)
 }
 
+func TestPagerFirstPageRetryAfterError(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusBadRequest), mock.WithBody([]byte(`{"message": "didn't work", "code": "PageError"}`)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"values": [1, 2, 3]}`)))
+	pl := exported.NewPipeline(srv)
+
+	pager := NewPager(PagingHandler[PageResponse]{
+		More: func(current PageResponse) bool {
+			return current.NextPage
+		},
+		Fetcher: func(ctx context.Context, current *PageResponse) (PageResponse, error) {
+			return pageResponseFetcher(ctx, pl, srv.URL())
+		},
+	})
+	require.True(t, pager.firstPage)
+
+	// the first page fails, so the pager must not advance
+	page, err := pager.NextPage(context.Background())
+	require.Error(t, err)
+	require.Empty(t, page)
+	require.True(t, pager.More())
+	require.Nil(t, pager.current)
+
+	// a second call sends the same request again and succeeds
+	page, err = pager.NextPage(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3}, page.Values)
+	require.False(t, pager.More())
+}
+
+func TestPagerSecondPageRetryAfterError(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"values": [1, 2], "next": true}`)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusBadRequest), mock.WithBody([]byte(`{"message": "didn't work", "code": "PageError"}`)))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusOK), mock.WithBody([]byte(`{"values": [3, 4]}`)))
+	pl := exported.NewPipeline(srv)
+
+	pager := NewPager(PagingHandler[PageResponse]{
+		More: func(current PageResponse) bool {
+			return current.NextPage
+		},
+		Fetcher: func(ctx context.Context, current *PageResponse) (PageResponse, error) {
+			return pageResponseFetcher(ctx, pl, srv.URL())
+		},
+	})
+	require.True(t, pager.firstPage)
+
+	page, err := pager.NextPage(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2}, page.Values)
+	require.True(t, page.NextPage)
+
+	// the second page fails, so the pager keeps the first page as its current page
+	page, err = pager.NextPage(context.Background())
+	require.Error(t, err)
+	var respErr *exported.ResponseError
+	require.True(t, errors.As(err, &respErr))
+	require.Equal(t, "PageError", respErr.ErrorCode)
+	require.True(t, pager.More())
+	require.NotNil(t, pager.current)
+	require.Equal(t, []int{1, 2}, pager.current.Values)
+
+	// a third call sends the same request again and succeeds
+	page, err = pager.NextPage(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []int{3, 4}, page.Values)
+	require.False(t, pager.More())
+}
+
 func TestPagerResponderError(t *testing.T) {
 	srv, close := mock.NewServer()
 	defer close()


### PR DESCRIPTION
## Summary

`runtime.Pager.More()` returns `true` after `NextPage()` returns an error, and the doc comments do not say so. A caller that stays in the loop repeats the request. Issue #27219 asks either to make the pager terminal after an error, or to document the current behavior. This change takes the second option: it defines the current behavior as a contract, states it in the doc comments, fixes the two in-repo paging examples, and adds tests that pin the behavior.

## Motivation

`NextPage` returns before it assigns `p.current` when the fetcher gives an error (`sdk/azcore/runtime/pager.go`), so the pager does not advance. `More` returns `true` whenever `p.current` is nil, so a caller that only logs the error stays in the loop and sends the same request again.

The terminal-pager option was rejected because the fakes framework depends on the current behavior. `fake.PagerResponder.AddError` injects an error between pages, which is the documented pattern in `sdk/azcore/fake/example_test.go` and is exercised end to end through a real generated `armcompute` pager in `ExampleVirtualMachinesServer_NewListPager_intermediate_responseError` (`sdk/samples/fakes/examples_test.go`). A terminal pager would silently truncate every user test written in that pattern. It would also remove the ability to retry one failed page in a long listing, and it would be a behavior break in a GA package.

No runtime behavior changes here. The tests pin behavior that already exists, so a future change to it fails a test.

## Changes

* `sdk/azcore/runtime/pager.go`: doc comments on `Pager`, `Pager.More`, `Pager.NextPage`, and `PagingHandler.Fetcher` state that the pager does not advance on error, that `More` keeps its previous result, and that a later `NextPage` call sends the same request again. No executable code changed.
* `sdk/azcore/runtime/pager_test.go`: added `TestPagerFirstPageRetryAfterError` and `TestPagerSecondPageRetryAfterError`, which pin the retry behavior for a first-page error and for a mid-sequence error.
* `sdk/azcore/doc.go`: the Pageable Operations example now exits the loop on error instead of falling through after `// handle err`.
* `documentation/development/ARM/new-version-guideline.md`: the paging example now calls `log.Fatalf` on error instead of `// handle error...`, matching `MIGRATION_GUIDE.md`.
* `sdk/azcore/CHANGELOG.md`: entry under Other Changes in the Unreleased section.

One doc surface is outside this repo and needs a follow-up: the paging example at https://azure.github.io/azure-sdk/golang_introduction.html (source in `Azure/azure-sdk`) also continues the loop after `// handle error...` and needs the same fix.

Fixes #27219

## Test plan

* `gofmt -l .`, `go build ./...`, `go vet ./...` in `sdk/azcore`: clean.
* `go test ./...` in `sdk/azcore`: all packages pass, including the two new tests.
* `go test ./...` in `sdk/samples/fakes`: passes, which confirms the mid-sequence error injection contract this change preserves.