### PR TITLE
[azcosmos] Deduplicate partition key ranges by ID during cache refresh

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 <!-- cSpell:ignore documentdb unmarshalling -->
 
+## 1.6.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+* Fixed partition key range cache refreshes failing against containers undergoing physical partition splits. A change-feed drain accumulates every page, so a range that is updated mid-split is re-delivered as a second revision of the same range ID; the routing map now deduplicates by range ID (keeping the latest revision) before validating range continuity, instead of rejecting the set with a "service returned an incomplete set of ranges" error reporting that the range overlaps itself. A full refresh that still observes an incomplete set is now retried once before failing. See [Issue 27246](https://github.com/Azure/azure-sdk-for-go/issues/27246).
+
+### Other Changes
+
 ## 1.6.0-beta.1 (2026-07-16)
 
 ### Features Added

--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bugs Fixed
 
-* Fixed partition key range cache refreshes failing against containers undergoing physical partition splits. A change-feed drain accumulates every page, so a range that is updated mid-split is re-delivered as a second revision of the same range ID; the routing map now deduplicates by range ID (keeping the latest revision) before validating range continuity, instead of rejecting the set with a "service returned an incomplete set of ranges" error reporting that the range overlaps itself. A full refresh that still observes an incomplete set is now retried once before failing. See [PR 27282](https://github.com/Azure/azure-sdk-for-go/pull/27282).
+* Fixed partition key range cache refreshes failing against containers undergoing physical partition splits. A change-feed drain accumulates every page, so a range that is updated mid-split is re-delivered as a second revision of the same range ID; the routing map now deduplicates by range ID (keeping the latest revision) before validating range continuity, instead of rejecting the set with a "service returned an incomplete set of ranges" error reporting that the range overlaps itself. A full refresh that still observes an incomplete set is now retried up to three times with bounded jittered backoff before failing. See [PR 27282](https://github.com/Azure/azure-sdk-for-go/pull/27282).
 
 ### Other Changes
 

--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bugs Fixed
 
-* Fixed partition key range cache refreshes failing against containers undergoing physical partition splits. A change-feed drain accumulates every page, so a range that is updated mid-split is re-delivered as a second revision of the same range ID; the routing map now deduplicates by range ID (keeping the latest revision) before validating range continuity, instead of rejecting the set with a "service returned an incomplete set of ranges" error reporting that the range overlaps itself. A full refresh that still observes an incomplete set is now retried once before failing. See [Issue 27246](https://github.com/Azure/azure-sdk-for-go/issues/27246).
+* Fixed partition key range cache refreshes failing against containers undergoing physical partition splits. A change-feed drain accumulates every page, so a range that is updated mid-split is re-delivered as a second revision of the same range ID; the routing map now deduplicates by range ID (keeping the latest revision) before validating range continuity, instead of rejecting the set with a "service returned an incomplete set of ranges" error reporting that the range overlaps itself. A full refresh that still observes an incomplete set is now retried once before failing. See [PR 27282](https://github.com/Azure/azure-sdk-for-go/pull/27282).
 
 ### Other Changes
 

--- a/sdk/data/azcosmos/cosmos_collection_routing_map.go
+++ b/sdk/data/azcosmos/cosmos_collection_routing_map.go
@@ -25,8 +25,8 @@ type collectionRoutingMap struct {
 }
 
 // newCollectionRoutingMap creates a new collectionRoutingMap from a set of ranges.
-// It filters out "gone" parent ranges (identified via the Parents field on child ranges)
-// and sorts the remaining ranges by MinInclusive.
+// It filters out "gone" parent ranges (identified via the Parents field on child ranges),
+// deduplicates the survivors by range ID, and sorts them by MinInclusive.
 func newCollectionRoutingMap(ranges []partitionKeyRange, changeFeedETag string) *collectionRoutingMap {
 	goneRanges := make(map[string]bool)
 	for _, r := range ranges {
@@ -35,16 +35,32 @@ func newCollectionRoutingMap(ranges []partitionKeyRange, changeFeedETag string) 
 		}
 	}
 
-	// Filter out gone ranges
+	// Filter out gone ranges and deduplicate by range ID, keeping the last
+	// revision seen. A change-feed drain accumulates every page, so a range that
+	// is updated while a split is in progress is re-delivered on a later page as
+	// a new revision of the same ID. Records arrive in change-feed order, so the
+	// later one is current. Deduplicating here — before sorting and before
+	// isCompleteSetOfRanges — matches the .NET, Java, Python and Rust SDKs, which
+	// all key by range ID prior to validating continuity. Without it, the two
+	// revisions sort adjacently and the map is rejected as overlapping itself.
+	indexByID := make(map[string]int, len(ranges))
 	filtered := make([]partitionKeyRange, 0, len(ranges))
 	for _, r := range ranges {
-		if !goneRanges[r.ID] {
-			filtered = append(filtered, r)
+		if goneRanges[r.ID] {
+			continue
 		}
+		if i, seen := indexByID[r.ID]; seen {
+			filtered[i] = r
+			continue
+		}
+		indexByID[r.ID] = len(filtered)
+		filtered = append(filtered, r)
 	}
 
-	// Sort by MinInclusive using length-aware comparison for HPK boundaries
-	sort.Slice(filtered, func(i, j int) bool {
+	// Sort by MinInclusive using length-aware comparison for HPK boundaries.
+	// The sort is stable so that ranges sharing a boundary keep change-feed order,
+	// keeping discontinuity diagnostics reproducible for invalid snapshots.
+	sort.SliceStable(filtered, func(i, j int) bool {
 		return epk.CompareEPK(filtered[i].MinInclusive, filtered[j].MinInclusive) < 0
 	})
 
@@ -90,12 +106,30 @@ func (crm *collectionRoutingMap) tryCombine(newRanges []partitionKeyRange, newET
 		}
 	}
 
-	// Build sorted slice
+	// Build the combined slice in a deterministic order: existing ranges first
+	// (already sorted), then any new range IDs in change-feed arrival order.
+	// Ranging over combinedByID would use Go's randomized map iteration order,
+	// which makes discontinuity diagnostics non-reproducible.
 	combined := make([]partitionKeyRange, 0, len(combinedByID))
-	for _, r := range combinedByID {
+	appended := make(map[string]bool, len(combinedByID))
+	appendOnce := func(id string) {
+		if appended[id] {
+			return
+		}
+		r, ok := combinedByID[id]
+		if !ok {
+			return
+		}
+		appended[id] = true
 		combined = append(combined, r)
 	}
-	sort.Slice(combined, func(i, j int) bool {
+	for _, r := range crm.orderedRanges {
+		appendOnce(r.ID)
+	}
+	for _, r := range newRanges {
+		appendOnce(r.ID)
+	}
+	sort.SliceStable(combined, func(i, j int) bool {
 		return epk.CompareEPK(combined[i].MinInclusive, combined[j].MinInclusive) < 0
 	})
 

--- a/sdk/data/azcosmos/cosmos_collection_routing_map_test.go
+++ b/sdk/data/azcosmos/cosmos_collection_routing_map_test.go
@@ -71,8 +71,139 @@ func Test_newCollectionRoutingMap_rangeByID(t *testing.T) {
 	require.Equal(t, "05C1CFFFFFFFF8", r.MaxExclusive)
 }
 
+func Test_newCollectionRoutingMap_deduplicatesRepeatedRangeID(t *testing.T) {
+	// A change-feed drain accumulates every page, so a range that is touched while
+	// a split is in progress is re-delivered on a later page. The routing map must
+	// collapse the revisions instead of reporting that the range overlaps itself.
+	// See https://github.com/Azure/azure-sdk-for-go/issues/27246
+	ranges := []partitionKeyRange{
+		{ID: "0", MinInclusive: "", MaxExclusive: "05C1CFFFFFFFF8"},
+		{ID: "1", MinInclusive: "05C1CFFFFFFFF8", MaxExclusive: "FF"},
+		{ID: "1", MinInclusive: "05C1CFFFFFFFF8", MaxExclusive: "FF"},
+	}
+
+	rm := newCollectionRoutingMap(ranges, "etag1")
+	require.Equal(t, 2, len(rm.orderedRanges))
+	require.Equal(t, "0", rm.orderedRanges[0].ID)
+	require.Equal(t, "1", rm.orderedRanges[1].ID)
+	require.True(t, isCompleteSetOfRanges(rm.orderedRanges))
+}
+
+func Test_newCollectionRoutingMap_duplicateRangeID_lastRevisionWins(t *testing.T) {
+	// Records arrive in change-feed order, so a later revision of a range ID
+	// supersedes an earlier one. Matches the last-write-wins semantics of the
+	// .NET, Java, Python and Rust SDKs.
+	ranges := []partitionKeyRange{
+		{ID: "0", MinInclusive: "", MaxExclusive: "05C1CFFFFFFFF8"},
+		{ID: "1", MinInclusive: "05C1CFFFFFFFF8", MaxExclusive: "FF"},
+		{ID: "0", MinInclusive: "", MaxExclusive: "0BC1"},
+		{ID: "1", MinInclusive: "0BC1", MaxExclusive: "FF"},
+	}
+
+	rm := newCollectionRoutingMap(ranges, "etag1")
+	require.Equal(t, 2, len(rm.orderedRanges))
+	require.True(t, isCompleteSetOfRanges(rm.orderedRanges))
+
+	require.Equal(t, "0", rm.orderedRanges[0].ID)
+	require.Equal(t, "0BC1", rm.orderedRanges[0].MaxExclusive, "later revision of range 0 should win")
+	require.Equal(t, "1", rm.orderedRanges[1].ID)
+	require.Equal(t, "0BC1", rm.orderedRanges[1].MinInclusive, "later revision of range 1 should win")
+
+	// rangeByID must agree with orderedRanges
+	require.Equal(t, "0BC1", rm.rangeByID["0"].MaxExclusive)
+	require.Equal(t, "0BC1", rm.rangeByID["1"].MinInclusive)
+}
+
+func Test_newCollectionRoutingMap_duplicateRangeID_goneStillFiltered(t *testing.T) {
+	// A split that completes mid-drain re-delivers the parent with an updated
+	// status alongside its children, and unrelated ranges can be re-delivered in
+	// the same drain. Every revision of the parent must be dropped, while the
+	// live duplicate is collapsed to its latest revision.
+	ranges := []partitionKeyRange{
+		{ID: "0", MinInclusive: "", MaxExclusive: "05C1CFFFFFFFF8"},
+		{ID: "3", MinInclusive: "05C1CFFFFFFFF8", MaxExclusive: "FF"},
+		{ID: "1", MinInclusive: "", MaxExclusive: "02E0", Parents: []string{"0"}},
+		{ID: "2", MinInclusive: "02E0", MaxExclusive: "05C1CFFFFFFFF8", Parents: []string{"0"}},
+		// Parent re-delivered as Offline, and live range "3" re-delivered as Online.
+		{ID: "0", MinInclusive: "", MaxExclusive: "05C1CFFFFFFFF8", Status: "Offline"},
+		{ID: "3", MinInclusive: "05C1CFFFFFFFF8", MaxExclusive: "FF", Status: "Online"},
+	}
+
+	rm := newCollectionRoutingMap(ranges, "etag1")
+	require.Equal(t, 3, len(rm.orderedRanges))
+	require.Equal(t, "1", rm.orderedRanges[0].ID)
+	require.Equal(t, "2", rm.orderedRanges[1].ID)
+	require.Equal(t, "3", rm.orderedRanges[2].ID)
+	// Both revisions of the gone parent are dropped...
+	require.True(t, rm.isGone("0"))
+	require.NotContains(t, rm.rangeByID, "0")
+	// ...and the live duplicate collapses to its latest revision.
+	require.Equal(t, "Online", rm.orderedRanges[2].Status)
+	require.True(t, isCompleteSetOfRanges(rm.orderedRanges))
+}
+
+func Test_newCollectionRoutingMap_deterministicOrderingForInvalidSnapshot(t *testing.T) {
+	// Two distinct IDs sharing a boundary can only appear in an invalid snapshot,
+	// which is exactly when the discontinuity diagnostic ends up in a customer's
+	// error message. The ordering must be reproducible so the diagnostic is too.
+	//
+	// The tied pair sits at index 7 of 13 records: that is large enough for
+	// sort.Slice to leave its stable insertion-sort path, and this particular
+	// arrangement is one where the unstable sort swaps the pair.
+	ranges := []partitionKeyRange{
+		{ID: "p00", MinInclusive: "04", MaxExclusive: "08"},
+		{ID: "p01", MinInclusive: "08", MaxExclusive: "0C"},
+		{ID: "p02", MinInclusive: "0C", MaxExclusive: "10"},
+		{ID: "p03", MinInclusive: "10", MaxExclusive: "14"},
+		{ID: "p04", MinInclusive: "14", MaxExclusive: "18"},
+		{ID: "p05", MinInclusive: "18", MaxExclusive: "1C"},
+		{ID: "p06", MinInclusive: "1C", MaxExclusive: "20"},
+		{ID: "parent", MinInclusive: "", MaxExclusive: "FF"},
+		{ID: "child", MinInclusive: "", MaxExclusive: "04"},
+		{ID: "p07", MinInclusive: "20", MaxExclusive: "24"},
+		{ID: "p08", MinInclusive: "24", MaxExclusive: "28"},
+		{ID: "p09", MinInclusive: "28", MaxExclusive: "2C"},
+		{ID: "p10", MinInclusive: "2C", MaxExclusive: "FF"},
+	}
+
+	first := describeRangeDiscontinuity(newCollectionRoutingMap(ranges, "").orderedRanges)
+	require.NotEmpty(t, first)
+	for i := 0; i < 50; i++ {
+		rm := newCollectionRoutingMap(ranges, "")
+		require.False(t, isCompleteSetOfRanges(rm.orderedRanges))
+		// Change-feed arrival order is preserved for the tied boundary.
+		require.Equal(t, "parent", rm.orderedRanges[0].ID)
+		require.Equal(t, "child", rm.orderedRanges[1].ID)
+		require.Equal(t, first, describeRangeDiscontinuity(rm.orderedRanges))
+	}
+}
+
+func Test_tryCombine_duplicateRangeID_lastRevisionWins(t *testing.T) {
+	// Guards the combined-slice construction: a range ID that appears both in the
+	// existing map and repeatedly in the incremental batch must be appended once,
+	// carrying its latest revision. Appending per occurrence would leave duplicate
+	// entries that fail the continuity check and collapse the merge to nil.
+	initial := newCollectionRoutingMap([]partitionKeyRange{
+		{ID: "0", MinInclusive: "", MaxExclusive: "05C1CFFFFFFFF8"},
+		{ID: "1", MinInclusive: "05C1CFFFFFFFF8", MaxExclusive: "FF"},
+	}, "etag1")
+
+	// The same range ID is re-delivered across the accumulated incremental pages.
+	newRanges := []partitionKeyRange{
+		{ID: "1", MinInclusive: "05C1CFFFFFFFF8", MaxExclusive: "FF", Status: "Splitting"},
+		{ID: "1", MinInclusive: "05C1CFFFFFFFF8", MaxExclusive: "FF", Status: "Online"},
+	}
+
+	merged := initial.tryCombine(newRanges, "etag2")
+	require.NotNil(t, merged)
+	require.Equal(t, 2, len(merged.orderedRanges))
+	require.Equal(t, "0", merged.orderedRanges[0].ID)
+	require.Equal(t, "1", merged.orderedRanges[1].ID)
+	require.Equal(t, "Online", merged.orderedRanges[1].Status)
+	require.Equal(t, len(merged.rangeByID), len(merged.orderedRanges))
+}
+
 func Test_tryCombine_successfulSplit(t *testing.T) {
-	// Initial state: two ranges
 	initial := newCollectionRoutingMap([]partitionKeyRange{
 		{ID: "0", MinInclusive: "", MaxExclusive: "05C1CFFFFFFFF8"},
 		{ID: "1", MinInclusive: "05C1CFFFFFFFF8", MaxExclusive: "FF"},

--- a/sdk/data/azcosmos/cosmos_partition_key_range_cache.go
+++ b/sdk/data/azcosmos/cosmos_partition_key_range_cache.go
@@ -329,6 +329,13 @@ func (c *partitionKeyRangeCache) invalidate(containerRID string) {
 // to prevent runaway requests during large-scale splits.
 const maxChangeFeedIterations = 1000
 
+// maxIncompleteRoutingMapRetries bounds how many times a full change-feed drain
+// is retried when the accumulated ranges are not a complete covering. A snapshot
+// taken while a partition split is in flight can be transiently inconsistent, and
+// a fresh drain usually observes the settled state. Matches the Java SDK's
+// InCompleteRoutingMapRetryPolicy (MAX_INCOMPLETE_ROUTING_MAP_RETRIES = 1).
+const maxIncompleteRoutingMapRetries = 1
+
 // Linear backoff with jitter for 429 retries: base, 2*base, ... capped at
 // changeFeedPageRetryMaxDelay. Exposed as vars so tests can shrink them.
 var (
@@ -454,6 +461,11 @@ func jitter(maxJitter time.Duration) time.Duration {
 // returned map on the entry. ctx is the detached refresh context created
 // by runRefresh — never a caller-scoped context.
 //
+// It attempts an incremental refresh when a previous routing map with an ETag
+// exists, falling back to a full change-feed refresh if the incremental merge is
+// incomplete. That full drain is retried up to maxIncompleteRoutingMapRetries
+// times if the service returns a set of ranges that is not a complete covering.
+//
 // ⚠️ The returned routing map may be a snapshot of entry.routingMap taken
 // before the network I/O (the "no changes since last refresh" branch).
 // Callers MUST subject the result to runRefresh's generation check —
@@ -505,23 +517,37 @@ func (c *partitionKeyRangeCache) refreshEntryDetached(
 	}
 
 	// Full change-feed refresh: fetch all ranges from the beginning using A-IM
-	// without an ETag, looping until 304 Not Modified.
-	result, err := fetchAllChangeFeedPages(ctx, containerLink, "", client)
-	if err != nil {
-		return nil, err
-	}
+	// without an ETag, looping until 304 Not Modified. A snapshot observed while
+	// a partition split is in flight can be transiently incomplete, so retry the
+	// drain a bounded number of times before surfacing the failure.
+	var lastErr error
+	for attempt := 0; attempt <= maxIncompleteRoutingMapRetries; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 
-	if !result.completed {
-		return nil, fmt.Errorf("partition key range cache refresh failed: change-feed pagination did not terminate after %d iterations for container %s (accumulated %d ranges)", maxChangeFeedIterations, containerLink, len(result.ranges))
-	}
+		result, err := fetchAllChangeFeedPages(ctx, containerLink, "", client)
+		if err != nil {
+			return nil, err
+		}
 
-	newMap := newCollectionRoutingMap(result.ranges, result.finalETag)
-	if !isCompleteSetOfRanges(newMap.orderedRanges) {
+		if !result.completed {
+			return nil, fmt.Errorf("partition key range cache refresh failed: change-feed pagination did not terminate after %d iterations for container %s (accumulated %d ranges)", maxChangeFeedIterations, containerLink, len(result.ranges))
+		}
+
+		newMap := newCollectionRoutingMap(result.ranges, result.finalETag)
+		if isCompleteSetOfRanges(newMap.orderedRanges) {
+			return newMap, nil
+		}
+
 		issue := describeRangeDiscontinuity(newMap.orderedRanges)
-		return nil, fmt.Errorf("partition key range cache refresh failed: service returned an incomplete set of ranges for container %s (raw ranges=%d, final ranges=%d, issue: %s). This may indicate a transient issue during a partition split", containerLink, len(result.ranges), len(newMap.orderedRanges), issue)
+		lastErr = fmt.Errorf("partition key range cache refresh failed: service returned an incomplete set of ranges for container %s (raw ranges=%d, final ranges=%d, issue: %s). This may indicate a transient issue during a partition split", containerLink, len(result.ranges), len(newMap.orderedRanges), issue)
+		if attempt < maxIncompleteRoutingMapRetries {
+			log.Writef(azlog.EventResponse, "partition key range cache refresh for container %s returned an incomplete set of ranges (%s); retrying the full change-feed drain (retry %d of %d)", containerLink, issue, attempt+1, maxIncompleteRoutingMapRetries)
+		}
 	}
 
-	return newMap, nil
+	return nil, lastErr
 }
 
 // fetchPartitionKeyRangesResult holds the result of a single change-feed fetch.

--- a/sdk/data/azcosmos/cosmos_partition_key_range_cache.go
+++ b/sdk/data/azcosmos/cosmos_partition_key_range_cache.go
@@ -329,16 +329,21 @@ func (c *partitionKeyRangeCache) invalidate(containerRID string) {
 // to prevent runaway requests during large-scale splits.
 const maxChangeFeedIterations = 1000
 
-// maxIncompleteRoutingMapRetries bounds how many times a full change-feed drain
-// is retried when the accumulated ranges are not a complete covering. A snapshot
-// taken while a partition split is in flight can be transiently inconsistent, and
-// a fresh drain usually observes the settled state. Matches the Java SDK's
-// InCompleteRoutingMapRetryPolicy (MAX_INCOMPLETE_ROUTING_MAP_RETRIES = 1).
-const maxIncompleteRoutingMapRetries = 1
+// maxIncompleteRoutingMapAttempts bounds how many full change-feed drains are
+// attempted when the accumulated ranges are not a complete covering. Matches the
+// Python SDK's transient snapshot retry budget.
+const maxIncompleteRoutingMapAttempts = 4
 
-// Linear backoff with jitter for 429 retries: base, 2*base, ... capped at
-// changeFeedPageRetryMaxDelay. Exposed as vars so tests can shrink them.
 var (
+	// Floored full-jitter backoff for transient routing-map snapshots. The
+	// deterministic upper bound doubles from 200ms and is capped at 2s; the
+	// random delay is selected from [min(50ms, upper/4), upper).
+	incompleteRoutingMapRetryInitialDelay = 200 * time.Millisecond
+	incompleteRoutingMapRetryMinDelay     = 50 * time.Millisecond
+	incompleteRoutingMapRetryMaxDelay     = 2 * time.Second
+
+	// Linear backoff with jitter for 429 retries: base, 2*base, ... capped at
+	// changeFeedPageRetryMaxDelay. Exposed as vars so tests can shrink them.
 	changeFeedPageRetryBaseDelay = 100 * time.Millisecond
 	changeFeedPageRetryJitter    = 50 * time.Millisecond
 	changeFeedPageRetryMaxDelay  = 5 * time.Second
@@ -432,13 +437,20 @@ func fetchOneChangeFeedPageWithRetry(
 		}
 		delay += jitter(changeFeedPageRetryJitter)
 		log.Writef(azlog.EventResponse, "partition key range change-feed page throttled for container %s (attempt %d, retrying in %s): %v", containerLink, attempt+1, delay, err)
-		timer := time.NewTimer(delay)
-		select {
-		case <-timer.C:
-		case <-ctx.Done():
-			timer.Stop()
-			return fetchPartitionKeyRangesResult{}, ctx.Err()
+		if err := waitForRetry(ctx, delay); err != nil {
+			return fetchPartitionKeyRangesResult{}, err
 		}
+	}
+}
+
+func waitForRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
@@ -456,6 +468,34 @@ func jitter(maxJitter time.Duration) time.Duration {
 	return time.Duration(rand.Int63n(int64(maxJitter)))
 }
 
+func incompleteRoutingMapRetryBounds(retryAttempt int) (time.Duration, time.Duration) {
+	upper := incompleteRoutingMapRetryInitialDelay
+	if upper > incompleteRoutingMapRetryMaxDelay {
+		upper = incompleteRoutingMapRetryMaxDelay
+	}
+	for attempt := 1; attempt < retryAttempt && upper < incompleteRoutingMapRetryMaxDelay; attempt++ {
+		if upper > incompleteRoutingMapRetryMaxDelay/2 {
+			upper = incompleteRoutingMapRetryMaxDelay
+			break
+		}
+		upper *= 2
+	}
+	if upper <= 0 {
+		return 0, 0
+	}
+
+	floor := incompleteRoutingMapRetryMinDelay
+	if quarter := upper / 4; floor > quarter {
+		floor = quarter
+	}
+	return floor, upper
+}
+
+func incompleteRoutingMapRetryDelay(retryAttempt int) time.Duration {
+	floor, upper := incompleteRoutingMapRetryBounds(retryAttempt)
+	return floor + jitter(upper-floor)
+}
+
 // refreshEntryDetached fetches PK ranges and returns a fresh routing map.
 // All network I/O runs without holding any lock; the caller installs the
 // returned map on the entry. ctx is the detached refresh context created
@@ -463,8 +503,8 @@ func jitter(maxJitter time.Duration) time.Duration {
 //
 // It attempts an incremental refresh when a previous routing map with an ETag
 // exists, falling back to a full change-feed refresh if the incremental merge is
-// incomplete. That full drain is retried up to maxIncompleteRoutingMapRetries
-// times if the service returns a set of ranges that is not a complete covering.
+// incomplete. A transiently incomplete full snapshot is retried with bounded
+// jittered backoff before the error is surfaced.
 //
 // ⚠️ The returned routing map may be a snapshot of entry.routingMap taken
 // before the network I/O (the "no changes since last refresh" branch).
@@ -521,7 +561,7 @@ func (c *partitionKeyRangeCache) refreshEntryDetached(
 	// a partition split is in flight can be transiently incomplete, so retry the
 	// drain a bounded number of times before surfacing the failure.
 	var lastErr error
-	for attempt := 0; attempt <= maxIncompleteRoutingMapRetries; attempt++ {
+	for attempt := 1; attempt <= maxIncompleteRoutingMapAttempts; attempt++ {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
@@ -542,8 +582,12 @@ func (c *partitionKeyRangeCache) refreshEntryDetached(
 
 		issue := describeRangeDiscontinuity(newMap.orderedRanges)
 		lastErr = fmt.Errorf("partition key range cache refresh failed: service returned an incomplete set of ranges for container %s (raw ranges=%d, final ranges=%d, issue: %s). This may indicate a transient issue during a partition split", containerLink, len(result.ranges), len(newMap.orderedRanges), issue)
-		if attempt < maxIncompleteRoutingMapRetries {
-			log.Writef(azlog.EventResponse, "partition key range cache refresh for container %s returned an incomplete set of ranges (%s); retrying the full change-feed drain (retry %d of %d)", containerLink, issue, attempt+1, maxIncompleteRoutingMapRetries)
+		if attempt < maxIncompleteRoutingMapAttempts {
+			delay := incompleteRoutingMapRetryDelay(attempt)
+			log.Writef(azlog.EventResponse, "partition key range cache refresh for container %s returned an incomplete set of ranges (%s) on attempt %d of %d; retrying the full change-feed drain in %s", containerLink, issue, attempt, maxIncompleteRoutingMapAttempts, delay)
+			if err := waitForRetry(ctx, delay); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/sdk/data/azcosmos/cosmos_partition_key_range_cache_test.go
+++ b/sdk/data/azcosmos/cosmos_partition_key_range_cache_test.go
@@ -508,6 +508,180 @@ func (p *captureRequestsPolicy) Do(req *policy.Request) (*http.Response, error) 
 	return req.Next()
 }
 
+func Test_partitionKeyRangeCache_fullRefresh_duplicateRangeRevisionsAcrossPages(t *testing.T) {
+	// Scenario: a full change-feed drain re-delivers a range that is not gone,
+	// producing two revisions of the same range ID in the accumulated pages.
+	// The routing map must collapse them instead of rejecting the set as
+	// overlapping itself. See https://github.com/Azure/azure-sdk-for-go/issues/27246
+	srv, close := mock.NewTLSServer()
+	defer close()
+
+	// Page 1: both ranges
+	srv.AppendResponse(
+		mock.WithBody([]byte(`{
+			"_rid": "testRID",
+			"PartitionKeyRanges": [
+				{"_rid": "r0", "id": "0", "minInclusive": "", "maxExclusive": "05C1E18D2D7F08", "parents": []},
+				{"_rid": "r1", "id": "1", "minInclusive": "05C1E18D2D7F08", "maxExclusive": "FF", "parents": []}
+			],
+			"_count": 2
+		}`)),
+		mock.WithHeader(cosmosHeaderEtag, "etag1"),
+		mock.WithStatusCode(200),
+	)
+	// Page 2: range "1" re-delivered with an updated status — same ID, still live
+	srv.AppendResponse(
+		mock.WithBody([]byte(`{
+			"_rid": "testRID",
+			"PartitionKeyRanges": [
+				{"_rid": "r1", "id": "1", "minInclusive": "05C1E18D2D7F08", "maxExclusive": "FF", "parents": [], "status": "Online"}
+			],
+			"_count": 1
+		}`)),
+		mock.WithHeader(cosmosHeaderEtag, "etag2"),
+		mock.WithStatusCode(200),
+	)
+	// 304 terminates the drain
+	srv.AppendResponse(
+		mock.WithStatusCode(304),
+		mock.WithHeader(cosmosHeaderEtag, "etag2"),
+	)
+
+	client := createMockClientForPKRangeCache(srv)
+
+	entry := &pkRangeCacheEntry{}
+	client.caches.pkRangeCache.mu.Lock()
+	client.caches.pkRangeCache.entries["testRID"] = entry
+	client.caches.pkRangeCache.mu.Unlock()
+
+	rm, err := client.caches.pkRangeCache.getRoutingMap(context.Background(), "testRID", "dbs/db1/colls/col1", client)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(rm.orderedRanges))
+	require.Equal(t, "0", rm.orderedRanges[0].ID)
+	require.Equal(t, "1", rm.orderedRanges[1].ID)
+	// The later revision wins
+	require.Equal(t, "Online", rm.orderedRanges[1].Status)
+	require.Equal(t, "etag2", rm.changeFeedETag)
+}
+
+func Test_partitionKeyRangeCache_fullRefresh_incompleteRanges_retriesOnce(t *testing.T) {
+	// Scenario: the first full drain observes a transiently incomplete snapshot
+	// (mid-split). A single retry of the drain sees the settled state and succeeds.
+	srv, close := mock.NewTLSServer()
+	defer close()
+
+	// Drain 1: only half the key space is covered
+	srv.AppendResponse(
+		mock.WithBody([]byte(`{
+			"_rid": "testRID",
+			"PartitionKeyRanges": [
+				{"_rid": "r0", "id": "0", "minInclusive": "", "maxExclusive": "05C1E18D2D7F08", "parents": []}
+			],
+			"_count": 1
+		}`)),
+		mock.WithHeader(cosmosHeaderEtag, "etag1"),
+		mock.WithStatusCode(200),
+	)
+	srv.AppendResponse(
+		mock.WithStatusCode(304),
+		mock.WithHeader(cosmosHeaderEtag, "etag1"),
+	)
+	// Drain 2: complete covering
+	srv.AppendResponse(
+		mock.WithBody([]byte(`{
+			"_rid": "testRID",
+			"PartitionKeyRanges": [
+				{"_rid": "r0", "id": "0", "minInclusive": "", "maxExclusive": "05C1E18D2D7F08", "parents": []},
+				{"_rid": "r1", "id": "1", "minInclusive": "05C1E18D2D7F08", "maxExclusive": "FF", "parents": []}
+			],
+			"_count": 2
+		}`)),
+		mock.WithHeader(cosmosHeaderEtag, "etag2"),
+		mock.WithStatusCode(200),
+	)
+	srv.AppendResponse(
+		mock.WithStatusCode(304),
+		mock.WithHeader(cosmosHeaderEtag, "etag2"),
+	)
+
+	client := createMockClientForPKRangeCache(srv)
+
+	entry := &pkRangeCacheEntry{}
+	client.caches.pkRangeCache.mu.Lock()
+	client.caches.pkRangeCache.entries["testRID"] = entry
+	client.caches.pkRangeCache.mu.Unlock()
+
+	rm, err := client.caches.pkRangeCache.getRoutingMap(context.Background(), "testRID", "dbs/db1/colls/col1", client)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(rm.orderedRanges))
+	require.Equal(t, "etag2", rm.changeFeedETag)
+
+	// The successful map must be cached
+	entry.mu.Lock()
+	require.NotNil(t, entry.routingMap)
+	entry.mu.Unlock()
+}
+
+func Test_partitionKeyRangeCache_fullRefresh_incompleteRanges_failsAfterRetryBudget(t *testing.T) {
+	// Scenario: every drain returns an incomplete snapshot. The cache retries the
+	// drain maxIncompleteRoutingMapRetries times, then surfaces the error.
+	srv, close := mock.NewTLSServer()
+	defer close()
+
+	incompletePage := []byte(`{
+		"_rid": "testRID",
+		"PartitionKeyRanges": [
+			{"_rid": "r0", "id": "0", "minInclusive": "", "maxExclusive": "05C1E18D2D7F08", "parents": []}
+		],
+		"_count": 1
+	}`)
+
+	for i := 0; i <= maxIncompleteRoutingMapRetries; i++ {
+		srv.AppendResponse(
+			mock.WithBody(incompletePage),
+			mock.WithHeader(cosmosHeaderEtag, "etag1"),
+			mock.WithStatusCode(200),
+		)
+		srv.AppendResponse(
+			mock.WithStatusCode(304),
+			mock.WithHeader(cosmosHeaderEtag, "etag1"),
+		)
+	}
+
+	capture := &captureRequestsPolicy{}
+	defaultEndpoint, _ := url.Parse(srv.URL())
+	internalClient, _ := azcore.NewClient("azcosmostest", "v1.0.0",
+		azruntime.PipelineOptions{PerCall: []policy.Policy{capture}},
+		&policy.ClientOptions{Transport: srv})
+	client := &Client{
+		endpoint:    srv.URL(),
+		endpointUrl: defaultEndpoint,
+		internal:    internalClient,
+		gem:         &globalEndpointManager{preferredLocations: []string{}},
+		caches: &sharedCacheSet{
+			pkRangeCache:   newPartitionKeyRangeCache(),
+			containerCache: newContainerPropertiesCache(),
+		},
+	}
+
+	entry := &pkRangeCacheEntry{}
+	client.caches.pkRangeCache.mu.Lock()
+	client.caches.pkRangeCache.entries["testRID"] = entry
+	client.caches.pkRangeCache.mu.Unlock()
+
+	_, err := client.caches.pkRangeCache.getRoutingMap(context.Background(), "testRID", "dbs/db1/colls/col1", client)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "incomplete set of ranges")
+
+	// Two drains of two requests each: the initial attempt plus one retry
+	require.Equal(t, 2*(maxIncompleteRoutingMapRetries+1), len(capture.requests))
+
+	// Nothing should have been cached
+	entry.mu.Lock()
+	require.Nil(t, entry.routingMap)
+	entry.mu.Unlock()
+}
+
 func Test_partitionKeyRangeCache_fullRefresh_setsChangeFeedHeaders(t *testing.T) {
 	// Scenario: Verify that full refresh requests include A-IM and x-ms-max-item-count headers.
 	srv, close := mock.NewTLSServer()

--- a/sdk/data/azcosmos/cosmos_partition_key_range_cache_test.go
+++ b/sdk/data/azcosmos/cosmos_partition_key_range_cache_test.go
@@ -564,9 +564,56 @@ func Test_partitionKeyRangeCache_fullRefresh_duplicateRangeRevisionsAcrossPages(
 	require.Equal(t, "etag2", rm.changeFeedETag)
 }
 
-func Test_partitionKeyRangeCache_fullRefresh_incompleteRanges_retriesOnce(t *testing.T) {
+func disableIncompleteRoutingMapRetryDelay(t *testing.T) {
+	t.Helper()
+	initialDelay := incompleteRoutingMapRetryInitialDelay
+	minDelay := incompleteRoutingMapRetryMinDelay
+	maxDelay := incompleteRoutingMapRetryMaxDelay
+	t.Cleanup(func() {
+		incompleteRoutingMapRetryInitialDelay = initialDelay
+		incompleteRoutingMapRetryMinDelay = minDelay
+		incompleteRoutingMapRetryMaxDelay = maxDelay
+	})
+	incompleteRoutingMapRetryInitialDelay = 0
+	incompleteRoutingMapRetryMinDelay = 0
+	incompleteRoutingMapRetryMaxDelay = 0
+}
+
+func Test_incompleteRoutingMapRetryBounds(t *testing.T) {
+	tests := []struct {
+		attempt int
+		floor   time.Duration
+		upper   time.Duration
+	}{
+		{attempt: 1, floor: 50 * time.Millisecond, upper: 200 * time.Millisecond},
+		{attempt: 2, floor: 50 * time.Millisecond, upper: 400 * time.Millisecond},
+		{attempt: 3, floor: 50 * time.Millisecond, upper: 800 * time.Millisecond},
+		{attempt: 4, floor: 50 * time.Millisecond, upper: 1600 * time.Millisecond},
+		{attempt: 5, floor: 50 * time.Millisecond, upper: 2 * time.Second},
+	}
+
+	for _, test := range tests {
+		floor, upper := incompleteRoutingMapRetryBounds(test.attempt)
+		require.Equal(t, test.floor, floor)
+		require.Equal(t, test.upper, upper)
+		for range 100 {
+			delay := incompleteRoutingMapRetryDelay(test.attempt)
+			require.GreaterOrEqual(t, delay, floor)
+			require.Less(t, delay, upper)
+		}
+	}
+}
+
+func Test_waitForRetry_contextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, waitForRetry(ctx, time.Hour), context.Canceled)
+}
+
+func Test_partitionKeyRangeCache_fullRefresh_incompleteRanges_retriesWithBackoff(t *testing.T) {
 	// Scenario: the first full drain observes a transiently incomplete snapshot
-	// (mid-split). A single retry of the drain sees the settled state and succeeds.
+	// (mid-split). A retry of the drain sees the settled state and succeeds.
+	disableIncompleteRoutingMapRetryDelay(t)
 	srv, close := mock.NewTLSServer()
 	defer close()
 
@@ -624,7 +671,8 @@ func Test_partitionKeyRangeCache_fullRefresh_incompleteRanges_retriesOnce(t *tes
 
 func Test_partitionKeyRangeCache_fullRefresh_incompleteRanges_failsAfterRetryBudget(t *testing.T) {
 	// Scenario: every drain returns an incomplete snapshot. The cache retries the
-	// drain maxIncompleteRoutingMapRetries times, then surfaces the error.
+	// drain until maxIncompleteRoutingMapAttempts is reached, then surfaces the error.
+	disableIncompleteRoutingMapRetryDelay(t)
 	srv, close := mock.NewTLSServer()
 	defer close()
 
@@ -636,7 +684,7 @@ func Test_partitionKeyRangeCache_fullRefresh_incompleteRanges_failsAfterRetryBud
 		"_count": 1
 	}`)
 
-	for i := 0; i <= maxIncompleteRoutingMapRetries; i++ {
+	for i := 0; i < maxIncompleteRoutingMapAttempts; i++ {
 		srv.AppendResponse(
 			mock.WithBody(incompletePage),
 			mock.WithHeader(cosmosHeaderEtag, "etag1"),
@@ -673,8 +721,8 @@ func Test_partitionKeyRangeCache_fullRefresh_incompleteRanges_failsAfterRetryBud
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "incomplete set of ranges")
 
-	// Two drains of two requests each: the initial attempt plus one retry
-	require.Equal(t, 2*(maxIncompleteRoutingMapRetries+1), len(capture.requests))
+	// Each attempt drains one data page and one 304 terminator.
+	require.Equal(t, 2*maxIncompleteRoutingMapAttempts, len(capture.requests))
 
 	// Nothing should have been cached
 	entry.mu.Lock()

--- a/sdk/data/azcosmos/version.go
+++ b/sdk/data/azcosmos/version.go
@@ -7,5 +7,5 @@ const (
 	moduleName = "github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 
 	// serviceLibVersion is the semantic version (see http://semver.org) of this module.
-	serviceLibVersion = "v1.6.0-beta.1"
+	serviceLibVersion = "v1.6.0-beta.2"
 )


### PR DESCRIPTION
Fixes #27246

## Problem

A cold partition key range cache refresh drains the `/pkranges` change feed (`A-IM: Incremental feed`) from an empty ETag, accumulating **every** page until the service returns `304 Not Modified`. If a physical partition split is in flight while that drain runs, a range that is updated mid-drain is re-delivered on a later page as a *second revision of the same range ID*.

`newCollectionRoutingMap` did build a `rangeByID` map (which implicitly deduped), but it discarded that map for ordering purposes and returned the **non-deduplicated** `filtered` slice as `orderedRanges`. `refreshEntry` then ran `isCompleteSetOfRanges` over that slice. The two revisions of the same ID sort adjacently, `ranges[i].MinInclusive != ranges[i-1].MaxExclusive`, and the caller gets the nonsensical diagnostic reported in the issue:

```
partition key range cache refresh failed: service returned an incomplete set of ranges
for container ... (issue: overlap between range id=X ... and range id=X ...)
```

— a range reported as overlapping *itself*.

`tryCombine` (the incremental path) was never affected because it already keys by ID via `combinedByID` before validating. That matches the reporter's observation that the failure is specific to cold-cache initialization.

## Fix

`newCollectionRoutingMap` now deduplicates by range ID **before** sorting and **before** the completeness check, keeping the last revision seen in change-feed arrival order.

This is exactly what every other Cosmos SDK does:

| SDK | Mechanism |
| --- | --- |
| .NET | `CollectionRoutingMap.TryCreateCompleteRoutingMap`: `rangeById[range.Item1.Id] = range;` then sorts `rangeById.Values` |
| Java | `InMemoryCollectionRoutingMap.tryCreateCompleteRoutingMap`: `rangeById.put(...)`, sorts `rangeById.values()` |
| Python | `_build_routing_map_from_ranges`: explicit `deduped_by_id[...] = r` |
| Rust | `fetch_and_build_routing_map`: `HashMap::extend` (last-write-wins) then `.into_values()` |

The .NET source even carries the matching comment: *"Splits could have happened during change feed query and we might have a mix of gone and new ranges."*

Note the gone-range filter still behaves correctly: `goneRanges` is computed over the raw input before deduplication, so *every* revision of a parent range is dropped.

## Additional hardening

1. **Bounded transient-snapshot retry** (`maxIncompleteRoutingMapAttempts = 4`). A snapshot taken mid-split can be transiently inconsistent even after deduplication, so a failed full drain is retried up to three times with floored full-jitter exponential backoff. The retry windows have deterministic upper bounds of 200 ms, 400 ms, and 800 ms, with a floor of `min(50 ms, upper/4)`. This mirrors Python's `_TRANSIENT_SNAPSHOT_RETRY_MAX_ATTEMPTS = 4` policy rather than Java's single immediate retry. `refreshEntryDetached` only returns a map on success, so a partially-updated routing map is never published. Behavior on a non-terminating drain (`!result.completed`) is unchanged — it still returns immediately.

2. **Deterministic ordering.** `newCollectionRoutingMap` and `tryCombine` used `sort.Slice` (unstable), and `tryCombine` built its slice by ranging over a Go map (randomized). This made `describeRangeDiscontinuity` — the string customers paste into bug reports — non-reproducible *within a single process run*. Both now build in deterministic input order and use `sort.SliceStable`. Go was the weakest of the five SDKs here; Python, Java, and Rust all sort stably over a deterministic or per-process-stable sequence. This is not a correctness change (validation fails either way), only a diagnosability one.