### PR TITLE
Use 'none' environment for auto-release publish

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-go-release.yml
+++ b/eng/pipelines/templates/jobs/archetype-go-release.yml
@@ -84,7 +84,11 @@ stages:
         )
     jobs:
       - deployment: ReleaseGate
-        environment: package-publish
+        # Auto-release is fully automated and must not wait on the package-publish approval gate.
+        ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
+          environment: none
+        ${{ else }}:
+          environment: package-publish
         # when in a deployment, the pool name must be hardcoded. If it is a variable reference, AzDO is unable to locate the pool
         # to check authorization for the definition. As a result the deployment will fail to start looking like this:
         # https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5020114&view=logs&j=999b5c42-1b8c-5343-8349-a768054333f6

--- a/eng/pipelines/templates/jobs/archetype-go-release.yml
+++ b/eng/pipelines/templates/jobs/archetype-go-release.yml
@@ -46,7 +46,7 @@ stages:
   # On a post-merge main CI build, resolve the merged PR and require the 'auto-release' label plus a
   # direct change to this pipeline's package before releasing. Manual/scheduled runs skip this stage
   # and keep releasing on the changelog/tag gate alone.
-  - ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
+  - ${{ if and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
     - template: /eng/common/pipelines/templates/stages/archetype-auto-release-prepare.yml
       parameters:
         DependsOn: ${{ parameters.DependsOn }}
@@ -85,7 +85,7 @@ stages:
     jobs:
       - deployment: ReleaseGate
         # Auto-release is fully automated and must not wait on the package-publish approval gate.
-        ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
+        ${{ if and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
           environment: none
         ${{ else }}:
           environment: package-publish

--- a/eng/pipelines/templates/jobs/archetype-go-release.yml
+++ b/eng/pipelines/templates/jobs/archetype-go-release.yml
@@ -65,7 +65,7 @@ stages:
     displayName: 'Release: ${{ parameters.ServiceDirectory }}'
     # On post-merge main CI, also require the auto-release label + changed-package signal from
     # AutoReleasePrepare. Manual/scheduled runs release on the changelog/tag gate alone.
-    ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
+    ${{ if and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
       dependsOn:
         - CheckRelease
         - AutoReleasePrepare


### PR DESCRIPTION
## What
The publish deployment now targets the 
one environment for auto-release runs.

## Why
Auto-release is fully automated post-merge CI, so a manual approval gate would block the publish flow.

## Impact
Manual releases are unaffected and keep the existing approval-gated package-publish environment.

## Note

one must be, or will be auto-created as, an Azure DevOps environment with no approvals/checks.