### PR TITLE
[compute] Update armbulkactions 0.2.0 release date for release plan 35410

### DIFF
--- a/sdk/resourcemanager/compute/armbulkactions/CHANGELOG.md
+++ b/sdk/resourcemanager/compute/armbulkactions/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.2.0 (2026-07-22)
+## 0.2.0 (2026-07-30)
 ### Features Added
 
 - New value `ResourceOperationTypeGetInstanceView` added to enum type `ResourceOperationType`


### PR DESCRIPTION
Updates the `sdk/resourcemanager/compute/armbulkactions` **0.2.0** CHANGELOG release date to `2026-07-30` so the release pipeline recognizes a valid planned release date.

Unblocks the release of the package for release plan **35410**. The generation PR (#27227) is already merged; only the changelog release date needs to reflect the planned release day. No code changes -- changelog date only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>