### PR TITLE
chore: add @meetamitbhatia to CODEOWNERS alongside @j7nw4r

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,10 +60,10 @@
 # ServiceOwners:                                                   @rajeshka @shankarsama
 
 # PRLabel: %Event Hubs
-/sdk/messaging/azeventhubs/                                        @axisc @hmlam @sjkwak @j7nw4r @SwayGom @sagar0207
+/sdk/messaging/azeventhubs/                                        @axisc @hmlam @sjkwak @j7nw4r @meetamitbhatia @SwayGom @sagar0207
 
 # ServiceLabel: %Event Hubs
-# ServiceOwners:                                                   @axisc @hmlam @sjkwak @j7nw4r @SwayGom @sagar0207
+# ServiceOwners:                                                   @axisc @hmlam @sjkwak @j7nw4r @meetamitbhatia @SwayGom @sagar0207
 
 # PRLabel: %Internal
 /sdk/internal/                                                     @jhendrixMSFT @richardpark-msft @rickwinter @xirzec
@@ -109,13 +109,13 @@
 # ServiceOwners:                                                   @jhendrixMSFT @rickwinter @xirzec
 
 # PRLabel: %Service Bus
-/sdk/messaging/azservicebus/                                       @EldertGrootenboer @skarri-microsoft @j7nw4r @SwayGom @sagar0207
+/sdk/messaging/azservicebus/                                       @EldertGrootenboer @skarri-microsoft @j7nw4r @meetamitbhatia @SwayGom @sagar0207
 
 # PRLabel: %Service Bus
-/sdk/messaging/stress/                                             @EldertGrootenboer @skarri-microsoft @j7nw4r @SwayGom @sagar0207
+/sdk/messaging/stress/                                             @EldertGrootenboer @skarri-microsoft @j7nw4r @meetamitbhatia @SwayGom @sagar0207
 
 # ServiceLabel: %Service Bus
-# ServiceOwners:                                                   @EldertGrootenboer @skarri-microsoft @j7nw4r @SwayGom @sagar0207
+# ServiceOwners:                                                   @EldertGrootenboer @skarri-microsoft @j7nw4r @meetamitbhatia @SwayGom @sagar0207
 
 # PRLabel: %Storage
 /sdk/storage/                                                      @gapra-msft @jhendrixMSFT @souravgupta-msft @tanyasethi-msft


### PR DESCRIPTION
## Summary

@meetamitbhatia (Amit Bhatia) is not in the CODEOWNERS file. He works on the messaging libraries and must get review requests on the same paths as @j7nw4r.

## Motivation

@meetamitbhatia joined the messaging team. Without a CODEOWNERS entry, GitHub does not add him to pull requests that touch the messaging paths. The team then loses a reviewer, and review latency goes up.

## Changes

This change adds `@meetamitbhatia` next to `@j7nw4r` on every line that already lists `@j7nw4r`. It changes 3 owner paths and 2 `ServiceOwners` comments. It removes no owner and adds no new path.

Owner paths:

- `/sdk/messaging/azeventhubs/`
- `/sdk/messaging/azservicebus/`
- `/sdk/messaging/stress/`

## Validation

@meetamitbhatia is a member of the `Azure` organization, so the CODEOWNERS linter can resolve the handle.
