### PR TITLE
docs(azcosmos): add Go Cosmos V2  FFI design decision and distribution design

### DIFF
--- a/sdk/data/azcosmos/docs/adr/0000-index.md
+++ b/sdk/data/azcosmos/docs/adr/0000-index.md
@@ -4,8 +4,10 @@ ADRs (Architecture Decision Records) capture **what we decided** and a brief
 **why**, in a minimal, easy-to-reference form. They are **numbered and
 immutable**: once accepted, an ADR is not edited; a later ADR may supersede it.
 Detailed discussion and exploration live in
-[`../go-v2-ffi-decision.md`](../go-v2-ffi-decision.md) and
-[`../go-ffi-distribution-design.md`](../go-ffi-distribution-design.md), not here.
+[`go-v2-ffi-decision.md`](https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/data/azcosmos/docs/go-v2-ffi-decision.md)
+and
+[`go-ffi-distribution-design.md`](https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/data/azcosmos/docs/go-ffi-distribution-design.md),
+not here.
 
 **Format (template):** Status (immediately under the title) · Context (2-4
 sentences) · Decision (1-3 bullets) · Consequences (2-4 bullets) · Alternatives
@@ -13,7 +15,7 @@ considered (1 line each).
 
 | # | Title | Status |
 |---|-------|--------|
-| [0001](0001-go-v2-uses-ffi.md) | Go v2 uses the Rust driver through FFI | Proposed |
+| [0001](https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/data/azcosmos/docs/adr/0001-go-v2-uses-ffi.md) | Go v2 uses the Rust driver through FFI | Proposed |
 
 > This ADR is proposed for review. Packaging mechanics are intentionally left to
 > the distribution design document; this record captures the Go v2 implementation

--- a/sdk/data/azcosmos/docs/adr/0000-index.md
+++ b/sdk/data/azcosmos/docs/adr/0000-index.md
@@ -1,0 +1,20 @@
+# Architecture Decision Records — Go v2 FFI direction
+
+ADRs (Architecture Decision Records) capture **what we decided** and a brief
+**why**, in a minimal, easy-to-reference form. They are **numbered and
+immutable**: once accepted, an ADR is not edited; a later ADR may supersede it.
+Detailed discussion and exploration live in
+[`../go-v2-ffi-decision.md`](../go-v2-ffi-decision.md) and
+[`../go-ffi-distribution-design.md`](../go-ffi-distribution-design.md), not here.
+
+**Format (template):** Status (immediately under the title) · Context (2-4
+sentences) · Decision (1-3 bullets) · Consequences (2-4 bullets) · Alternatives
+considered (1 line each).
+
+| # | Title | Status |
+|---|-------|--------|
+| [0001](0001-go-v2-uses-ffi.md) | Go v2 uses the Rust driver through FFI | Proposed |
+
+> This ADR is proposed for review. Packaging mechanics are intentionally left to
+> the distribution design document; this record captures the Go v2 implementation
+> direction.

--- a/sdk/data/azcosmos/docs/adr/0001-go-v2-uses-ffi.md
+++ b/sdk/data/azcosmos/docs/adr/0001-go-v2-uses-ffi.md
@@ -44,8 +44,9 @@ logic in Go and carrying long-term Rust-to-Go drift risk.
 
 ## Discussion
 
-See [`../go-v2-ffi-decision.md`](../go-v2-ffi-decision.md) for the meeting
-context, pure-Go spike evidence, packaging concerns, tentative platform matrix,
-and market reference points. See
-[`../go-ffi-distribution-design.md`](../go-ffi-distribution-design.md) for the
-native-driver distribution design discussion.
+See
+[`go-v2-ffi-decision.md`](https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/data/azcosmos/docs/go-v2-ffi-decision.md)
+for the meeting context, pure-Go spike evidence, packaging concerns, tentative
+platform matrix, and market reference points. See
+[`go-ffi-distribution-design.md`](https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/data/azcosmos/docs/go-ffi-distribution-design.md)
+for the native-driver distribution design discussion.

--- a/sdk/data/azcosmos/docs/adr/0001-go-v2-uses-ffi.md
+++ b/sdk/data/azcosmos/docs/adr/0001-go-v2-uses-ffi.md
@@ -1,0 +1,51 @@
+# ADR 0001 — Go v2 uses the Rust driver through FFI
+
+**Status:** Proposed
+
+## Context
+
+Go v2 needs a path that can deliver in the current timeframe while staying close
+to the Rust Cosmos driver's behavior. A time-boxed pure-Go spike proved that a
+gateway-mode core path can be ported and validated, but it also clarified the
+central trade-off: avoiding cgo and native packaging means re-owning driver
+logic in Go and carrying long-term Rust-to-Go drift risk.
+
+## Decision
+
+- Go v2 proceeds with the **Rust-driver FFI path** for the current delivery
+  window.
+- The Go binding consumes the **prebuilt Rust native driver** through cgo and the
+  C ABI surface.
+- Packaging mechanics, platform matrix, signing, ABI versioning, and native
+  artifact placement are handled by the Go FFI distribution design.
+
+## Consequences
+
+- Go v2 gets the same driver implementation as Rust, reducing short-term feature
+  drift and implementation risk.
+- Go v2 takes a dependency on `CGO_ENABLED=1` for the native driver path.
+- The Go packaging model becomes part of the product decision: customers should
+  not manually install a Rust toolchain or copy native libraries for the common
+  path, but cgo still requires an available C build toolchain.
+- Differential validation remains important so Go-visible behavior can be tested
+  against the Rust driver.
+
+## Alternatives considered
+
+- **Pure-Go driver port** — technically feasible for the core path tested, but
+  not selected for Go v2 because it shifts cost from packaging to long-term Go
+  ownership and Rust-to-Go drift.
+- **Manual native-library installation** — rejected for the common path because
+  it breaks the normal `go get` / `go build` expectation for a first-party Go
+  SDK.
+- **Pure-Go downloader shim** — rejected as the default path because Go modules
+  do not provide a standard post-install hook, and build-time network downloads
+  are often blocked in enterprise and offline environments.
+
+## Discussion
+
+See [`../go-v2-ffi-decision.md`](../go-v2-ffi-decision.md) for the meeting
+context, pure-Go spike evidence, packaging concerns, tentative platform matrix,
+and market reference points. See
+[`../go-ffi-distribution-design.md`](../go-ffi-distribution-design.md) for the
+native-driver distribution design discussion.

--- a/sdk/data/azcosmos/docs/go-ffi-distribution-design.md
+++ b/sdk/data/azcosmos/docs/go-ffi-distribution-design.md
@@ -97,7 +97,7 @@ bundled platform-specific static builds as the default, with dynamic/manual
 linking as an escape hatch for special cases.
 
 References:
