### PR TITLE
Pin go-git to v5.16.5 to fix SDK generation in sparse-checkout repos

### DIFF
--- a/eng/tools/generator/CHANGELOG.md
+++ b/eng/tools/generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.4.17 (2026-07-28)
+
+### Bugs Fixed
+
+- Pinned `github.com/go-git/go-git/v5` to `v5.16.5`. Newer `v5` releases reject repositories that enable the `worktreeConfig` extension, which is how the SDK automation pipelines check out `azure-sdk-for-go` (`git sparse-checkout init`), causing generation to fail with `core.repositoryformatversion does not support extension: worktreeconfig`.
+
 ## 0.4.16 (2026-06-29)
 
 ### Features Added

--- a/eng/tools/generator/go.mod
+++ b/eng/tools/generator/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/eng/tools/internal v0.0.0-20260727183921-c01f3f9aef9d
 	github.com/Masterminds/semver v1.5.0
 	github.com/ahmetb/go-linq/v3 v3.2.0
-	github.com/go-git/go-git/v5 v5.19.1
+	github.com/go-git/go-git/v5 v5.16.5
 	github.com/goccy/go-yaml v1.19.2
 	github.com/google/go-github/v62 v62.0.0
 	github.com/spf13/cobra v1.10.2

--- a/eng/tools/generator/go.sum
+++ b/eng/tools/generator/go.sum
@@ -35,8 +35,8 @@ github.com/go-git/go-billy/v5 v5.9.1 h1:8U73XiOTfINdItHVa6z4Gv7ToObcZ6grkqQbLryL
 github.com/go-git/go-billy/v5 v5.9.1/go.mod h1:ExsU+jcGwXTBOnyilvAnEM1wug1IxHr4yP2ZXsNRtV0=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
-github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.16.5 h1:mdkuqblwr57kVfXri5TTH+nMFLNUxIj9Z7F5ykFbw5s=
+github.com/go-git/go-git/v5 v5.16.5/go.mod h1:QOMLpNf1qxuSY4StA/ArOdfFR2TrKEjJiye2kel2m+M=
 github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
 github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=

--- a/eng/tools/generator/repo/workTree_test.go
+++ b/eng/tools/generator/repo/workTree_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package repo
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewWorkTreeWithWorktreeConfigExtension guards against dependency upgrades that break
+// opening repositories initialized with `git sparse-checkout init`, which is how the SDK
+// automation pipelines check out azure-sdk-for-go. That command enables the `worktreeConfig`
+// extension, and go-git v5.17.0 through at least v5.19.1 reject such repositories.
+func TestNewWorkTreeWithWorktreeConfigExtension(t *testing.T) {
+	dir := t.TempDir()
+
+	for _, args := range [][]string{
+		{"init"},
+		{"sparse-checkout", "init"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		output, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v failed: %s", args, string(output))
+	}
+
+	wt, err := NewWorkTree(dir)
+	require.NoError(t, err)
+	require.NotNil(t, wt)
+}

--- a/eng/tools/generator/version.go
+++ b/eng/tools/generator/version.go
@@ -5,5 +5,5 @@ package main
 
 const (
 	moduleName    = "github.com/Azure/azure-sdk-for-go/eng/tools/generator"
-	moduleVersion = "v0.4.16"
+	moduleVersion = "v0.4.17"
 )


### PR DESCRIPTION
## Problem

The `SDK Validation - Go` and `SDK Generation - Go` pipelines are failing for every spec PR, e.g. [build 6625909](https://dev.azure.com/azure-sdk/public/_build/results?buildId=6625909&view=logs&j=406f67d9-8952-5074-7a53-dcb346cb6a5f&t=ccc7497c-4498-591f-65a2-fc3e28e61219):

```
[Go] [ERROR] failed to get sdk repo: cannot open '/mnt/vss/_work/1/s/azure-sdk-for-go':
core.repositoryformatversion does not support extension: worktreeconfig
```

Generation aborts before any work happens, so `generateOutput.json` is never written and `spec-gen-sdk` fails with `[EXT-ERR] Failed to read generateOutput.json`.

## Root cause

#27267 (`***NO_CI*** update Go dependencies`) bumped `github.com/go-git/go-git/v5` from `v5.16.5` to `v5.19.1` in `eng/tools/generator`.

go-git `v5.17.0` added `verifyExtensions()` in `repository_extensions.go`, which rejects unknown `extensions.*` config keys. Its allow-list is case-mismatched — extension names are normalized with `strings.ToLower`, but the allow-list keys are camelCase, so the standard v0-compatible extensions never match:

```go
extensionsValidForV0 = map[string]struct{}{
    "noop":            {},
    "partialClone":    {},   // never matches "partialclone"
    "preciousObjects": {},   // never matches "preciousobjects"
    "worktreeConfig":  {},   // never matches "worktreeconfig"
}
...
for _, ext := range needed {                       // ext.name is strings.ToLower(opt.Key)
    if _, ok := extensionsValidForV0[ext.name]; !ok {
        unsupported = append(unsupported, ext.name)
    }
}
```

The pipelines check out `azure-sdk-for-go` via the `Sparse checkout repositories` step:

```
==> git clone --no-checkout --filter=tree:0 https://github.com/Azure/azure-sdk-for-go .
==> git sparse-checkout init
```

`git sparse-checkout init` writes `extensions.worktreeConfig = true` into `.git/config` (with `repositoryformatversion = 0`), so `repo.OpenSDKRepository` → `git.PlainOpenWithOptions` now fails.

Upstream is aware — go-git/go-git#2156 and go-git/go-git#2171 — and it is fixed on go-git's `main` (v6) branch, but **no v5 release contains the fix**: `v5.19.1` is the latest v5 tag and the `releases/v5.x` branch still carries the camelCase map.

## Fix

Pin `github.com/go-git/go-git/v5` back to `v5.16.5`, the last release before extension validation was introduced. `eng/tools/generator` is the only module in the repo that depends on go-git, so the change is contained.

Also adds a regression test that initializes a repository with `git sparse-checkout init` and asserts `NewWorkTree` succeeds, so a future dependency bump fails in CI instead of silently breaking SDK generation.

We can drop the pin once a fixed `v5.x` release ships.

## Verification

- Reproduced the exact CI error standalone against `v5.19.1`, and confirmed `v5.16.5` opens the same repository successfully.
- The new test **fails** on `v5.19.1` with the identical error message and **passes** on `v5.16.5`.
- `go build ./...` and `go test ./...` pass for `eng/tools/generator`.
