### PR TITLE
feat(azeventhubs): add GetPartitionProperties to PartitionClient

### DIFF
--- a/sdk/messaging/azeventhubs/CHANGELOG.md
+++ b/sdk/messaging/azeventhubs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.0.3 (Unreleased)
 
+### Features Added
+
+- Added a `GetPartitionProperties` method to `PartitionClient` and `ProcessorPartitionClient`, so callers do not need the `ConsumerClient` to read partition properties. (#25038)
+
 ### Bugs Fixed
 
 - Fixed missing `consumers.Delete()` call when checkpoint initialization fails, which could block future consumer creation for the affected partition. (#24983)

--- a/sdk/messaging/azeventhubs/internal/amqp_fakes.go
+++ b/sdk/messaging/azeventhubs/internal/amqp_fakes.go
@@ -7,11 +7,12 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2/internal/amqpwrap"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2/internal/auth"
 	"github.com/Azure/go-amqp"
 )
 
 type FakeNSForPartClient struct {
-	NamespaceForAMQPLinks
+	NamespaceForManagementOps
 
 	Receiver          *FakeAMQPReceiver
 	NewReceiverErr    error
@@ -20,6 +21,11 @@ type FakeNSForPartClient struct {
 	Sender          *FakeAMQPSender
 	NewSenderErr    error
 	NewSenderCalled int
+
+	// RPCLink is returned from NewRPCLink. Set this to test management operations.
+	RPCLink        amqpwrap.RPCLink
+	NewRPCLinkErr  error
+	NewRPCLinkCall int
 
 	RecoverFn func(ctx context.Context, clientRevision uint64) error
 }
@@ -61,6 +67,20 @@ func (ns *FakeNSForPartClient) Recover(ctx context.Context, clientRevision uint6
 func (ns *FakeNSForPartClient) NegotiateClaim(ctx context.Context, entityPath string) (context.CancelFunc, <-chan struct{}, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	return cancel, ctx.Done(), nil
+}
+
+func (ns *FakeNSForPartClient) NewRPCLink(ctx context.Context, managementPath string) (amqpwrap.RPCLink, uint64, error) {
+	ns.NewRPCLinkCall++
+
+	if ns.NewRPCLinkErr != nil {
+		return nil, 0, ns.NewRPCLinkErr
+	}
+
+	return ns.RPCLink, 1, nil
+}
+
+func (ns *FakeNSForPartClient) GetTokenForEntity(eventHub string) (*auth.Token, error) {
+	return auth.NewToken(auth.CBSTokenTypeJWT, "fake-token", ""), nil
 }
 
 func (ns *FakeNSForPartClient) NewAMQPSession(ctx context.Context) (amqpwrap.AMQPSession, uint64, error) {
@@ -120,6 +140,45 @@ func (r *FakeAMQPReceiver) Receive(ctx context.Context, o *amqp.ReceiveOptions) 
 func (r *FakeAMQPReceiver) Close(ctx context.Context) error {
 	r.CloseCalled++
 	return r.CloseError
+}
+
+// FakeRPCLink is a fake for the management link. It records each request and
+// returns a canned response.
+type FakeRPCLink struct {
+	// Requests holds each message that was passed to RPC.
+	Requests []*amqp.Message
+
+	// Response is returned from RPC when RPCError is nil.
+	Response *amqpwrap.RPCResponse
+	RPCError error
+
+	NameForLink string
+
+	CloseCalled int
+	CloseError  error
+}
+
+func (l *FakeRPCLink) RPC(ctx context.Context, msg *amqp.Message) (*amqpwrap.RPCResponse, error) {
+	l.Requests = append(l.Requests, msg)
+
+	if l.RPCError != nil {
+		return nil, l.RPCError
+	}
+
+	return l.Response, nil
+}
+
+func (l *FakeRPCLink) ConnID() uint64 {
+	return 1
+}
+
+func (l *FakeRPCLink) LinkName() string {
+	return l.NameForLink
+}
+
+func (l *FakeRPCLink) Close(ctx context.Context) error {
+	l.CloseCalled++
+	return l.CloseError
 }
 
 type FakeAMQPSender struct {

--- a/sdk/messaging/azeventhubs/internal/links.go
+++ b/sdk/messaging/azeventhubs/internal/links.go
@@ -18,9 +18,16 @@ type AMQPLink interface {
 	LinkName() string
 }
 
+// LinksForManagementOps are the functions that the management operations use within Links[T].
+type LinksForManagementOps interface {
+	// RetryManagement is [Links.RetryManagement]
+	RetryManagement(ctx context.Context, eventName azlog.Event, operation string, retryOptions exported.RetryOptions, fn func(ctx context.Context, lwid LinkWithID[amqpwrap.RPCLink]) error) error
+}
+
 // LinksForPartitionClient are the functions that the PartitionClient uses within Links[T]
-// (for unit testing only)
 type LinksForPartitionClient[LinkT AMQPLink] interface {
+	LinksForManagementOps
+
 	// Retry is [Links.Retry]
 	Retry(ctx context.Context, eventName azlog.Event, operation string, partitionID string, retryOptions exported.RetryOptions, fn func(ctx context.Context, lwid LinkWithID[LinkT]) error) error
 

--- a/sdk/messaging/azeventhubs/mgmt.go
+++ b/sdk/messaging/azeventhubs/mgmt.go
@@ -37,7 +37,7 @@ type GetEventHubPropertiesOptions struct {
 }
 
 // getEventHubProperties gets event hub properties, like the available partition IDs and when the Event Hub was created.
-func getEventHubProperties[LinkT internal.AMQPLink](ctx context.Context, eventName log.Event, ns internal.NamespaceForManagementOps, links *internal.Links[LinkT], eventHub string, retryOptions RetryOptions, options *GetEventHubPropertiesOptions) (EventHubProperties, error) {
+func getEventHubProperties(ctx context.Context, eventName log.Event, ns internal.NamespaceForManagementOps, links internal.LinksForManagementOps, eventHub string, retryOptions RetryOptions, options *GetEventHubPropertiesOptions) (EventHubProperties, error) {
 	var props EventHubProperties
 
 	err := links.RetryManagement(ctx, eventName, "getEventHubProperties", retryOptions, func(ctx context.Context, lwid internal.LinkWithID[amqpwrap.RPCLink]) error {
@@ -114,7 +114,7 @@ type GetPartitionPropertiesOptions struct {
 
 // getPartitionProperties gets properties for a specific partition. This includes data like the last enqueued sequence number, the first sequence
 // number and when an event was last enqueued to the partition.
-func getPartitionProperties[LinkT internal.AMQPLink](ctx context.Context, eventName log.Event, ns internal.NamespaceForManagementOps, links *internal.Links[LinkT], eventHub string, partitionID string, retryOptions RetryOptions, options *GetPartitionPropertiesOptions) (PartitionProperties, error) {
+func getPartitionProperties(ctx context.Context, eventName log.Event, ns internal.NamespaceForManagementOps, links internal.LinksForManagementOps, eventHub string, partitionID string, retryOptions RetryOptions, options *GetPartitionPropertiesOptions) (PartitionProperties, error) {
 	var props PartitionProperties
 
 	err := links.RetryManagement(ctx, eventName, "getPartitionProperties", retryOptions, func(ctx context.Context, lwid internal.LinkWithID[amqpwrap.RPCLink]) error {

--- a/sdk/messaging/azeventhubs/partition_client.go
+++ b/sdk/messaging/azeventhubs/partition_client.go
@@ -64,6 +64,7 @@ type PartitionClient struct {
 	eventHub         string
 	instanceID       string
 	links            internal.LinksForPartitionClient[amqpwrap.AMQPReceiverCloser]
+	namespace        internal.NamespaceForManagementOps
 	offsetExpression string
 	ownerLevel       *int64
 	partitionID      string
@@ -188,6 +189,13 @@ func (pc *PartitionClient) ReceiveEvents(ctx context.Context, count int, options
 	return events, nil
 }
 
+// GetPartitionProperties gets properties for the partition that this client receives from. This includes
+// data like the last enqueued sequence number, the first sequence number and when an event was last enqueued
+// to the partition.
+func (pc *PartitionClient) GetPartitionProperties(ctx context.Context, options *GetPartitionPropertiesOptions) (PartitionProperties, error) {
+	return getPartitionProperties(ctx, EventConsumer, pc.namespace, pc.links, pc.eventHub, pc.partitionID, pc.retryOptions, options)
+}
+
 // Close releases resources for this client.
 func (pc *PartitionClient) Close(ctx context.Context) error {
 	if pc.links != nil {
@@ -262,7 +270,7 @@ func (pc *PartitionClient) init(ctx context.Context) error {
 }
 
 type partitionClientArgs struct {
-	namespace internal.NamespaceForAMQPLinks
+	namespace internal.NamespaceForManagementOps
 
 	consumerGroup string
 	eventHub      string
@@ -290,6 +298,7 @@ func newPartitionClient(args partitionClientArgs, options *PartitionClientOption
 	client := &PartitionClient{
 		consumerGroup:    args.consumerGroup,
 		eventHub:         args.eventHub,
+		namespace:        args.namespace,
 		offsetExpression: offsetExpr,
 		ownerLevel:       options.OwnerLevel,
 		partitionID:      args.partitionID,

--- a/sdk/messaging/azeventhubs/partition_client_unit_test.go
+++ b/sdk/messaging/azeventhubs/partition_client_unit_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2/internal"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2/internal/amqpwrap"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2/internal/test"
 	"github.com/Azure/go-amqp"
 	"github.com/stretchr/testify/require"
@@ -217,6 +218,102 @@ func TestUnit_PartitionClient_PrefetchLimit(t *testing.T) {
 		client, err := newPartitionClient(int32(defaultMaxCreditSize) + 1)
 		require.EqualError(t, err, fmt.Sprintf("options.Prefetch cannot exceed %d", defaultMaxCreditSize))
 		require.Nil(t, client)
+	})
+}
+
+func TestUnit_PartitionClient_GetPartitionProperties(t *testing.T) {
+	lastEnqueuedOn := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	newFakeNS := func() *internal.FakeNSForPartClient {
+		return &internal.FakeNSForPartClient{
+			RPCLink: &internal.FakeRPCLink{
+				Response: &amqpwrap.RPCResponse{
+					Code: 200,
+					Message: &amqp.Message{
+						Value: map[string]any{
+							"name":                          "eventHubName",
+							"partition":                     "101",
+							"begin_sequence_number":         int64(100),
+							"last_enqueued_sequence_number": int64(200),
+							"last_enqueued_offset":          "300",
+							"last_enqueued_time_utc":        lastEnqueuedOn,
+							"is_partition_empty":            false,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	expectedProps := PartitionProperties{
+		BeginningSequenceNumber:    100,
+		EventHubName:               "eventHubName",
+		IsEmpty:                    false,
+		LastEnqueuedOffset:         "300",
+		LastEnqueuedOn:             lastEnqueuedOn,
+		LastEnqueuedSequenceNumber: 200,
+		PartitionID:                "101",
+	}
+
+	t.Run("returns the properties for this client's partition", func(t *testing.T) {
+		ns := newFakeNS()
+
+		client, err := newPartitionClient(partitionClientArgs{
+			namespace:   ns,
+			eventHub:    "eventHubName",
+			partitionID: "101",
+		}, nil)
+		require.NoError(t, err)
+
+		props, err := client.GetPartitionProperties(context.Background(), nil)
+		require.NoError(t, err)
+		require.Equal(t, expectedProps, props)
+
+		// the client uses its own partition ID, the caller does not pass one.
+		rpcLink := ns.RPCLink.(*internal.FakeRPCLink)
+		require.Equal(t, 1, len(rpcLink.Requests))
+		require.Equal(t, "READ", rpcLink.Requests[0].ApplicationProperties["operation"])
+		require.Equal(t, "com.microsoft:partition", rpcLink.Requests[0].ApplicationProperties["type"])
+		require.Equal(t, "eventHubName", rpcLink.Requests[0].ApplicationProperties["name"])
+		require.Equal(t, "101", rpcLink.Requests[0].ApplicationProperties["partition"])
+		require.NotEmpty(t, rpcLink.Requests[0].ApplicationProperties["security_token"])
+
+		test.RequireClose(t, client)
+	})
+
+	t.Run("fails after the client is closed", func(t *testing.T) {
+		client, err := newPartitionClient(partitionClientArgs{
+			namespace:   newFakeNS(),
+			eventHub:    "eventHubName",
+			partitionID: "101",
+		}, nil)
+		require.NoError(t, err)
+
+		test.RequireClose(t, client)
+
+		props, err := client.GetPartitionProperties(context.Background(), nil)
+		require.EqualError(t, err, "client has been closed by user")
+		require.Equal(t, PartitionProperties{}, props)
+	})
+
+	t.Run("ProcessorPartitionClient forwards to the inner client", func(t *testing.T) {
+		client, err := newPartitionClient(partitionClientArgs{
+			namespace:   newFakeNS(),
+			eventHub:    "eventHubName",
+			partitionID: "101",
+		}, nil)
+		require.NoError(t, err)
+
+		processorClient := &ProcessorPartitionClient{
+			partitionID: "101",
+			innerClient: client,
+		}
+
+		props, err := processorClient.GetPartitionProperties(context.Background(), nil)
+		require.NoError(t, err)
+		require.Equal(t, expectedProps, props)
+
+		test.RequireClose(t, client)
 	})
 }
 

--- a/sdk/messaging/azeventhubs/processor_partition_client.go
+++ b/sdk/messaging/azeventhubs/processor_partition_client.go
@@ -33,6 +33,15 @@ func (c *ProcessorPartitionClient) ReceiveEvents(ctx context.Context, count int,
 	return c.innerClient.ReceiveEvents(ctx, count, options)
 }
 
+// GetPartitionProperties gets properties for the partition that this client receives from. This includes
+// data like the last enqueued sequence number, the first sequence number and when an event was last enqueued
+// to the partition.
+//
+// See [PartitionClient.GetPartitionProperties] for more information.
+func (p *ProcessorPartitionClient) GetPartitionProperties(ctx context.Context, options *GetPartitionPropertiesOptions) (PartitionProperties, error) {
+	return p.innerClient.GetPartitionProperties(ctx, options)
+}
+
 // UpdateCheckpoint updates the checkpoint in the CheckpointStore. New Processors will resume after
 // this checkpoint for this partition.
 func (p *ProcessorPartitionClient) UpdateCheckpoint(ctx context.Context, latestEvent *ReceivedEventData, options *UpdateCheckpointOptions) error {


### PR DESCRIPTION
## Summary

`ConsumerClient` and `ProducerClient` both have a `GetPartitionProperties` method. `PartitionClient` does not. An application that passes a `PartitionClient` around as its unit of per-partition work must also pass the parent `ConsumerClient`, only to read partition properties.

Fixes #25038.

## Motivation

The usual reason to read partition properties from a consumer is a lag calculation: compare the last enqueued sequence number against the position that the consumer reached. The data is partition scoped, and the client that needs it is partition scoped, but the method lives on the parent client. So the caller threads two objects through every call path where one would do.

`PartitionClient` already has what the call needs. Its constructor builds an `internal.Links` with the `<eventHub>/$management` path. Two things blocked the method. The client dropped the namespace after the constructor used it, and the narrow `LinksForPartitionClient` interface did not expose `RetryManagement`.

## Changes

`PartitionClient.GetPartitionProperties` and `ProcessorPartitionClient.GetPartitionProperties` are new. Both are additive. Neither takes a partition ID, because each client already knows its own partition. This matches the .NET `PartitionReceiver.GetPartitionPropertiesAsync` shape. Both reuse the existing `PartitionProperties` and `GetPartitionPropertiesOptions` types.

`PartitionClient` now stores its namespace, and `partitionClientArgs.namespace` widens from `internal.NamespaceForAMQPLinks` to `internal.NamespaceForManagementOps`.

A new internal `LinksForManagementOps` interface holds `RetryManagement`, and `LinksForPartitionClient` embeds it. `getEventHubProperties` and `getPartitionProperties` in `mgmt.go` now take that interface instead of a concrete `*internal.Links[LinkT]`, which drops a type parameter from both. Every existing call site stays unchanged, and fake link injection in the unit tests keeps working.

`FakeNSForPartClient` gains `NewRPCLink` and `GetTokenForEntity`, and a new `FakeRPCLink` records requests and returns a canned response, so management operations are testable without live resources.

## Test plan

`TestUnit_PartitionClient_GetPartitionProperties` covers three cases with fakes and no live Event Hubs namespace: the returned properties match the canned response; the outgoing request carries the client's own partition ID, event hub name, `com.microsoft:partition` type, and a security token; and a call after `Close` returns `client has been closed by user`. A third subtest makes sure the `ProcessorPartitionClient` forwarder returns the same properties.

Run from `sdk/messaging/azeventhubs`:

- `go build ./...` passes.
- `go vet ./...` reports nothing.
- `gofmt -l .` prints nothing.
- `go test ./...` passes. Live tests self skip without the environment variables.
- `golangci-lint run -c ../../../eng/.golangci.yml ./...` reports 0 issues.

## Notes for reviewers

Each `PartitionClient` opens its own `$management` link on first use, rather than sharing the `ConsumerClient` link. This matches the existing `ProducerClient` cost model. An application that polls properties on many partition clients holds one management link per client.

`getPartitionPropertiesInternal` passes `context.Background()` to `rpcLink.RPC` instead of the caller's `ctx` (mgmt.go). This is pre-existing and it affects the current `ConsumerClient` and `ProducerClient` methods too. The new method inherits the same behavior. A fix belongs in a separate change.

The unreleased CHANGELOG heading is `2.0.3`, a patch number, and this is a feature. The heading is left alone for the release process to set.