-[`kafka/README.md#librdkafka`](https://github.com/confluentinc/confluent-kafka-go/blob/master/kafka/README.md#librdkafka)
+[`kafka/README.md#build-tags`](https://github.com/confluentinc/confluent-kafka-go/blob/master/kafka/README.md#build-tags)
 and
 [`librdkafka_vendor`](https://pkg.go.dev/github.com/confluentinc/confluent-kafka-go/v2/kafka/librdkafka_vendor).
 

--- a/sdk/data/azcosmos/docs/go-ffi-distribution-design.md
+++ b/sdk/data/azcosmos/docs/go-ffi-distribution-design.md
@@ -69,6 +69,13 @@ package azcosmos
 import _ "github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-linux-amd64"
 ```
 
+Fourth, normal builds should benefit from Go's lazy module loading. A module can
+list multiple platform driver modules in `require`, while a single-platform
+`go get` / `go build` only needs the driver reached by the active build-tagged
+import. Full-graph workflows such as `go mod download all`, vendoring, proxy
+prewarming, or CI validation that intentionally walks the complete build list
+may still fetch the whole default driver matrix.
+
 ## 3. Design goals
 
 | Goal | Why it matters |
@@ -355,16 +362,16 @@ dimension. If both are supported, the design needs an explicit convention such
 as a custom `musl` build tag, a separate opt-in package, or a default Linux
 choice with the other variant documented as optional.
 
-**Size gist:** if the default `azcosmos` module requires six default driver
-modules, customers may still download/cache roughly the same ~30 MB matrix
-before compression. The difference is that the payload is split into separate
-module ZIPs, optional targets can stay out of the default path, and the final app
-still links only the current platform's native driver.
+**Size gist:** for ordinary `go get` / `go build` workflows, customers should
+fetch the active platform driver module rather than the full default matrix. A
+full-graph command such as `go mod download all`, vendoring, proxy prewarming, or
+CI validation can still fetch all default driver modules. The final app links
+only the current platform's native driver.
 
 | Area | Effect |
 |---|---|
 | Customer experience | Good. Common platforms still use `go get azcosmos` / `go build`. |
-| Download footprint | Better than one giant module in cache shape, but the default `azcosmos` module may still cause all default driver module ZIPs to be downloaded. |
+| Download footprint | Normal builds fetch the active driver module; full-graph workflows can fetch the default driver matrix. |
 | Version safety | Manageable if all modules are released together and exact versions are pinned. |
 | Repository impact | Still high for `azure-sdk-for-go` contributors because the repo contains all native modules. |
 | Long-tail targets | Better. Optional targets can be extra modules not included in default `azcosmos`. |
@@ -415,15 +422,14 @@ package azcosmos
 import _ "github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-linux-amd64-gnu"
 ```
 
-**Size gist:** for customers, this is similar to Option B if `azcosmos` still
-depends on the default driver modules. The default download/cache can still be
-the default matrix, but the binary modules come from a separate repository and
-the final app links only one target.
+**Size gist:** for customers, this is similar to Option B. Ordinary builds fetch
+the active driver module from the separate native-driver repository; full-graph
+workflows can fetch the full default matrix. The final app links only one target.
 
 | Area | Effect |
 |---|---|
 | Customer experience | Good for default platforms if `azcosmos` wires driver imports automatically. |
-| Download footprint | Similar to Option B from the customer's module-cache perspective. |
+| Download footprint | Same customer behavior as Option B, but the active driver module comes from a separate repository. |
 | Version safety | Requires stronger release discipline across repositories. |
 | Repository impact | Better for Azure SDK for Go contributors; binary churn lives elsewhere. |
 | Governance | Needs clear ownership, release, security, signing, and support boundaries. |
@@ -601,8 +607,8 @@ is still useful for bundled paths because it catches packaging mistakes.
 | Model | Common-platform customer flow | Customer-visible native setup | Download behavior |
 |---|---|---|---|
 | A. Single bundled module | `go get azcosmos`; `go build` | cgo toolchain only | Downloads whole default matrix in one module |
-| B. Split modules, same repo | `go get azcosmos`; `go build` | cgo toolchain only | Downloads default driver modules as dependencies; links only the active target |
-| C. Split modules, separate repo | `go get azcosmos`; `go build` | cgo toolchain only | Downloads driver modules from a second repo through Go module system |
+| B. Split modules, same repo | `go get azcosmos`; `go build` | cgo toolchain only | Normal builds fetch active driver module; full-graph workflows can fetch default matrix |
+| C. Split modules, separate repo | `go get azcosmos`; `go build` | cgo toolchain only | Same as Option B, but the active driver module comes from a separate repo |
 | Advanced dynamic library | imports/configures advanced path | customer-managed native library | Downloads only Go wrapper; customer supplies native payload |
 
 ## 13. Repository and release comparison

--- a/sdk/data/azcosmos/docs/go-ffi-distribution-design.md
+++ b/sdk/data/azcosmos/docs/go-ffi-distribution-design.md
@@ -28,6 +28,12 @@ the SDK needs roughly this matrix:
 | Linux glibc | amd64, arm64 |
 | Optional or follow-up | Windows x86, Linux musl/Alpine, additional long-tail targets |
 
+Windows targets also need an ABI/toolchain dimension. The implementation design
+is expected to produce both GNU/MinGW-compatible `.a` artifacts for cgo linking
+and MSVC-compatible `.lib` artifacts where needed, but this document does not
+finalize that artifact split. Before GA, the Windows support matrix must state
+which Rust target triples and link artifacts are used for each Go target.
+
 With an optimized native driver around **~5 MB per target**, a six-target matrix
 is roughly **~30 MB before compression**. Expanding to ten targets approaches the
 earlier **~50 MB** mental model. The design question is not only binary size; it
@@ -140,8 +146,8 @@ github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos
 ├── client.go
 ├── internal/core/
 ├── internal/native/
-│   ├── windows-amd64/azurecosmos.lib
-│   ├── windows-arm64/azurecosmos.lib
+│   ├── windows-amd64/{libazurecosmos.a or azurecosmos.lib}
+│   ├── windows-arm64/{libazurecosmos.a or azurecosmos.lib}
 │   ├── darwin-amd64/libazurecosmos.a
 │   ├── darwin-arm64/libazurecosmos.a
 │   ├── linux-amd64-gnu/libazurecosmos.a

--- a/sdk/data/azcosmos/docs/go-ffi-distribution-design.md
+++ b/sdk/data/azcosmos/docs/go-ffi-distribution-design.md
@@ -1,0 +1,649 @@
+<!-- cspell:ignore amd64 arm64 azcosmos azcosmoscore checksums glibc GOARCH GOOS libc LDFLAGS libazurecosmos librdkafka metapackage musl onnxruntime SRCDIR -->
+# Go FFI native-driver distribution design
+
+> **Status:** Design discussion for Go Central SDK and architecture-board review.
+>
+> This document captures the native-driver distribution problem for a Go SDK
+> backed by the Rust Cosmos driver through FFI. It focuses on customer
+> experience, Go module layout, native binary placement, and the trade-offs that
+> need Go Central SDK alignment.
+
+## 1. Problem statement
+
+The Go v2 FFI path lets Go reuse the Rust Cosmos driver instead of re-owning the
+same driver logic in Go. That reduces implementation drift, but it moves a real
+decision into distribution:
+
+> Where should the platform-specific native driver binaries live, and how should
+> a Go customer get the correct one?
+
+The native driver is built once per supported OS/architecture/libc target. If the
+initial supported set includes Windows, macOS, and Linux on x64/amd64 and ARM64,
+the SDK needs roughly this matrix:
+
+| Target family | Initial target examples |
+|---|---|
+| Windows | amd64, arm64 |
+| macOS | amd64, arm64 |
+| Linux glibc | amd64, arm64 |
+| Optional or follow-up | Windows x86, Linux musl/Alpine, additional long-tail targets |
+
+With an optimized native driver around **~5 MB per target**, a six-target matrix
+is roughly **~30 MB before compression**. Expanding to ten targets approaches the
+earlier **~50 MB** mental model. The design question is not only binary size; it
+is **who downloads which targets, when, and how visible the native dependency is
+to the customer**.
+
+## 2. Go module mechanics that shape the design
+
+Go has three mechanics that matter here.
+
+First, a GitHub repository and a Go module are not the same thing. A repository
+can contain many modules, each rooted at its own `go.mod`. Go customers normally
+consume module ZIPs through the Go module cache/proxy; they do not clone the
+whole repository just to use a package.
+
+Second, Go builds packages, not an entire repository by default. A cgo
+requirement in `azcosmos` does not automatically mean unrelated Azure SDK for Go
+modules require cgo. Customers and CI invoke `go build`, `go test`, or `go list`
+against specific modules/packages.
+
+Third, cgo link flags are collected from packages in the build graph. The cgo
+documentation says `#cgo LDFLAGS` directives from any package in the program are
+concatenated at link time. That means a platform-specific driver package can
+contribute the native library path, but only if that package is imported by the
+program. A `require` entry alone is not enough; the package must be reachable
+through an import, often a blank import.
+
+```go
+//go:build linux && amd64
+
+package azcosmos
+
+import _ "github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-linux-amd64"
+```
+
+## 3. Design goals
+
+| Goal | Why it matters |
+|---|---|
+| Keep the common path close to `go get` / `go build` | Cosmos Go v1 feels like a normal Go SDK; Go v2 should not surprise mainstream customers. |
+| Avoid making every customer download every long-tail binary | The native matrix can grow over time, and module-cache footprint matters. |
+| Keep versioning safe | The Go wrapper, C header, and native driver ABI must match. |
+| Work in enterprise and offline environments | Build-time network downloads and ad-hoc install scripts are often blocked. |
+| Keep the Azure SDK for Go repository manageable | Committing many binary artifacts affects contributors who clone the repo, even if customers use module ZIPs. |
+| Make unsupported platforms fail clearly | Customers should see a direct "no driver configured for this platform" message, not an obscure linker failure. |
+
+## 4. Industry reference points
+
+### Confluent Kafka: bundle-first hybrid
+
+`confluent-kafka-go` is the closest market precedent. It is a Go library backed
+by the native `librdkafka` implementation. Its developer documentation describes
+bundled platform-specific static builds as the default, with dynamic/manual
+linking as an escape hatch for special cases.
+
+References:
+[`kafka/README.md#librdkafka`](https://github.com/confluentinc/confluent-kafka-go/blob/master/kafka/README.md#librdkafka)
+and
+[`librdkafka_vendor`](https://pkg.go.dev/github.com/confluentinc/confluent-kafka-go/v2/kafka/librdkafka_vendor).
+
+The useful lesson is not "copy Confluent exactly." The useful lesson is that a
+Go library can be native-backed and still preserve a mostly normal customer
+experience by bundling common platform binaries and documenting escape hatches.
+
+### ONNX Runtime Go: wrapper-only, user supplies native runtime
+
+`onnxruntime_go` keeps the Go wrapper separate from the platform runtime. The
+customer supplies the matching `onnxruntime.dll`, `.so`, or `.dylib` and points
+the wrapper at it before initialization.
+
+Reference:
+[`onnxruntime_go` requirements](https://github.com/yalue/onnxruntime_go#requirements).
+
+The useful lesson is that wrapper-only distribution keeps the Go module small,
+but it makes native acquisition part of the customer setup. That is often
+acceptable in ML/runtime scenarios; it is a harder fit for a first-party Azure
+data SDK's default path.
+
+### go-sqlite3: cgo toolchain requirement is explicit
+
+`go-sqlite3` is a widely used Go package that directly documents the cgo and
+compiler requirement.
+
+Reference:
+[`go-sqlite3` installation](https://github.com/mattn/go-sqlite3#installation).
+
+The useful lesson is that the Go ecosystem accepts cgo in some packages, but it
+does not hide the compiler requirement. Cosmos should be equally explicit:
+prebuilt Rust artifacts remove the need for a Rust toolchain and manual native
+library copying, but **cgo still requires a C build toolchain**.
+
+### Go community discussion: no wheel-like standard
+
+The Go community has discussed prebuilt cgo dependencies and the absence of a
+Python-wheel-like mechanism for `go.mod`.
+
+Reference:
+[`golang-nuts` discussion](https://groups.google.com/g/golang-nuts/c/ahZXdoClBGg).
+
+The useful lesson is that Go does not provide a standard native-binary packaging
+solution. Cosmos has to choose and own a distribution model.
+
+## 5. Option A: one public module bundles the full native matrix
+
+This is the simplest Confluent-like shape.
+
+```text
+github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos
+├── go.mod
+├── client.go
+├── internal/core/
+├── internal/native/
+│   ├── windows-amd64/azurecosmos.lib
+│   ├── windows-arm64/azurecosmos.lib
+│   ├── darwin-amd64/libazurecosmos.a
+│   ├── darwin-arm64/libazurecosmos.a
+│   ├── linux-amd64-gnu/libazurecosmos.a
+│   └── linux-arm64-gnu/libazurecosmos.a
+├── driver_windows_amd64.go
+├── driver_darwin_arm64.go
+└── driver_linux_amd64.go
+```
+
+Selection happens through Go build tags:
+
+```go
+//go:build darwin && arm64
+
+package azcosmos
+
+/*
+#cgo LDFLAGS: -L${SRCDIR}/internal/native/darwin-arm64 -lazurecosmos
+*/
+import "C"
+```
+
+Customer flow:
+
+```text
+customer app imports azcosmos
+        │
+        ▼
+Go downloads one azcosmos module ZIP containing the default native matrix
+        │
+        ▼
+Go build tags select the one matching native library
+        │
+        ▼
+application links with the Rust driver for the current platform
+```
+
+**Size gist:** customers download/cache the whole default native matrix as part
+of one `azcosmos` module. A six-target default set is roughly ~30 MB before
+compression; a ten-target set approaches ~50 MB. The final app links only the
+current platform's native driver.
+
+| Area | Effect |
+|---|---|
+| Customer experience | Best. One `go get`; one module; no platform package choices. |
+| Download footprint | Worst. Every `azcosmos` customer downloads the default native matrix. |
+| Version safety | Strong. Go wrapper and native bits are versioned together. |
+| Repository impact | High if the module lives in `azure-sdk-for-go`; binaries are committed with SDK source. |
+| Long-tail targets | Adding one target increases the default module for everyone. |
+
+## 6. Option B: split modules in the Azure SDK for Go repository
+
+This is a multi-module model where the public SDK stays zero-touch for default
+platforms, but each native binary lives in its own Go module.
+
+```text
+github.com/Azure/azure-sdk-for-go
+└── sdk/data/azcosmos-core/
+    ├── go.mod
+    ├── core.go
+    └── include/azurecosmos.h
+
+└── sdk/data/azcosmos-driver-linux-amd64-gnu/
+    ├── go.mod
+    ├── link_linux_amd64.go
+    └── native/libazurecosmos.a
+
+└── sdk/data/azcosmos-driver-darwin-arm64/
+    ├── go.mod
+    ├── link_darwin_arm64.go
+    └── native/libazurecosmos.a
+
+└── sdk/data/azcosmos/
+    ├── go.mod
+    ├── client.go
+    ├── default_driver_linux_amd64.go
+    ├── default_driver_darwin_arm64.go
+    └── unsupported_driver.go
+```
+
+`azcosmos-core` contains the shared Go wrapper and C ABI declarations:
+
+```go
+// sdk/data/azcosmos-core/go.mod
+module github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos-core
+
+go 1.25.0
+```
+
+```c
+/* sdk/data/azcosmos-core/include/azurecosmos.h */
+#pragma once
+
+const char* azurecosmos_abi_version(void);
+void* azurecosmos_client_new(const char* endpoint, const char* key);
+void azurecosmos_client_free(void* client);
+```
+
+```go
+// sdk/data/azcosmos-core/core.go
+package azcosmoscore
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/include
+#include "azurecosmos.h"
+*/
+import "C"
+
+func ABIVersion() string {
+    return C.GoString(C.azurecosmos_abi_version())
+}
+```
+
+Each driver module contains exactly one native library and the link flags for
+that target:
+
+```go
+// sdk/data/azcosmos-driver-linux-amd64-gnu/go.mod
+module github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos-driver-linux-amd64-gnu
+
+go 1.25.0
+```
+
+```go
+// sdk/data/azcosmos-driver-linux-amd64-gnu/link_linux_amd64.go
+//go:build linux && amd64 && !musl
+
+package azcosmosdriverlinuxamd64gnu
+
+/*
+#cgo LDFLAGS: -L${SRCDIR}/native -lazurecosmos
+*/
+import "C"
+```
+
+The public `azcosmos` module depends on the core module and the default driver
+modules:
+
+```go
+// sdk/data/azcosmos/go.mod
+module github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos
+
+go 1.25.0
+
+require (
+    github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos-core v1.2.3
+    github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos-driver-darwin-arm64 v1.2.3
+    github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos-driver-linux-amd64-gnu v1.2.3
+    github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos-driver-windows-amd64 v1.2.3
+)
+```
+
+`azcosmos` imports the active default driver through build-tagged blank imports.
+This import is important: a `require` entry alone does not make the driver's
+cgo link flags participate in the final link.
+
+```go
+// sdk/data/azcosmos/default_driver_linux_amd64.go
+//go:build linux && amd64 && !musl
+
+package azcosmos
+
+import _ "github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos-driver-linux-amd64-gnu"
+```
+
+```go
+// sdk/data/azcosmos/default_driver_darwin_arm64.go
+//go:build darwin && arm64
+
+package azcosmos
+
+import _ "github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos-driver-darwin-arm64"
+```
+
+A customer on a default platform writes ordinary Go application code. They do
+not import the driver package directly:
+
+```go
+// customer-app/go.mod
+module example.com/customer-app
+
+go 1.25.0
+
+require github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.2.3
+```
+
+```go
+// customer-app/main.go
+package main
+
+import "github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+
+func main() {
+    _ = azcosmos.NativeDriverVersion()
+}
+```
+
+For `GOOS=linux GOARCH=amd64`, Go includes `default_driver_linux_amd64.go`.
+That file blank-imports `azcosmos-driver-linux-amd64-gnu`, so the driver module
+contributes `#cgo LDFLAGS` and the app links against
+`native/libazurecosmos.a`.
+
+For libc variants, Go does not provide a built-in `glibc` versus `musl` target
+dimension. If both are supported, the design needs an explicit convention such
+as a custom `musl` build tag, a separate opt-in package, or a default Linux
+choice with the other variant documented as optional.
+
+**Size gist:** if the default `azcosmos` module requires six default driver
+modules, customers may still download/cache roughly the same ~30 MB matrix
+before compression. The difference is that the payload is split into separate
+module ZIPs, optional targets can stay out of the default path, and the final app
+still links only the current platform's native driver.
+
+| Area | Effect |
+|---|---|
+| Customer experience | Good. Common platforms still use `go get azcosmos` / `go build`. |
+| Download footprint | Better than one giant module in cache shape, but the default `azcosmos` module may still cause all default driver module ZIPs to be downloaded. |
+| Version safety | Manageable if all modules are released together and exact versions are pinned. |
+| Repository impact | Still high for `azure-sdk-for-go` contributors because the repo contains all native modules. |
+| Long-tail targets | Better. Optional targets can be extra modules not included in default `azcosmos`. |
+
+## 7. Option C: split modules, native drivers in a separate repository
+
+This keeps the customer-facing SDK in `azure-sdk-for-go`, but moves the binary
+payload modules to a separate Azure-owned repository. This is the preferred
+direction for further design because it keeps the large binaries out of the
+Azure SDK for Go repository without changing the common customer flow.
+
+```text
+github.com/Azure/azure-sdk-for-go
+└── sdk/data/azcosmos/
+└── sdk/data/azcosmos-core/
+
+github.com/Azure/azure-cosmos-go-native-drivers
+└── azcosmos-driver-windows-amd64/
+└── azcosmos-driver-windows-arm64/
+└── azcosmos-driver-darwin-amd64/
+└── azcosmos-driver-darwin-arm64/
+└── azcosmos-driver-linux-amd64-gnu/
+└── azcosmos-driver-linux-arm64-gnu/
+```
+
+Customer flow is still Go-native:
+
+```text
+customer runs:
+  go get github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos
+
+Go module graph includes:
+  azcosmos
+  azcosmos-core
+  github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-darwin-arm64
+
+customer does not clone the native-driver repo manually
+```
+
+The public SDK can hide the separate repository behind build-tagged blank
+imports:
+
+```go
+//go:build linux && amd64
+
+package azcosmos
+
+import _ "github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-linux-amd64-gnu"
+```
+
+**Size gist:** for customers, this is similar to Option B if `azcosmos` still
+depends on the default driver modules. The default download/cache can still be
+the default matrix, but the binary modules come from a separate repository and
+the final app links only one target.
+
+| Area | Effect |
+|---|---|
+| Customer experience | Good for default platforms if `azcosmos` wires driver imports automatically. |
+| Download footprint | Similar to Option B from the customer's module-cache perspective. |
+| Version safety | Requires stronger release discipline across repositories. |
+| Repository impact | Better for Azure SDK for Go contributors; binary churn lives elsewhere. |
+| Governance | Needs clear ownership, release, security, signing, and support boundaries. |
+
+This model separates two concerns:
+
+```text
+Go customers care about modules.
+Azure SDK contributors care about repositories.
+```
+
+Separate modules help customer download granularity. A separate repository helps
+the Azure SDK for Go repository avoid carrying binary payloads in its Git
+history.
+
+## 8. Advanced mode: customer-managed dynamic library
+
+This is not the default path. It is an advanced mode for customers who want or
+need to manage the native library through their own deployment system.
+
+If the Go wrapper links dynamically, a customer could choose not to use an
+`azcosmos-driver-*` package and instead use `azcosmos-core` directly. As long as
+the matching `libazurecosmos` is available on the platform's library load path,
+the application can link/load the native driver through the customer's packaging
+system.
+
+```text
+customer app
+  imports azcosmos-core or an advanced azcosmos configuration path
+  places libazurecosmos on the library load path
+  builds/runs with the customer's native package manager or image layout
+```
+
+**Size gist:** the Go module stays small because it does not carry the native
+matrix. Customers still need one native driver for their platform, but they
+acquire, place, and update it themselves.
+
+| Area | Effect |
+|---|---|
+| Customer experience | Good only for customers that already manage native dependencies. |
+| Download footprint | Minimal Go module footprint. |
+| Version safety | Must validate SDK/native ABI compatibility at startup. |
+| Enterprise/offline | Useful for strict packaging environments. |
+| Supportability | Native setup becomes a customer-owned prerequisite. |
+
+This should be documented as an escape hatch, not the default Azure SDK
+experience.
+
+## 9. Options not selected for the default path
+
+### Small SDK module plus GitHub release assets
+
+This model keeps the Go SDK module small and publishes native drivers as GitHub
+release assets:
+
+```text
+GitHub release v1.2.3
+├── azurecosmos-native-windows-amd64.zip
+├── azurecosmos-native-darwin-arm64.tar.gz
+├── azurecosmos-native-linux-amd64-gnu.tar.gz
+└── checksums.txt
+```
+
+It gives customers a smaller per-platform download, but requires an explicit
+download/install step or helper command before `go build`. That is too
+disruptive for the default Go SDK experience and introduces extra proxy, cache,
+checksum, install-path, and linker-path failure modes.
+
+### Standalone native-backed Go SDK
+
+A separate public SDK identity, such as `azcosmosnative`, would avoid impacting
+existing `azcosmos` users, but it confuses the support and migration matrix. If
+Go v2 is not shipped as the normal `azcosmos` evolution, customers must
+understand which package is the supported future and how long the old package
+continues. That is a product-level split rather than a packaging solution, so it
+is not selected here.
+
+## 10. Default driver set selection
+
+If a split-module model is used, there are two distinct decisions:
+
+1. **Which driver modules are published?**
+2. **Which of those are included in the default `azcosmos` experience?**
+
+For example:
+
+```text
+Published modules:
+  windows-amd64
+  windows-arm64
+  darwin-amd64
+  darwin-arm64
+  linux-amd64-gnu
+  linux-arm64-gnu
+  windows-386
+  linux-amd64-musl
+
+Default azcosmos imports:
+  windows-amd64
+  windows-arm64
+  darwin-amd64
+  darwin-arm64
+  linux-amd64-gnu
+  linux-arm64-gnu
+
+Optional:
+  windows-386
+  linux-amd64-musl
+```
+
+Build-time selection then happens through build tags:
+
+```text
+GOOS=darwin GOARCH=arm64
+       │
+       ▼
+default_driver_darwin_arm64.go is included
+       │
+       ▼
+azcosmos-driver-darwin-arm64 is imported
+       │
+       ▼
+darwin/arm64 native library contributes link flags
+```
+
+For a platform outside the default set, the SDK should fail clearly:
+
+```text
+azcosmos: no native Cosmos driver package is configured for linux/amd64/musl.
+Add the linux/amd64/musl driver package or use a supported default platform.
+```
+
+Optional targets need a documented activation story. Without an import, Go may
+know about the module version in `go.mod`, but the driver's cgo link flags will
+not participate in the final link.
+
+## 11. Versioning and ABI safety
+
+All models need a version contract between:
+
+- Go wrapper package
+- `azurecosmos.h`
+- native Rust driver library
+- C ABI version
+
+The safest customer-facing rule is exact version alignment:
+
+```text
+azcosmos v1.2.3
+  requires azcosmos-core v1.2.3
+  requires azcosmos-driver-* v1.2.3
+  expects native ABI version 1.2.3
+```
+
+At minimum, the native driver should expose an ABI/version function:
+
+```c
+const char* azurecosmos_abi_version(void);
+```
+
+The Go wrapper can validate it during initialization and produce a direct error
+if the linked library is wrong:
+
+```text
+azcosmos: native driver ABI mismatch:
+  Go wrapper expects 1.2.3
+  linked native driver reports 1.2.1
+```
+
+This validation matters most for manual, dynamic, or optional-driver paths. It
+is still useful for bundled paths because it catches packaging mistakes.
+
+## 12. Customer experience comparison
+
+| Model | Common-platform customer flow | Customer-visible native setup | Download behavior |
+|---|---|---|---|
+| A. Single bundled module | `go get azcosmos`; `go build` | cgo toolchain only | Downloads whole default matrix in one module |
+| B. Split modules, same repo | `go get azcosmos`; `go build` | cgo toolchain only | Downloads default driver modules as dependencies; links only the active target |
+| C. Split modules, separate repo | `go get azcosmos`; `go build` | cgo toolchain only | Downloads driver modules from a second repo through Go module system |
+| Advanced dynamic library | imports/configures advanced path | customer-managed native library | Downloads only Go wrapper; customer supplies native payload |
+
+## 13. Repository and release comparison
+
+| Model | Azure SDK for Go repo impact | Release coordination | Reviewability |
+|---|---|---|---|
+| A. Single bundled module | Highest; all binaries live under one module | Simple, one module version | Large binary diffs in SDK PRs |
+| B. Split modules, same repo | High; binaries still live in repo, but module payloads are separated | Moderate; many modules, same repo | Binary PRs still affect SDK repo |
+| C. Split modules, separate repo | Lower; native payload outside main SDK repo | Higher; cross-repo version alignment | Cleaner SDK PRs, separate native PRs |
+| Advanced dynamic library | Low source impact | Higher customer responsibility | Native setup mostly outside SDK PRs |
+
+## 14. Discussion checkpoints for Go Central SDK review
+
+These are the questions that likely need board-level alignment:
+
+1. Is the default Azure SDK experience allowed to require cgo and a C toolchain
+   when prebuilt native driver artifacts are included?
+2. Should the default Cosmos Go module include all mainstream platform drivers,
+   or should some platforms be opt-in?
+3. Should native driver packages live in a separate Azure-owned repository to
+   keep binary payload out of `azure-sdk-for-go`?
+4. Does the Azure SDK release system support synchronized versioning across a
+   public SDK module, core wrapper module, and several driver modules?
+5. How should optional/long-tail platforms be activated: direct blank import,
+   Azure SDK metapackage, dynamic/manual native path, or unsupported?
+6. What is the signing, checksum, and provenance story for native artifacts?
+7. What exact error should customers see when no driver is configured for their
+   target?
+
+## 15. Current read
+
+The split-module design with native driver modules in a **separate Azure-owned
+repository** is the strongest candidate for discussion. It preserves the
+common-platform customer experience while keeping large binary artifacts out of
+the Azure SDK for Go repository.
+
+```text
+Common path:
+  go get azcosmos
+  go build
+  default driver selected through build tags
+
+Repository placement:
+  azcosmos Go code in azure-sdk-for-go
+  native driver modules in a separate Azure-owned repository
+```
+
+For customer experience, the separate-repo option can still be nearly invisible
+if the driver packages are normal Go modules and the public `azcosmos` package
+imports the default drivers automatically.

--- a/sdk/data/azcosmos/docs/go-ffi-distribution-design.md
+++ b/sdk/data/azcosmos/docs/go-ffi-distribution-design.md
@@ -62,7 +62,7 @@ program. A `require` entry alone is not enough; the package must be reachable
 through an import, often a blank import.
 
 ```go
-//go:build linux && amd64
+//go:build cgo && linux && amd64
 
 package azcosmos
 
@@ -280,7 +280,7 @@ go 1.25.0
 
 ```go
 // sdk/data/azcosmos-driver-linux-amd64-gnu/link_linux_amd64.go
-//go:build linux && amd64 && !musl
+//go:build cgo && linux && amd64 && !musl
 
 package azcosmosdriverlinuxamd64gnu
 
@@ -313,7 +313,7 @@ cgo link flags participate in the final link.
 
 ```go
 // sdk/data/azcosmos/default_driver_linux_amd64.go
-//go:build linux && amd64 && !musl
+//go:build cgo && linux && amd64 && !musl
 
 package azcosmos
 
@@ -322,7 +322,7 @@ import _ "github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos-driver-linux-amd64
 
 ```go
 // sdk/data/azcosmos/default_driver_darwin_arm64.go
-//go:build darwin && arm64
+//go:build cgo && darwin && arm64
 
 package azcosmos
 
@@ -415,7 +415,7 @@ The public SDK can hide the separate repository behind build-tagged blank
 imports:
 
 ```go
-//go:build linux && amd64
+//go:build cgo && linux && amd64
 
 package azcosmos
 
@@ -540,10 +540,11 @@ Optional:
   linux-amd64-musl
 ```
 
-Build-time selection then happens through build tags:
+Build-time selection then happens through build tags. Every native driver
+selector includes `cgo`, because the selected package imports `C`:
 
 ```text
-GOOS=darwin GOARCH=arm64
+CGO_ENABLED=1 GOOS=darwin GOARCH=arm64
        │
        ▼
 default_driver_darwin_arm64.go is included
@@ -554,6 +555,46 @@ azcosmos-driver-darwin-arm64 is imported
        ▼
 darwin/arm64 native library contributes link flags
 ```
+
+### cgo-disabled and cross-compilation behavior
+
+There is no functional non-cgo path for Go v2. When `CGO_ENABLED=0`, no
+native-driver selector or driver package should be included. Otherwise, a
+selector can blank-import a driver package whose only Go source imports `C`,
+leaving customers with the opaque Go error `build constraints exclude all Go
+files`.
+
+Instead, the public module needs a `!cgo` diagnostic guard that does not import
+any driver and causes client initialization to fail explicitly:
+
+```go
+//go:build !cgo
+
+package azcosmos
+
+import "errors"
+
+func nativeDriverUnavailableError() error {
+    return errors.New(
+        "azcosmos: Go v2 requires CGO_ENABLED=1, a target-compatible C " +
+            "toolchain, and a matching native Cosmos driver artifact",
+    )
+}
+```
+
+This is a diagnostic path only: it does not provide a pure-Go implementation,
+degraded mode, or alternate driver. The cgo-enabled implementation uses the
+same initialization boundary without returning this error.
+
+Cross-compilation requires the same explicit treatment. Go normally disables
+cgo when cross-compiling unless the customer enables it and configures a
+target-compatible C compiler. The supported command must therefore provide
+`CGO_ENABLED=1`, the appropriate `CC`/toolchain for the target, and a matching
+native driver artifact. A cross-build with cgo disabled reaches the `!cgo`
+guard and receives the clear unsupported-configuration error. If cgo is
+enabled but the target compiler or native artifact is missing, compilation or
+linking necessarily fails before Go code can initialize; the supported
+cross-compilation instructions must make those prerequisites explicit.
 
 For a platform outside the default set, the SDK should fail clearly:
 

--- a/sdk/data/azcosmos/docs/go-ffi-distribution-design.md
+++ b/sdk/data/azcosmos/docs/go-ffi-distribution-design.md
@@ -575,14 +575,27 @@ All models need a version contract between:
 - native Rust driver library
 - C ABI version
 
-The safest customer-facing rule is exact version alignment:
+**Go module versions cannot enforce this contract.** A `require` line sets a
+*minimum* version, not a pin. Under Minimal Version Selection (MVS), any other
+module in the customer's build graph can raise a driver module to a newer
+version than the wrapper declared. The wrapper has no way to demand exact
+module-version equality, so correctness must rest on an **ABI-compatibility
+contract**, not on matching module version strings.
+
+The rule is: the wrapper declares the native ABI it needs, and any
+MVS-selected driver is acceptable as long as it stays ABI-compatible.
 
 ```text
 azcosmos v1.2.3
-  requires azcosmos-core v1.2.3
-  requires azcosmos-driver-* v1.2.3
-  expects native ABI version 1.2.3
+  requires native ABI major 1, minimum minor 2
+  accepts any driver module whose native ABI is 1.x with x >= 2
+  (MVS may select azcosmos-driver-* v1.2.3, v1.3.0, or newer —
+   all valid while the ABI stays 1.x compatible)
 ```
+
+ABI compatibility follows the usual rule: same major, minor greater-than-or-equal
+to what the wrapper needs. A major bump means incompatible; the wrapper must
+reject it.
 
 At minimum, the native driver should expose an ABI/version function:
 
@@ -590,17 +603,18 @@ At minimum, the native driver should expose an ABI/version function:
 const char* azurecosmos_abi_version(void);
 ```
 
-The Go wrapper can validate it during initialization and produce a direct error
-if the linked library is wrong:
+The Go wrapper validates it during initialization against a compatibility
+*range*, not an exact string, and fails only on genuine incompatibility:
 
 ```text
-azcosmos: native driver ABI mismatch:
-  Go wrapper expects 1.2.3
-  linked native driver reports 1.2.1
+azcosmos: native driver ABI incompatible:
+  Go wrapper requires ABI major 1, minor >= 2
+  linked native driver reports ABI 2.0  (major mismatch)
 ```
 
-This validation matters most for manual, dynamic, or optional-driver paths. It
-is still useful for bundled paths because it catches packaging mistakes.
+A newer-but-compatible driver (for example ABI 1.4 when the wrapper needs 1.2)
+must pass. This validation matters most for manual, dynamic, or optional-driver
+paths, and still catches packaging mistakes on bundled paths.
 
 ## 12. Customer experience comparison
 
@@ -630,12 +644,15 @@ These are the questions that likely need board-level alignment:
    or should some platforms be opt-in?
 3. Should native driver packages live in a separate Azure-owned repository to
    keep binary payload out of `azure-sdk-for-go`?
-4. Does the Azure SDK release system support synchronized versioning across a
+4. Under MVS, the customer graph can select a newer driver module than the
+   wrapper declared. What is the ABI-compatibility policy that keeps this safe —
+   same-major / minimum-minor, and who owns bumping the major?
+5. Does the Azure SDK release system support synchronized versioning across a
    public SDK module, core wrapper module, and several driver modules?
-5. How should optional/long-tail platforms be activated: direct blank import,
+6. How should optional/long-tail platforms be activated: direct blank import,
    Azure SDK metapackage, dynamic/manual native path, or unsupported?
-6. What is the signing, checksum, and provenance story for native artifacts?
-7. What exact error should customers see when no driver is configured for their
+7. What is the signing, checksum, and provenance story for native artifacts?
+8. What exact error should customers see when no driver is configured for their
    target?
 
 ## 15. Current read

--- a/sdk/data/azcosmos/docs/go-ffi-distribution-design.md
+++ b/sdk/data/azcosmos/docs/go-ffi-distribution-design.md
@@ -226,30 +226,75 @@ platforms, but each native binary lives in its own Go module.
 
 ```text
 github.com/Azure/azure-sdk-for-go
-└── sdk/data/azcosmos-core/
-    ├── go.mod
-    ├── core.go
-    └── include/azurecosmos.h
-
-└── sdk/data/azcosmos-driver-linux-amd64-gnu/
-    ├── go.mod
-    ├── link_linux_amd64.go
-    └── native/libazurecosmos.a
-
+└── sdk/data/azcosmos/                          # public SDK + build-tagged driver imports
+└── sdk/data/azcosmos-core/                     # shared Go wrapper + C ABI header
+└── sdk/data/azcosmos-driver-linux-amd64-gnu/   # one native lib per module
 └── sdk/data/azcosmos-driver-darwin-arm64/
-    ├── go.mod
-    ├── link_darwin_arm64.go
-    └── native/libazurecosmos.a
+    └── ...                                      # one module per supported target
+```
 
+The module mechanics — a shared `azcosmos-core` wrapper, one
+`azcosmos-driver-<os>-<arch>` module per native binary, and build-tagged blank
+imports in the public `azcosmos` module — are identical to Option C below. Each
+driver module carries a single `native/libazurecosmos.a` plus its `#cgo LDFLAGS`
+link file, and `azcosmos` pulls in the active one through a `default_driver_*.go`
+blank import (with an `unsupported_driver.go` fallback for other builds).
+
+The **only** difference from Option C is placement: in Option B the native
+driver modules live **inside** `azure-sdk-for-go`, so every native binary and all
+of its churn sit in the main SDK repository. That single difference is what makes
+the repository impact high, and is why Option B was not selected. The full
+file-level layout (module files, C header, link files, default-driver imports,
+and the `!cgo` fallback) is documented once, under Option C.
+
+| Area | Effect |
+|---|---|
+| Customer experience | Good. Common platforms still use `go get azcosmos` / `go build`. |
+| Download footprint | Normal builds fetch the active driver module; full-graph workflows can fetch the default driver matrix. |
+| Version safety | Manageable if all modules are released together and exact versions are pinned. |
+| Repository impact | Still high for `azure-sdk-for-go` contributors because the repo contains all native modules. |
+| Long-tail targets | Better. Optional targets can be extra modules not included in default `azcosmos`. |
+
+## 7. Option C: split modules, native drivers in a separate repository
+
+This keeps the customer-facing SDK in `azure-sdk-for-go`, but moves the binary
+payload modules to a separate Azure-owned repository. **This is the selected
+distribution model for Go v2** because it keeps the large binaries out of the
+Azure SDK for Go repository without changing the common customer flow.
+
+```text
+github.com/Azure/azure-sdk-for-go
 └── sdk/data/azcosmos/
     ├── go.mod
     ├── client.go
     ├── default_driver_linux_amd64.go
     ├── default_driver_darwin_arm64.go
     └── unsupported_driver.go
+
+└── sdk/data/azcosmos-core/
+    ├── go.mod
+    ├── core.go
+    └── include/azurecosmos.h
+
+github.com/Azure/azure-cosmos-go-native-drivers
+└── azcosmos-driver-linux-amd64-gnu/
+    ├── go.mod
+    ├── link_linux_amd64.go
+    └── native/libazurecosmos.a
+
+└── azcosmos-driver-darwin-arm64/
+    ├── go.mod
+    ├── link_darwin_arm64.go
+    └── native/libazurecosmos.a
 ```
 
-`azcosmos-core` contains the shared Go wrapper and C ABI declarations:
+The public `azcosmos` package and the shared `azcosmos-core` module stay in
+`azure-sdk-for-go`. Only the per-target driver modules — the modules that carry
+the native binaries — move to the separate `azure-cosmos-go-native-drivers`
+repository.
+
+`azcosmos-core` holds the shared Go wrapper and the C ABI declarations. It
+carries no native binary, so it is small and changes only when the ABI changes:
 
 ```go
 // sdk/data/azcosmos-core/go.mod
@@ -282,18 +327,18 @@ func ABIVersion() string {
 }
 ```
 
-Each driver module contains exactly one native library and the link flags for
-that target:
+Each driver module in the separate repository contains exactly one native
+library and the link flags for that target:
 
 ```go
-// sdk/data/azcosmos-driver-linux-amd64-gnu/go.mod
-module github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos-driver-linux-amd64-gnu
+// azcosmos-driver-linux-amd64-gnu/go.mod
+module github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-linux-amd64-gnu
 
 go 1.25.0
 ```
 
 ```go
-// sdk/data/azcosmos-driver-linux-amd64-gnu/link_linux_amd64.go
+// azcosmos-driver-linux-amd64-gnu/link_linux_amd64.go
 //go:build cgo && linux && amd64 && !musl
 
 package azcosmosdriverlinuxamd64gnu
@@ -304,8 +349,8 @@ package azcosmosdriverlinuxamd64gnu
 import "C"
 ```
 
-The public `azcosmos` module depends on the core module and the default driver
-modules:
+The public `azcosmos` module depends on `azcosmos-core` (same repository) and on
+the default driver modules (the separate repository):
 
 ```go
 // sdk/data/azcosmos/go.mod
@@ -315,14 +360,14 @@ go 1.25.0
 
 require (
     github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos-core v1.2.3
-    github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos-driver-darwin-arm64 v1.2.3
-    github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos-driver-linux-amd64-gnu v1.2.3
-    github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos-driver-windows-amd64 v1.2.3
+    github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-darwin-arm64 v1.2.3
+    github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-linux-amd64-gnu v1.2.3
+    github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-windows-amd64 v1.2.3
 )
 ```
 
-`azcosmos` imports the active default driver through build-tagged blank imports.
-This import is important: a `require` entry alone does not make the driver's
+`azcosmos` pulls in the active default driver through build-tagged blank imports.
+This import is what matters: a `require` entry alone does not make the driver's
 cgo link flags participate in the final link.
 
 ```go
@@ -331,7 +376,7 @@ cgo link flags participate in the final link.
 
 package azcosmos
 
-import _ "github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos-driver-linux-amd64-gnu"
+import _ "github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-linux-amd64-gnu"
 ```
 
 ```go
@@ -340,20 +385,31 @@ import _ "github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos-driver-linux-amd64
 
 package azcosmos
 
-import _ "github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos-driver-darwin-arm64"
+import _ "github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-darwin-arm64"
 ```
 
-A customer on a default platform writes ordinary Go application code. They do
-not import the driver package directly:
+When no bundled driver applies — cgo disabled, or a platform outside the default
+matrix — `unsupported_driver.go` is compiled instead of a `default_driver_*.go`,
+turning a confusing linker error into an explicit, documented failure:
 
 ```go
-// customer-app/go.mod
-module example.com/customer-app
+// sdk/data/azcosmos/unsupported_driver.go
+//go:build !cgo || (!linux && !darwin && !windows)
 
-go 1.25.0
+package azcosmos
 
-require github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.2.3
+// Compiled only when no default native driver is wired in for the current build
+// (cgo disabled, or an unsupported OS/arch). It exists so the failure is clear
+// and actionable rather than a raw missing-symbol link error.
+func init() {
+    panic("azcosmos: no native Cosmos driver for this platform/build; cgo is " +
+        "required — see the distribution docs for supported targets and the " +
+        "advanced customer-managed dynamic-library mode.")
+}
 ```
+
+A customer on a default platform writes ordinary Go code and never references
+the separate driver repository or the driver package directly:
 
 ```go
 // customer-app/main.go
@@ -366,79 +422,34 @@ func main() {
 }
 ```
 
-For `GOOS=linux GOARCH=amd64`, Go includes `default_driver_linux_amd64.go`.
-That file blank-imports `azcosmos-driver-linux-amd64-gnu`, so the driver module
-contributes `#cgo LDFLAGS` and the app links against
-`native/libazurecosmos.a`.
-
-For libc variants, Go does not provide a built-in `glibc` versus `musl` target
-dimension. If both are supported, the design needs an explicit convention such
-as a custom `musl` build tag, a separate opt-in package, or a default Linux
-choice with the other variant documented as optional.
-
-**Size gist:** for ordinary `go get` / `go build` workflows, customers should
-fetch the active platform driver module rather than the full default matrix. A
-full-graph command such as `go mod download all`, vendoring, proxy prewarming, or
-CI validation can still fetch all default driver modules. The final app links
-only the current platform's native driver.
-
-| Area | Effect |
-|---|---|
-| Customer experience | Good. Common platforms still use `go get azcosmos` / `go build`. |
-| Download footprint | Normal builds fetch the active driver module; full-graph workflows can fetch the default driver matrix. |
-| Version safety | Manageable if all modules are released together and exact versions are pinned. |
-| Repository impact | Still high for `azure-sdk-for-go` contributors because the repo contains all native modules. |
-| Long-tail targets | Better. Optional targets can be extra modules not included in default `azcosmos`. |
-
-## 7. Option C: split modules, native drivers in a separate repository
-
-This keeps the customer-facing SDK in `azure-sdk-for-go`, but moves the binary
-payload modules to a separate Azure-owned repository. **This is the selected
-distribution model for Go v2** because it keeps the large binaries out of the
-Azure SDK for Go repository without changing the common customer flow.
-
-```text
-github.com/Azure/azure-sdk-for-go
-└── sdk/data/azcosmos/
-└── sdk/data/azcosmos-core/
-
-github.com/Azure/azure-cosmos-go-native-drivers
-└── azcosmos-driver-windows-amd64/
-└── azcosmos-driver-windows-arm64/
-└── azcosmos-driver-darwin-amd64/
-└── azcosmos-driver-darwin-arm64/
-└── azcosmos-driver-linux-amd64-gnu/
-└── azcosmos-driver-linux-arm64-gnu/
-```
-
-Customer flow is still Go-native:
+For `GOOS=linux GOARCH=amd64`, Go compiles `default_driver_linux_amd64.go`, which
+blank-imports `azcosmos-driver-linux-amd64-gnu` from the native-driver
+repository; that module contributes `#cgo LDFLAGS` and the app links against its
+`native/libazurecosmos.a`. The module graph therefore includes the one active
+driver module even though the customer only imported `azcosmos`:
 
 ```text
 customer runs:
   go get github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos
 
 Go module graph includes:
-  azcosmos
-  azcosmos-core
-  github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-darwin-arm64
+  azcosmos                          (azure-sdk-for-go)
+  azcosmos-core                     (azure-sdk-for-go)
+  azcosmos-driver-linux-amd64-gnu   (azure-cosmos-go-native-drivers)
 
 customer does not clone the native-driver repo manually
 ```
 
-The public SDK can hide the separate repository behind build-tagged blank
-imports:
+For libc variants, Go has no built-in `glibc` versus `musl` target dimension. If
+both are supported, the design needs an explicit convention such as a custom
+`musl` build tag or a separate opt-in driver module, resolved as a default Linux
+choice with the other variant selected explicitly.
 
-```go
-//go:build cgo && linux && amd64
-
-package azcosmos
-
-import _ "github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-linux-amd64-gnu"
-```
-
-**Size gist:** for customers, this is similar to Option B. Ordinary builds fetch
-the active driver module from the separate native-driver repository; full-graph
-workflows can fetch the full default matrix. The final app links only one target.
+**Size gist:** for ordinary `go get` / `go build` workflows, customers fetch the
+active platform driver module from the native-driver repository, not the full
+matrix. Full-graph commands (`go mod download all`, vendoring, proxy prewarming,
+CI validation) can still fetch every default driver module. The final app links
+only the current platform's native driver.
 
 | Area | Effect |
 |---|---|

--- a/sdk/data/azcosmos/docs/go-ffi-distribution-design.md
+++ b/sdk/data/azcosmos/docs/go-ffi-distribution-design.md
@@ -1,4 +1,4 @@
-<!-- cspell:ignore amd64 arm64 azcosmos azcosmoscore checksums glibc GOARCH GOOS libc LDFLAGS libazurecosmos librdkafka metapackage musl onnxruntime SRCDIR -->
+<!-- cspell:ignore amd64 arm64 azcosmos azcosmosnative cosmoscore checksums glibc GOARCH GOOS libc LDFLAGS libazurecosmos librdkafka metapackage musl onnxruntime SRCDIR -->
 # Go FFI native-driver distribution design
 
 > **Status:** Decided — Option C selected. Retained for Go Central SDK and
@@ -13,7 +13,7 @@
 
 **We are going with Option C: split modules, native drivers in a separate
 Azure-owned repository ([§7](#7-option-c-split-modules-native-drivers-in-a-separate-repository)).**
-The public `azcosmos` SDK stays in `azure-sdk-for-go`; the platform-specific
+The public `cosmos` SDK stays in `azure-sdk-for-go`; the platform-specific
 native driver binaries live in a separate Azure-owned repository and are pulled
 in as normal Go modules through build-tagged imports, so the customer flow stays
 plain `go get` / `go build`.
@@ -64,7 +64,7 @@ consume module ZIPs through the Go module cache/proxy; they do not clone the
 whole repository just to use a package.
 
 Second, Go builds packages, not an entire repository by default. A cgo
-requirement in `azcosmos` does not automatically mean unrelated Azure SDK for Go
+requirement in `cosmos` does not automatically mean unrelated Azure SDK for Go
 modules require cgo. Customers and CI invoke `go build`, `go test`, or `go list`
 against specific modules/packages.
 
@@ -78,9 +78,9 @@ through an import, often a blank import.
 ```go
 //go:build cgo && linux && amd64
 
-package azcosmos
+package cosmos
 
-import _ "github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-linux-amd64"
+import _ "github.com/Azure/azure-cosmos-go-driver/linux/amd64"
 ```
 
 Fourth, normal builds should benefit from Go's lazy module loading. A module can
@@ -162,7 +162,7 @@ solution. Cosmos has to choose and own a distribution model.
 This is the simplest Confluent-like shape.
 
 ```text
-github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos
+github.com/Azure/azure-sdk-for-go/sdk/data/cosmos
 ├── go.mod
 ├── client.go
 ├── internal/core/
@@ -183,7 +183,7 @@ Selection happens through Go build tags:
 ```go
 //go:build darwin && arm64
 
-package azcosmos
+package cosmos
 
 /*
 #cgo LDFLAGS: -L${SRCDIR}/internal/native/darwin-arm64 -lazurecosmos
@@ -194,10 +194,10 @@ import "C"
 Customer flow:
 
 ```text
-customer app imports azcosmos
+customer app imports cosmos
         │
         ▼
-Go downloads one azcosmos module ZIP containing the default native matrix
+Go downloads one cosmos module ZIP containing the default native matrix
         │
         ▼
 Go build tags select the one matching native library
@@ -207,14 +207,14 @@ application links with the Rust driver for the current platform
 ```
 
 **Size gist:** customers download/cache the whole default native matrix as part
-of one `azcosmos` module. A six-target default set is roughly ~30 MB before
+of one `cosmos` module. A six-target default set is roughly ~30 MB before
 compression; a ten-target set approaches ~50 MB. The final app links only the
 current platform's native driver.
 
 | Area | Effect |
 |---|---|
 | Customer experience | Best. One `go get`; one module; no platform package choices. |
-| Download footprint | Worst. Every `azcosmos` customer downloads the default native matrix. |
+| Download footprint | Worst. Every `cosmos` customer downloads the default native matrix. |
 | Version safety | Strong. Go wrapper and native bits are versioned together. |
 | Repository impact | High if the module lives in `azure-sdk-for-go`; binaries are committed with SDK source. |
 | Long-tail targets | Adding one target increases the default module for everyone. |
@@ -226,18 +226,18 @@ platforms, but each native binary lives in its own Go module.
 
 ```text
 github.com/Azure/azure-sdk-for-go
-└── sdk/data/azcosmos/                          # public SDK + build-tagged driver imports
-└── sdk/data/azcosmos-core/                     # shared Go wrapper + C ABI header
-└── sdk/data/azcosmos-driver-linux-amd64-gnu/   # one native lib per module
-└── sdk/data/azcosmos-driver-darwin-arm64/
+└── sdk/data/cosmos/                          # public SDK + build-tagged driver imports
+└── sdk/data/cosmos-core/                     # shared Go wrapper + C ABI header
+└── sdk/data/cosmos-driver-linux-amd64-gnu/   # one native lib per module
+└── sdk/data/cosmos-driver-darwin-arm64/
     └── ...                                      # one module per supported target
 ```
 
-The module mechanics — a shared `azcosmos-core` wrapper, one
-`azcosmos-driver-<os>-<arch>` module per native binary, and build-tagged blank
-imports in the public `azcosmos` module — are identical to Option C below. Each
+The module mechanics — a shared `cosmos-core` wrapper, one
+`cosmos-driver-<os>-<arch>` module per native binary, and build-tagged blank
+imports in the public `cosmos` module — are identical to Option C below. Each
 driver module carries a single `native/libazurecosmos.a` plus its `#cgo LDFLAGS`
-link file, and `azcosmos` pulls in the active one through a `default_driver_*.go`
+link file, and `cosmos` pulls in the active one through a `default_driver_*.go`
 blank import (with an `unsupported_driver.go` fallback for other builds).
 
 The **only** difference from Option C is placement: in Option B the native
@@ -249,11 +249,11 @@ and the `!cgo` fallback) is documented once, under Option C.
 
 | Area | Effect |
 |---|---|
-| Customer experience | Good. Common platforms still use `go get azcosmos` / `go build`. |
+| Customer experience | Good. Common platforms still use `go get cosmos` / `go build`. |
 | Download footprint | Normal builds fetch the active driver module; full-graph workflows can fetch the default driver matrix. |
 | Version safety | Manageable if all modules are released together and exact versions are pinned. |
 | Repository impact | Still high for `azure-sdk-for-go` contributors because the repo contains all native modules. |
-| Long-tail targets | Better. Optional targets can be extra modules not included in default `azcosmos`. |
+| Long-tail targets | Better. Optional targets can be extra modules not included in default `cosmos`. |
 
 ## 7. Option C: split modules, native drivers in a separate repository
 
@@ -264,47 +264,56 @@ Azure SDK for Go repository without changing the common customer flow.
 
 ```text
 github.com/Azure/azure-sdk-for-go
-└── sdk/data/azcosmos/
+└── sdk/data/cosmos/
     ├── go.mod
     ├── client.go
     ├── default_driver_linux_amd64.go
     ├── default_driver_darwin_arm64.go
     └── unsupported_driver.go
 
-└── sdk/data/azcosmos-core/
+└── sdk/data/cosmos-core/
     ├── go.mod
     ├── core.go
     └── include/azurecosmos.h
 
-github.com/Azure/azure-cosmos-go-native-drivers
-└── azcosmos-driver-linux-amd64-gnu/
+github.com/Azure/azure-cosmos-go-driver
+└── linux/amd64/
     ├── go.mod
     ├── link_linux_amd64.go
     └── native/libazurecosmos.a
 
-└── azcosmos-driver-darwin-arm64/
+└── darwin/arm64/
     ├── go.mod
     ├── link_darwin_arm64.go
     └── native/libazurecosmos.a
 ```
 
-The public `azcosmos` package and the shared `azcosmos-core` module stay in
-`azure-sdk-for-go`. Only the per-target driver modules — the modules that carry
-the native binaries — move to the separate `azure-cosmos-go-native-drivers`
-repository.
+**Naming convention.** The driver repository is
+`github.com/Azure/azure-cosmos-go-driver` and each target module lives at
+`<goos>/<goarch>` inside it, so a full module path reads
+`github.com/Azure/azure-cosmos-go-driver/linux/amd64`. Because the repository
+name and the directory are both part of every import path, both are kept
+purposeful: the repo name states plainly that this is the native Cosmos driver
+for Go, and the directories drop any redundant `driver-` prefix and just use the
+`GOOS`/`GOARCH` tokens. glibc is the unmarked default (`linux/amd64`); the musl
+variant is suffixed (`linux/amd64-musl`).
 
-`azcosmos-core` holds the shared Go wrapper and the C ABI declarations. It
+The public `cosmos` package and the shared `cosmos-core` module stay in
+`azure-sdk-for-go`. Only the per-target driver modules — the modules that carry
+the native binaries — move to the separate `azure-cosmos-go-driver` repository.
+
+`cosmos-core` holds the shared Go wrapper and the C ABI declarations. It
 carries no native binary, so it is small and changes only when the ABI changes:
 
 ```go
-// sdk/data/azcosmos-core/go.mod
-module github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos-core
+// sdk/data/cosmos-core/go.mod
+module github.com/Azure/azure-sdk-for-go/sdk/data/cosmos-core
 
 go 1.25.0
 ```
 
 ```c
-/* sdk/data/azcosmos-core/include/azurecosmos.h */
+/* sdk/data/cosmos-core/include/azurecosmos.h */
 #pragma once
 
 const char* azurecosmos_abi_version(void);
@@ -313,8 +322,8 @@ void azurecosmos_client_free(void* client);
 ```
 
 ```go
-// sdk/data/azcosmos-core/core.go
-package azcosmoscore
+// sdk/data/cosmos-core/core.go
+package cosmoscore
 
 /*
 #cgo CFLAGS: -I${SRCDIR}/include
@@ -331,17 +340,17 @@ Each driver module in the separate repository contains exactly one native
 library and the link flags for that target:
 
 ```go
-// azcosmos-driver-linux-amd64-gnu/go.mod
-module github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-linux-amd64-gnu
+// linux/amd64/go.mod
+module github.com/Azure/azure-cosmos-go-driver/linux/amd64
 
 go 1.25.0
 ```
 
 ```go
-// azcosmos-driver-linux-amd64-gnu/link_linux_amd64.go
+// linux/amd64/link_linux_amd64.go
 //go:build cgo && linux && amd64 && !musl
 
-package azcosmosdriverlinuxamd64gnu
+package driver
 
 /*
 #cgo LDFLAGS: -L${SRCDIR}/native -lazurecosmos
@@ -349,43 +358,43 @@ package azcosmosdriverlinuxamd64gnu
 import "C"
 ```
 
-The public `azcosmos` module depends on `azcosmos-core` (same repository) and on
+The public `cosmos` module depends on `cosmos-core` (same repository) and on
 the default driver modules (the separate repository):
 
 ```go
-// sdk/data/azcosmos/go.mod
-module github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos
+// sdk/data/cosmos/go.mod
+module github.com/Azure/azure-sdk-for-go/sdk/data/cosmos
 
 go 1.25.0
 
 require (
-    github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos-core v1.2.3
-    github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-darwin-arm64 v1.2.3
-    github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-linux-amd64-gnu v1.2.3
-    github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-windows-amd64 v1.2.3
+    github.com/Azure/azure-sdk-for-go/sdk/data/cosmos-core v1.2.3
+    github.com/Azure/azure-cosmos-go-driver/darwin/arm64 v1.2.3
+    github.com/Azure/azure-cosmos-go-driver/linux/amd64 v1.2.3
+    github.com/Azure/azure-cosmos-go-driver/windows/amd64 v1.2.3
 )
 ```
 
-`azcosmos` pulls in the active default driver through build-tagged blank imports.
+`cosmos` pulls in the active default driver through build-tagged blank imports.
 This import is what matters: a `require` entry alone does not make the driver's
 cgo link flags participate in the final link.
 
 ```go
-// sdk/data/azcosmos/default_driver_linux_amd64.go
+// sdk/data/cosmos/default_driver_linux_amd64.go
 //go:build cgo && linux && amd64 && !musl
 
-package azcosmos
+package cosmos
 
-import _ "github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-linux-amd64-gnu"
+import _ "github.com/Azure/azure-cosmos-go-driver/linux/amd64"
 ```
 
 ```go
-// sdk/data/azcosmos/default_driver_darwin_arm64.go
+// sdk/data/cosmos/default_driver_darwin_arm64.go
 //go:build cgo && darwin && arm64
 
-package azcosmos
+package cosmos
 
-import _ "github.com/Azure/azure-cosmos-go-native-drivers/azcosmos-driver-darwin-arm64"
+import _ "github.com/Azure/azure-cosmos-go-driver/darwin/arm64"
 ```
 
 When no bundled driver applies — cgo disabled, or a platform outside the default
@@ -393,16 +402,16 @@ matrix — `unsupported_driver.go` is compiled instead of a `default_driver_*.go
 turning a confusing linker error into an explicit, documented failure:
 
 ```go
-// sdk/data/azcosmos/unsupported_driver.go
+// sdk/data/cosmos/unsupported_driver.go
 //go:build !cgo || (!linux && !darwin && !windows)
 
-package azcosmos
+package cosmos
 
 // Compiled only when no default native driver is wired in for the current build
 // (cgo disabled, or an unsupported OS/arch). It exists so the failure is clear
 // and actionable rather than a raw missing-symbol link error.
 func init() {
-    panic("azcosmos: no native Cosmos driver for this platform/build; cgo is " +
+    panic("cosmos: no native Cosmos driver for this platform/build; cgo is " +
         "required — see the distribution docs for supported targets and the " +
         "advanced customer-managed dynamic-library mode.")
 }
@@ -415,27 +424,27 @@ the separate driver repository or the driver package directly:
 // customer-app/main.go
 package main
 
-import "github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+import "github.com/Azure/azure-sdk-for-go/sdk/data/cosmos"
 
 func main() {
-    _ = azcosmos.NativeDriverVersion()
+    _ = cosmos.NativeDriverVersion()
 }
 ```
 
 For `GOOS=linux GOARCH=amd64`, Go compiles `default_driver_linux_amd64.go`, which
-blank-imports `azcosmos-driver-linux-amd64-gnu` from the native-driver
+blank-imports `azure-cosmos-go-driver/linux/amd64` from the native-driver
 repository; that module contributes `#cgo LDFLAGS` and the app links against its
 `native/libazurecosmos.a`. The module graph therefore includes the one active
-driver module even though the customer only imported `azcosmos`:
+driver module even though the customer only imported `cosmos`:
 
 ```text
 customer runs:
-  go get github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos
+  go get github.com/Azure/azure-sdk-for-go/sdk/data/cosmos
 
 Go module graph includes:
-  azcosmos                          (azure-sdk-for-go)
-  azcosmos-core                     (azure-sdk-for-go)
-  azcosmos-driver-linux-amd64-gnu   (azure-cosmos-go-native-drivers)
+  cosmos                              (azure-sdk-for-go)
+  cosmos-core                         (azure-sdk-for-go)
+  azure-cosmos-go-driver/linux/amd64    (azure-cosmos-go-driver)
 
 customer does not clone the native-driver repo manually
 ```
@@ -453,7 +462,7 @@ only the current platform's native driver.
 
 | Area | Effect |
 |---|---|
-| Customer experience | Good for default platforms if `azcosmos` wires driver imports automatically. |
+| Customer experience | Good for default platforms if `cosmos` wires driver imports automatically. |
 | Download footprint | Same customer behavior as Option B, but the active driver module comes from a separate repository. |
 | Version safety | Requires stronger release discipline across repositories. |
 | Repository impact | Better for Azure SDK for Go contributors; binary churn lives elsewhere. |
@@ -476,14 +485,14 @@ This is not the default path. It is an advanced mode for customers who want or
 need to manage the native library through their own deployment system.
 
 If the Go wrapper links dynamically, a customer could choose not to use an
-`azcosmos-driver-*` package and instead use `azcosmos-core` directly. As long as
+`azure-cosmos-go-driver/*` module and instead use `cosmos-core` directly. As long as
 the matching `libazurecosmos` is available on the platform's library load path,
 the application can link/load the native driver through the customer's packaging
 system.
 
 ```text
 customer app
-  imports azcosmos-core or an advanced azcosmos configuration path
+  imports cosmos-core or an advanced cosmos configuration path
   places libazurecosmos on the library load path
   builds/runs with the customer's native package manager or image layout
 ```
@@ -525,44 +534,48 @@ checksum, install-path, and linker-path failure modes.
 
 ### Standalone native-backed Go SDK
 
-A separate public SDK identity, such as `azcosmosnative`, would avoid impacting
-existing `azcosmos` users, but it confuses the support and migration matrix. If
-Go v2 is not shipped as the normal `azcosmos` evolution, customers must
-understand which package is the supported future and how long the old package
-continues. That is a product-level split rather than a packaging solution, so it
-is not selected here.
+A permanently parallel native SDK identity — a separate `azcosmosnative`-style
+package that coexists indefinitely alongside the existing v1 `azcosmos` — would
+avoid disturbing current v1 users, but it confuses the support and migration
+matrix. Go v2 instead ships as the direct successor to `azcosmos`, published as
+the new `cosmos` / `cosmos-core` modules, so there is a single supported forward
+path rather than two coexisting native/non-native SDKs. A permanently parallel
+identity is a product-level split rather than a packaging solution, so it is not
+selected here.
 
 ## 10. Default driver set selection
 
 If a split-module model is used, there are two distinct decisions:
 
 1. **Which driver modules are published?**
-2. **Which of those are included in the default `azcosmos` experience?**
+2. **Which of those are included in the default `cosmos` experience?**
 
 For example:
 
 ```text
-Published modules:
-  windows-amd64
-  windows-arm64
-  darwin-amd64
-  darwin-arm64
-  linux-amd64-gnu
-  linux-arm64-gnu
-  windows-386
-  linux-amd64-musl
+Published modules (azure-cosmos-go-driver/<goos>/<goarch>):
+  windows/amd64
+  windows/arm64
+  darwin/arm64
+  linux/amd64          (glibc, unmarked)
+  linux/arm64          (glibc, unmarked)
+  linux/amd64-musl
+  linux/arm64-musl
+  darwin/amd64         (long-tail)
+  windows/386          (long-tail)
 
-Default azcosmos imports:
-  windows-amd64
-  windows-arm64
-  darwin-amd64
-  darwin-arm64
-  linux-amd64-gnu
-  linux-arm64-gnu
+Default cosmos imports (Big 5 + musl):
+  windows/amd64
+  windows/arm64
+  darwin/arm64
+  linux/amd64
+  linux/arm64
+  linux/amd64-musl
+  linux/arm64-musl
 
-Optional:
-  windows-386
-  linux-amd64-musl
+Optional (long-tail add-ons):
+  darwin/amd64
+  windows/386
 ```
 
 Build-time selection then happens through build tags. Every native driver
@@ -575,7 +588,7 @@ CGO_ENABLED=1 GOOS=darwin GOARCH=arm64
 default_driver_darwin_arm64.go is included
        │
        ▼
-azcosmos-driver-darwin-arm64 is imported
+azure-cosmos-go-driver/darwin/arm64 is imported
        │
        ▼
 darwin/arm64 native library contributes link flags
@@ -595,13 +608,13 @@ any driver and causes client initialization to fail explicitly:
 ```go
 //go:build !cgo
 
-package azcosmos
+package cosmos
 
 import "errors"
 
 func nativeDriverUnavailableError() error {
     return errors.New(
-        "azcosmos: Go v2 requires CGO_ENABLED=1, a target-compatible C " +
+        "cosmos: Go v2 requires CGO_ENABLED=1, a target-compatible C " +
             "toolchain, and a matching native Cosmos driver artifact",
     )
 }
@@ -624,7 +637,7 @@ cross-compilation instructions must make those prerequisites explicit.
 For a platform outside the default set, the SDK should fail clearly:
 
 ```text
-azcosmos: no native Cosmos driver package is configured for linux/amd64/musl.
+cosmos: no native Cosmos driver package is configured for linux/amd64/musl.
 Add the linux/amd64/musl driver package or use a supported default platform.
 ```
 
@@ -652,10 +665,10 @@ The rule is: the wrapper declares the native ABI it needs, and any
 MVS-selected driver is acceptable as long as it stays ABI-compatible.
 
 ```text
-azcosmos v1.2.3
+cosmos v1.2.3
   requires native ABI major 1, minimum minor 2
   accepts any driver module whose native ABI is 1.x with x >= 2
-  (MVS may select azcosmos-driver-* v1.2.3, v1.3.0, or newer —
+  (MVS may select azure-cosmos-go-driver/<os>/<arch> v1.2.3, v1.3.0, or newer —
    all valid while the ABI stays 1.x compatible)
 ```
 
@@ -673,7 +686,7 @@ The Go wrapper validates it during initialization against a compatibility
 *range*, not an exact string, and fails only on genuine incompatibility:
 
 ```text
-azcosmos: native driver ABI incompatible:
+cosmos: native driver ABI incompatible:
   Go wrapper requires ABI major 1, minor >= 2
   linked native driver reports ABI 2.0  (major mismatch)
 ```
@@ -686,9 +699,9 @@ paths, and still catches packaging mistakes on bundled paths.
 
 | Model | Common-platform customer flow | Customer-visible native setup | Download behavior |
 |---|---|---|---|
-| A. Single bundled module | `go get azcosmos`; `go build` | cgo toolchain only | Downloads whole default matrix in one module |
-| B. Split modules, same repo | `go get azcosmos`; `go build` | cgo toolchain only | Normal builds fetch active driver module; full-graph workflows can fetch default matrix |
-| C. Split modules, separate repo | `go get azcosmos`; `go build` | cgo toolchain only | Same as Option B, but the active driver module comes from a separate repo |
+| A. Single bundled module | `go get cosmos`; `go build` | cgo toolchain only | Downloads whole default matrix in one module |
+| B. Split modules, same repo | `go get cosmos`; `go build` | cgo toolchain only | Normal builds fetch active driver module; full-graph workflows can fetch default matrix |
+| C. Split modules, separate repo | `go get cosmos`; `go build` | cgo toolchain only | Same as Option B, but the active driver module comes from a separate repo |
 | Advanced dynamic library | imports/configures advanced path | customer-managed native library | Downloads only Go wrapper; customer supplies native payload |
 
 ## 13. Repository and release comparison
@@ -730,15 +743,15 @@ for Go repository.
 
 ```text
 Common path:
-  go get azcosmos
+  go get cosmos
   go build
   default driver selected through build tags
 
 Repository placement:
-  azcosmos Go code in azure-sdk-for-go
+  cosmos Go code in azure-sdk-for-go
   native driver modules in a separate Azure-owned repository
 ```
 
 For customer experience, the separate-repo option can still be nearly invisible
-if the driver packages are normal Go modules and the public `azcosmos` package
+if the driver packages are normal Go modules and the public `cosmos` package
 imports the default drivers automatically.

--- a/sdk/data/azcosmos/docs/go-ffi-distribution-design.md
+++ b/sdk/data/azcosmos/docs/go-ffi-distribution-design.md
@@ -1,12 +1,26 @@
 <!-- cspell:ignore amd64 arm64 azcosmos azcosmoscore checksums glibc GOARCH GOOS libc LDFLAGS libazurecosmos librdkafka metapackage musl onnxruntime SRCDIR -->
 # Go FFI native-driver distribution design
 
-> **Status:** Design discussion for Go Central SDK and architecture-board review.
+> **Status:** Decided — Option C selected. Retained for Go Central SDK and
+> architecture-board review of the rationale and considered options.
 >
 > This document captures the native-driver distribution problem for a Go SDK
 > backed by the Rust Cosmos driver through FFI. It focuses on customer
 > experience, Go module layout, native binary placement, and the trade-offs that
 > need Go Central SDK alignment.
+
+## Decision
+
+**We are going with Option C: split modules, native drivers in a separate
+Azure-owned repository ([§7](#7-option-c-split-modules-native-drivers-in-a-separate-repository)).**
+The public `azcosmos` SDK stays in `azure-sdk-for-go`; the platform-specific
+native driver binaries live in a separate Azure-owned repository and are pulled
+in as normal Go modules through build-tagged imports, so the customer flow stays
+plain `go get` / `go build`.
+
+Options A and B and the alternatives below are retained as the considered-options
+trail and rationale for this choice — readers who only want the selected model
+can jump straight to [§7](#7-option-c-split-modules-native-drivers-in-a-separate-repository).
 
 ## 1. Problem statement
 
@@ -379,8 +393,8 @@ only the current platform's native driver.
 ## 7. Option C: split modules, native drivers in a separate repository
 
 This keeps the customer-facing SDK in `azure-sdk-for-go`, but moves the binary
-payload modules to a separate Azure-owned repository. This is the preferred
-direction for further design because it keeps the large binaries out of the
+payload modules to a separate Azure-owned repository. **This is the selected
+distribution model for Go v2** because it keeps the large binaries out of the
 Azure SDK for Go repository without changing the common customer flow.
 
 ```text
@@ -699,9 +713,9 @@ These are the questions that likely need board-level alignment:
 ## 15. Current read
 
 The split-module design with native driver modules in a **separate Azure-owned
-repository** is the strongest candidate for discussion. It preserves the
-common-platform customer experience while keeping large binary artifacts out of
-the Azure SDK for Go repository.
+repository** (Option C) is the selected model. It preserves the common-platform
+customer experience while keeping large binary artifacts out of the Azure SDK
+for Go repository.
 
 ```text
 Common path:

--- a/sdk/data/azcosmos/docs/go-v2-ffi-decision.md
+++ b/sdk/data/azcosmos/docs/go-v2-ffi-decision.md
@@ -98,6 +98,11 @@ The initial packaging discussion is scoped to mainstream targets:
 | macOS | ARM64/Apple Silicon, x64/Intel |
 | Linux glibc | x64/amd64, ARM64 |
 
+Windows also has a native ABI/toolchain dimension. The implementation design is
+expected to produce both GNU/MinGW-compatible `.a` artifacts for cgo linking and
+MSVC-compatible `.lib` artifacts where needed, but this decision record does not
+finalize that split.
+
 Linux musl/Alpine is intentionally not counted in the baseline until the Go
 packaging plan decides whether it is in scope for the initial release.
 

--- a/sdk/data/azcosmos/docs/go-v2-ffi-decision.md
+++ b/sdk/data/azcosmos/docs/go-v2-ffi-decision.md
@@ -1,0 +1,161 @@
+<!-- cspell:ignore amd64 azcosmos cgo glibc musl -->
+# Go v2 Cosmos SDK FFI decision
+
+> **Status:** Proposed
+>
+> This document records the Go SDK direction to use the Rust Cosmos driver
+> through FFI for the Go v2 implementation. It is intended to be reviewed with
+> the Go Central SDK team and used as the decision record for the Go package.
+
+## Context
+
+Go v2 needs a path that can deliver in the current timeframe while staying close
+to the Rust Cosmos driver's behavior. A time-boxed pure-Go spike proved that a
+gateway-mode core path can be ported and validated, but it also clarified the
+central trade-off:
+
+> Is avoiding cgo and native packaging worth re-owning driver logic that Rust
+> already implements?
+
+Both paths are technically feasible:
+
+| Path | Shape |
+|---|---|
+| **FFI path** | Go calls the prebuilt Rust Cosmos driver through cgo and a C ABI. |
+| **Pure-Go port** | Go reimplements the driver behavior directly in Go. |
+
+## Decision
+
+- Go v2 proceeds with the **Rust-driver FFI path** for the current delivery
+  window.
+- The Go binding consumes the **prebuilt Rust native driver** through cgo and the
+  C ABI surface.
+- Packaging mechanics, platform matrix, signing, ABI versioning, and native
+  artifact placement are handled by a separate distribution design.
+
+## Why FFI for Go v2
+
+FFI has the better short-term delivery shape:
+
+- **Parity:** Go consumes the same driver implementation as Rust.
+- **Velocity:** new Rust-driver behavior does not need to be re-ported before Go
+  can benefit.
+- **Risk containment:** the hard driver logic stays in one implementation.
+- **Testing leverage:** the Go binding can validate language-level behavior
+  against the Rust driver's known behavior instead of re-proving the full driver.
+
+The main cost is not the Go wrapper itself. The main cost is **Go packaging and
+customer deployment experience**.
+
+## What the pure-Go spike proved
+
+The pure-Go spike showed that a gateway-mode core path can be ported in
+idiomatic Go:
+
+- `CGO_ENABLED=0`
+- zero third-party dependencies
+- point create/read
+- retry and routing behavior
+- basic failover behavior
+- cross-partition unordered query fan-out
+- unsupported-query rejection parity
+
+The spike was validated with a scenario-based differential harness. The harness
+put an HTTP endpoint in front of the Rust driver's in-memory emulator so the Go
+port and the Rust driver could run against the same emulator-backed state and
+compare caller-visible outcomes.
+
+This is valuable evidence: the Go port is credible. It is also a useful
+validation reference for Go-visible behavior. It is not the selected Go v2
+delivery path because every Rust-driver change would need to be tracked, ported,
+and revalidated in Go.
+
+## Packaging implications
+
+Cosmos Go v1 is consumed like a normal Go SDK:
+
+```bash
+go get github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos
+go build ./...
+```
+
+There is no Rust compiler, native shared library, or post-install step in the
+customer path. If Go v2 uses FFI, prebuilt Rust artifacts can preserve that part
+of the experience, but cgo still requires a C build toolchain. The packaging bar
+is therefore:
+
+> Can the Go SDK still feel like one normal Go module across the supported
+> Windows, macOS, and Linux targets?
+
+That means native Rust driver artifacts must be produced, versioned, selected,
+and linked for the supported Go OS/architecture matrix.
+
+The initial packaging discussion is scoped to mainstream targets:
+
+| OS family | Target combinations discussed |
+|---|---|
+| Windows | x64/amd64, ARM64, possibly x86 as a consideration |
+| macOS | ARM64/Apple Silicon, x64/Intel |
+| Linux glibc | x64/amd64, ARM64 |
+
+Linux musl/Alpine is intentionally not counted in the baseline until the Go
+packaging plan decides whether it is in scope for the initial release.
+
+With an estimated **~5 MB optimized native binary per platform**, a six-target
+matrix is roughly **~30 MB before compression**. Additional targets add to that
+footprint. This is manageable for an initial release, but it is a real packaging
+design point and should not be treated as an implementation detail.
+
+## Alternatives considered
+
+### Pure-Go driver port
+
+The pure-Go path has a strong developer-experience story:
+
+- `CGO_ENABLED=0`
+- normal Go cross-compilation
+- no native runtime dependency
+- Go standard library transport/TLS/runtime
+
+It is not selected for Go v2 because it moves the cost into ownership:
+
+- driver behavior must be reimplemented in Go
+- every Rust-driver change has to be tracked, ported, and revalidated
+- long-term drift becomes the main risk
+- harder areas still need evidence: richer query execution,
+  continuation/split-resume behavior, broader multi-region behavior, change
+  feed, and bulk/batch
+
+### Manual native-library installation as the default
+
+Manual native-library installation is not selected for the common path because it
+breaks the normal `go get` / `go build` expectation for a first-party Go SDK.
+It may still be useful as an advanced mode for customers with strict native
+packaging systems.
+
+### Pure-Go downloader shim
+
+A downloader shim is not selected as the default path. Go modules do not provide
+a standard post-install hook, and build-time network downloads are often blocked
+in enterprise and offline environments.
+
+## Consequences
+
+- Go v2 gets the same driver implementation as Rust, reducing short-term feature
+  drift and implementation risk.
+- Go v2 takes a dependency on `CGO_ENABLED=1` for the native driver path.
+- Customers should not manually install a Rust toolchain or copy native
+  libraries for the common path, but cgo still requires an available C build
+  toolchain.
+- Differential validation remains important so Go-visible behavior can be tested
+  against the Rust driver.
+
+## Non-goals
+
+- This document does not define the final Go packaging shape.
+- This document does not require customers to manually install native libraries
+  for the common path.
+- This document does not introduce direct mode; both the Rust driver and Go v2
+  path discussed here are gateway-mode SDKs.
+- This document does not remove the pure-Go spike as a reference or validation
+  asset.


### PR DESCRIPTION
## Summary

This PR adds design notes for the proposed Cosmos DB Go v2 SDK direction: use the Rust Cosmos driver through FFI instead of reimplementing the driver in Go for the first v2 delivery window.

The reason is scope and parity. The Rust driver already owns the advanced Cosmos behavior we need to keep consistent across SDKs, including routing, retries, session handling, failover behavior, query fan-out, and other driver-level concerns. The Go SDK would provide the Go-facing API surface, while the lower-level driver logic comes from the shared Rust implementation.

## What is included

- A short ADR index and ADR recording the Go v2 FFI direction.
- A supporting decision note explaining the FFI path, the pure-Go spike evidence, and why the pure-Go port is not the selected short-term path.
- A distribution design note for the native Rust driver binaries used by Go, including Go module layout options, platform binary size implications, cgo requirements, default driver selection, ABI/version safety, and review questions for Go Central SDK.

## Important framing

The FFI approach improves delivery speed and Rust-driver parity, but it introduces a real Go packaging decision: how customers get the correct native driver binary for Windows, macOS, and Linux without making the SDK feel unlike a normal Go package.

The current preferred direction in the design note is to keep the public `azcosmos` package in this repo, while considering separately published native-driver Go modules for the platform-specific binaries. That keeps the common `go get` / `go build` path possible while avoiding large binary payloads directly in the Azure SDK for Go repository.