### PR TITLE
azblob: expose XStore block hashes and CPU timing (code review only)

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 * Added `Offset`, `Crc64`, and `Sha256` fields to `Block`, and a new `Include` option (`BlockListIncludeItemCrc64`/`BlockListIncludeItemSha256`) on `GetBlockListOptions` that emits `include=crc64,sha256`, exposing the per-block offset and content hashes returned by `BlockBlobClient.GetBlockList` when the service supports it (committed block lists only).
+* Added `BlockBlobClient.GetBlobHash` for retrieving SHA256 hashes and optional SHA256 CPU time for selected blob byte ranges from the feature-gated XStore `comp=hash` operation.
 
 ### Breaking Changes
 

--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+* Added `Offset`, `Crc64`, and `Sha256` fields to `Block`, exposing the per-block offset and content hashes returned by `BlockBlobClient.GetBlockList` when the service includes them in the response.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-* Added `Offset`, `Crc64`, and `Sha256` fields to `Block`, exposing the per-block offset and content hashes returned by `BlockBlobClient.GetBlockList` when the service includes them in the response.
+* Added `Offset`, `Crc64`, and `Sha256` fields to `Block`, and a new `Include` option (`BlockListIncludeItemCrc64`/`BlockListIncludeItemSha256`) on `GetBlockListOptions` that emits `include=crc64,sha256`, exposing the per-block offset and content hashes returned by `BlockBlobClient.GetBlockList` when the service supports it (committed block lists only).
 
 ### Breaking Changes
 

--- a/sdk/storage/azblob/blockblob/client.go
+++ b/sdk/storage/azblob/blockblob/client.go
@@ -6,12 +6,16 @@ package blockblob
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"os"
 	"reflect"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -310,6 +314,160 @@ func (bb *Client) GetBlockList(ctx context.Context, listType BlockListType, opti
 	resp, err := bb.generated().GetBlockList(ctx, listType, o, lac, mac)
 
 	return resp, err
+}
+
+const (
+	maxGetBlobHashRanges      = 256
+	maxGetBlobHashHeaderBytes = 8192
+	maxGetBlobHashBytes       = int64(4000 * 1024 * 1024)
+)
+
+// GetBlobHash returns SHA256 hashes for selected byte ranges in a block blob.
+// Ranges must be sorted, non-overlapping, and contain between 1 and 256 entries.
+// Each range and their aggregate data size cannot exceed 4000 MiB.
+// The service must support the feature-gated GetBlobHash operation.
+func (bb *Client) GetBlobHash(ctx context.Context, ranges []BlobHashRange, options *GetBlobHashOptions) (GetBlobHashResponse, error) {
+	multiRange, err := formatBlobHashRanges(ranges)
+	if err != nil {
+		return GetBlobHashResponse{}, err
+	}
+	if err := validateGetBlobHashConditions(options); err != nil {
+		return GetBlobHashResponse{}, err
+	}
+
+	o, lac, cpk, mac := options.format()
+	resp, err := bb.generated().GetBlobHash(ctx, multiRange, o, lac, cpk, mac)
+	if err != nil {
+		return GetBlobHashResponse{}, err
+	}
+
+	return formatGetBlobHashResponse(resp, ranges)
+}
+
+func formatBlobHashRanges(ranges []BlobHashRange) (string, error) {
+	if len(ranges) == 0 {
+		return "", errors.New("blockblob: GetBlobHash requires at least one range")
+	}
+	if len(ranges) > maxGetBlobHashRanges {
+		return "", fmt.Errorf("blockblob: GetBlobHash accepts at most %d ranges", maxGetBlobHashRanges)
+	}
+
+	var header strings.Builder
+	header.Grow(maxGetBlobHashHeaderBytes)
+	header.WriteString("bytes=")
+
+	var totalBytes int64
+	var previousEnd int64
+	for i, rnge := range ranges {
+		if rnge.Offset < 0 {
+			return "", fmt.Errorf("blockblob: GetBlobHash range %d offset must not be negative", i)
+		}
+		if rnge.Count <= 0 {
+			return "", fmt.Errorf("blockblob: GetBlobHash range %d count must be positive", i)
+		}
+		if rnge.Count > maxGetBlobHashBytes {
+			return "", fmt.Errorf("blockblob: GetBlobHash range %d exceeds the %d-byte limit", i, maxGetBlobHashBytes)
+		}
+		if rnge.Offset > math.MaxInt64-(rnge.Count-1) {
+			return "", fmt.Errorf("blockblob: GetBlobHash range %d end exceeds int64", i)
+		}
+
+		end := rnge.Offset + rnge.Count - 1
+		if i > 0 {
+			if rnge.Offset <= ranges[i-1].Offset {
+				return "", fmt.Errorf("blockblob: GetBlobHash range %d is not sorted by offset", i)
+			}
+			if rnge.Offset <= previousEnd {
+				return "", fmt.Errorf("blockblob: GetBlobHash range %d overlaps the preceding range", i)
+			}
+			header.WriteByte(',')
+		}
+
+		if totalBytes > maxGetBlobHashBytes-rnge.Count {
+			return "", fmt.Errorf("blockblob: GetBlobHash ranges exceed the %d-byte aggregate limit", maxGetBlobHashBytes)
+		}
+		totalBytes += rnge.Count
+
+		header.WriteString(strconv.FormatInt(rnge.Offset, 10))
+		header.WriteByte('-')
+		header.WriteString(strconv.FormatInt(end, 10))
+		if header.Len() > maxGetBlobHashHeaderBytes {
+			return "", fmt.Errorf("blockblob: GetBlobHash x-ms-multi-range value exceeds %d bytes", maxGetBlobHashHeaderBytes)
+		}
+		previousEnd = end
+	}
+
+	return header.String(), nil
+}
+
+func validateGetBlobHashConditions(options *GetBlobHashOptions) error {
+	if options == nil ||
+		options.AccessConditions == nil ||
+		options.AccessConditions.ModifiedAccessConditions == nil ||
+		options.AccessConditions.ModifiedAccessConditions.IfMatch == nil {
+		return errors.New("blockblob: GetBlobHash requires AccessConditions.ModifiedAccessConditions.IfMatch")
+	}
+	ifMatch := *options.AccessConditions.ModifiedAccessConditions.IfMatch
+	if !isStrongETag(ifMatch) {
+		return errors.New("blockblob: GetBlobHash requires an exact strong IfMatch ETag")
+	}
+	return nil
+}
+
+func isStrongETag(etag azcore.ETag) bool {
+	value := string(etag)
+	if len(value) < 2 || value[0] != '"' || value[len(value)-1] != '"' {
+		return false
+	}
+	for i := 1; i < len(value)-1; i++ {
+		if value[i] == '"' || value[i] < 0x21 || value[i] == 0x7f {
+			return false
+		}
+	}
+	return true
+}
+
+func formatGetBlobHashResponse(resp generated.BlockBlobClientGetBlobHashResponse, ranges []BlobHashRange) (GetBlobHashResponse, error) {
+	if len(resp.RangeHashes) != len(ranges) {
+		return GetBlobHashResponse{}, fmt.Errorf("blockblob: GetBlobHash returned %d range hashes for %d requested ranges", len(resp.RangeHashes), len(ranges))
+	}
+
+	expected := make(map[BlobHashRange]struct{}, len(ranges))
+	for _, rnge := range ranges {
+		expected[rnge] = struct{}{}
+	}
+
+	results := make([]BlobHashResult, 0, len(resp.RangeHashes))
+	for i, result := range resp.RangeHashes {
+		if result == nil || result.Offset == nil || result.Length == nil {
+			return GetBlobHashResponse{}, fmt.Errorf("blockblob: GetBlobHash response range %d is missing Offset or Length", i)
+		}
+		rnge := BlobHashRange{Offset: *result.Offset, Count: *result.Length}
+		if _, ok := expected[rnge]; !ok {
+			return GetBlobHashResponse{}, fmt.Errorf("blockblob: GetBlobHash response range %d does not match a requested range", i)
+		}
+		delete(expected, rnge)
+		if len(result.Sha256) != sha256.Size {
+			return GetBlobHashResponse{}, fmt.Errorf("blockblob: GetBlobHash response range %d contains a %d-byte SHA256 hash; expected %d bytes", i, len(result.Sha256), sha256.Size)
+		}
+		results = append(results, BlobHashResult{
+			Offset: rnge.Offset,
+			Count:  rnge.Count,
+			SHA256: result.Sha256,
+		})
+	}
+
+	return GetBlobHashResponse{
+		RangeHashes:       results,
+		ETag:              resp.ETag,
+		LastModified:      resp.LastModified,
+		BlobContentLength: resp.BlobContentLength,
+		HashAlgorithm:     resp.HashAlgorithm,
+		RequestID:         resp.RequestID,
+		SHA256CPUTimeUS:   resp.SHA256CPUTimeUS,
+		ClientRequestID:   resp.ClientRequestID,
+		Version:           resp.Version,
+	}, nil
 }
 
 // Redeclared APIs ----- Copy over to Append blob and Page blob as well.

--- a/sdk/storage/azblob/blockblob/constants.go
+++ b/sdk/storage/azblob/blockblob/constants.go
@@ -35,6 +35,21 @@ func PossibleBlockListTypeValues() []BlockListType {
 	return generated.PossibleBlockListTypeValues()
 }
 
+// BlockListIncludeItem defines values for the GetBlockList include parameter, selecting additional
+// per-block datasets (such as content hashes) to return. Requires service-side support and is only
+// honored for BlockListTypeCommitted.
+type BlockListIncludeItem = generated.BlockListIncludeItem
+
+const (
+	BlockListIncludeItemCrc64  BlockListIncludeItem = generated.BlockListIncludeItemCrc64
+	BlockListIncludeItemSha256 BlockListIncludeItem = generated.BlockListIncludeItemSha256
+)
+
+// PossibleBlockListIncludeItemValues returns the possible values for the BlockListIncludeItem const type.
+func PossibleBlockListIncludeItemValues() []BlockListIncludeItem {
+	return generated.PossibleBlockListIncludeItemValues()
+}
+
 // BlobCopySourceTags - can be 'COPY' or 'REPLACE'
 type BlobCopySourceTags = generated.BlobCopySourceTags
 

--- a/sdk/storage/azblob/blockblob/get_blob_hash_live_test.go
+++ b/sdk/storage/azblob/blockblob/get_blob_hash_live_test.go
@@ -1,0 +1,83 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package blockblob_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetBlobHashLiveKnownCommittedRanges(t *testing.T) {
+	blobURL := os.Getenv("AZBLOB_XSTORE_GET_BLOB_HASH_URL")
+	if blobURL == "" {
+		t.Skip("set AZBLOB_XSTORE_GET_BLOB_HASH_URL to a readable XStore block blob SAS URL")
+	}
+
+	client, err := blockblob.NewClientWithNoCredential(blobURL, nil)
+	require.NoError(t, err)
+
+	blockList, err := client.GetBlockList(context.Background(), blockblob.BlockListTypeCommitted, &blockblob.GetBlockListOptions{
+		Include: []blockblob.BlockListIncludeItem{blockblob.BlockListIncludeItemCrc64},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, blockList.ETag)
+
+	ranges := make([]blockblob.BlobHashRange, 0, 4)
+	var total int64
+	for _, block := range blockList.CommittedBlocks {
+		if block.Offset == nil || block.Size == nil || *block.Size <= 0 || *block.Size > maxBlobHashBytes {
+			continue
+		}
+		if total > maxBlobHashBytes-*block.Size {
+			break
+		}
+		ranges = append(ranges, blockblob.BlobHashRange{Offset: *block.Offset, Count: *block.Size})
+		total += *block.Size
+		if len(ranges) == cap(ranges) {
+			break
+		}
+	}
+	require.NotEmpty(t, ranges)
+
+	etag := azcore.ETag(*blockList.ETag)
+	conditions := &blob.AccessConditions{
+		ModifiedAccessConditions: &blob.ModifiedAccessConditions{IfMatch: &etag},
+	}
+	hashes, err := client.GetBlobHash(context.Background(), ranges, &blockblob.GetBlobHashOptions{
+		AccessConditions: conditions,
+	})
+	require.NoError(t, err)
+	require.Len(t, hashes.RangeHashes, len(ranges))
+
+	returned := make(map[blockblob.BlobHashRange][]byte, len(hashes.RangeHashes))
+	for _, result := range hashes.RangeHashes {
+		returned[blockblob.BlobHashRange{Offset: result.Offset, Count: result.Count}] = result.SHA256
+	}
+
+	for _, rnge := range ranges {
+		download, err := client.BlobClient().DownloadStream(context.Background(), &blob.DownloadStreamOptions{
+			Range:            blob.HTTPRange{Offset: rnge.Offset, Count: rnge.Count},
+			AccessConditions: conditions,
+		})
+		require.NoError(t, err)
+		data, readErr := io.ReadAll(download.Body)
+		closeErr := download.Body.Close()
+		require.NoError(t, readErr)
+		require.NoError(t, closeErr)
+
+		expected := sha256.Sum256(data)
+		require.Equal(t, expected[:], returned[rnge])
+	}
+}

--- a/sdk/storage/azblob/blockblob/get_blob_hash_test.go
+++ b/sdk/storage/azblob/blockblob/get_blob_hash_test.go
@@ -1,0 +1,531 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package blockblob_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+	"github.com/stretchr/testify/require"
+)
+
+const maxBlobHashBytes = int64(4000 * 1024 * 1024)
+
+type getBlobHashTransportResponse struct {
+	statusCode int
+	headers    http.Header
+	body       string
+	err        error
+}
+
+type getBlobHashTransport struct {
+	mu        sync.Mutex
+	requests  []*http.Request
+	responses []getBlobHashTransportResponse
+}
+
+func (t *getBlobHashTransport) Do(req *http.Request) (*http.Response, error) {
+	if err := req.Context().Err(); err != nil {
+		return nil, err
+	}
+
+	t.mu.Lock()
+	index := len(t.requests)
+	cloned := req.Clone(req.Context())
+	cloned.Header = req.Header.Clone()
+	t.requests = append(t.requests, cloned)
+	response := t.responses[len(t.responses)-1]
+	if index < len(t.responses) {
+		response = t.responses[index]
+	}
+	t.mu.Unlock()
+
+	if response.err != nil {
+		return nil, response.err
+	}
+	statusCode := response.statusCode
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+	return &http.Response{
+		Request:    req,
+		Status:     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+		StatusCode: statusCode,
+		Header:     response.headers.Clone(),
+		Body:       io.NopCloser(strings.NewReader(response.body)),
+	}, nil
+}
+
+func (t *getBlobHashTransport) requestCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.requests)
+}
+
+func (t *getBlobHashTransport) request(index int) *http.Request {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.requests[index]
+}
+
+type getBlobHashRequestIDPolicy struct{}
+
+func (getBlobHashRequestIDPolicy) Do(req *policy.Request) (*http.Response, error) {
+	req.Raw().Header.Set("x-ms-client-request-id", "azblob-test-request-id")
+	return req.Next()
+}
+
+func getBlobHashHeaderValue(header http.Header, name string) string {
+	for headerName, values := range header {
+		if strings.EqualFold(headerName, name) && len(values) > 0 {
+			return values[0]
+		}
+	}
+	return ""
+}
+
+func newGetBlobHashClient(t *testing.T, url string, transport *getBlobHashTransport, configure func(*blockblob.ClientOptions)) *blockblob.Client {
+	t.Helper()
+	options := &blockblob.ClientOptions{ClientOptions: policy.ClientOptions{
+		Transport:       transport,
+		Telemetry:       policy.TelemetryOptions{ApplicationID: "testApp/1.0.0-preview.2"},
+		PerCallPolicies: []policy.Policy{getBlobHashRequestIDPolicy{}},
+	}}
+	if configure != nil {
+		configure(options)
+	}
+	client, err := blockblob.NewClientWithNoCredential(url, options)
+	require.NoError(t, err)
+	return client
+}
+
+func blobHashOptions() *blockblob.GetBlobHashOptions {
+	etag := azcore.ETag(`"opaque-epoch"`)
+	return &blockblob.GetBlobHashOptions{
+		AccessConditions: &blob.AccessConditions{
+			ModifiedAccessConditions: &blob.ModifiedAccessConditions{IfMatch: &etag},
+		},
+	}
+}
+
+func blobHashForRange(rnge blockblob.BlobHashRange) []byte {
+	hash := sha256.Sum256([]byte(fmt.Sprintf("%d:%d", rnge.Offset, rnge.Count)))
+	return hash[:]
+}
+
+func rangeHashXML(ranges []blockblob.BlobHashRange, unknownFields bool) string {
+	var body strings.Builder
+	body.WriteString(`<?xml version="1.0" encoding="utf-8"?><RangeHashList>`)
+	if unknownFields {
+		body.WriteString(`<FutureRootField>ignored</FutureRootField>`)
+	}
+	for _, rnge := range ranges {
+		fmt.Fprintf(&body, `<RangeHash><Offset>%d</Offset><Length>%d</Length><Sha256>%s</Sha256>`,
+			rnge.Offset, rnge.Count, base64.StdEncoding.EncodeToString(blobHashForRange(rnge)))
+		if unknownFields {
+			body.WriteString(`<FutureRangeField>ignored</FutureRangeField>`)
+		}
+		body.WriteString(`</RangeHash>`)
+	}
+	body.WriteString(`</RangeHashList>`)
+	return body.String()
+}
+
+func blobHashResponse(ranges []blockblob.BlobHashRange) getBlobHashTransportResponse {
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/xml")
+	headers.Set("ETag", `"opaque-epoch"`)
+	headers.Set("Last-Modified", "Mon, 02 Jan 2006 15:04:05 GMT")
+	headers.Set("x-ms-blob-content-length", "8192")
+	headers.Set("x-ms-hash-algorithm", "Sha256")
+	headers.Set("x-ms-request-id", "service-request")
+	headers.Set("x-ms-client-request-id", "client-request")
+	headers.Set("x-ms-test-dedupe-sha256-cpu-time-us", "321")
+	headers.Set("x-ms-version", "2025-11-05")
+	return getBlobHashTransportResponse{headers: headers, body: rangeHashXML(ranges, false)}
+}
+
+func TestGetBlobHash(t *testing.T) {
+	requested := []blockblob.BlobHashRange{{Offset: 0, Count: 1024}, {Offset: 4096, Count: 2048}}
+	responseOrder := []blockblob.BlobHashRange{requested[1], requested[0]}
+	transport := &getBlobHashTransport{responses: []getBlobHashTransportResponse{blobHashResponse(responseOrder)}}
+	client := newGetBlobHashClient(t, "https://fake.blob.core.windows.net/container/blob?sig=secret", transport, nil)
+
+	response, err := client.GetBlobHash(context.Background(), requested, blobHashOptions())
+	require.NoError(t, err)
+	require.Len(t, response.RangeHashes, 2)
+	require.Equal(t, responseOrder[0].Offset, response.RangeHashes[0].Offset)
+	require.Equal(t, responseOrder[0].Count, response.RangeHashes[0].Count)
+	require.Equal(t, blobHashForRange(responseOrder[0]), response.RangeHashes[0].SHA256)
+	require.Equal(t, azcore.ETag(`"opaque-epoch"`), *response.ETag)
+	require.Equal(t, int64(8192), *response.BlobContentLength)
+	require.Equal(t, "Sha256", *response.HashAlgorithm)
+	require.Equal(t, "service-request", *response.RequestID)
+	require.Equal(t, "client-request", *response.ClientRequestID)
+	require.Equal(t, int64(321), *response.SHA256CPUTimeUS)
+	require.Equal(t, "2025-11-05", *response.Version)
+
+	require.Equal(t, 1, transport.requestCount())
+	req := transport.request(0)
+	require.Equal(t, http.MethodGet, req.Method)
+	require.Equal(t, "hash", req.URL.Query().Get("comp"))
+	require.Equal(t, "secret", req.URL.Query().Get("sig"))
+	require.Equal(t, "bytes=0-1023,4096-6143", getBlobHashHeaderValue(req.Header, "x-ms-multi-range"))
+	require.Equal(t, "Sha256", getBlobHashHeaderValue(req.Header, "x-ms-hash-algorithm"))
+	require.Equal(t, `"opaque-epoch"`, getBlobHashHeaderValue(req.Header, "If-Match"))
+	require.Equal(t, "2025-11-05", getBlobHashHeaderValue(req.Header, "x-ms-version"))
+	require.Equal(t, "application/xml", getBlobHashHeaderValue(req.Header, "Accept"))
+	require.True(t, req.Body == nil || req.Body == http.NoBody)
+	require.Zero(t, req.ContentLength)
+}
+
+func TestGetBlobHashConditions(t *testing.T) {
+	ranges := []blockblob.BlobHashRange{{Offset: 0, Count: 1}}
+	transport := &getBlobHashTransport{responses: []getBlobHashTransportResponse{blobHashResponse(ranges)}}
+	client := newGetBlobHashClient(t, "https://fake.blob.core.windows.net/container/blob", transport, nil)
+
+	leaseID := "lease-id"
+	ifTags := `"tag" = 'value'`
+	etag := azcore.ETag(`"etag"`)
+	algorithm := blob.EncryptionAlgorithmTypeAES256
+	encryptionKey := "base64-key"
+	encryptionKeySHA256 := "base64-key-sha256"
+	_, err := client.GetBlobHash(context.Background(), ranges, &blockblob.GetBlobHashOptions{
+		AccessConditions: &blob.AccessConditions{
+			LeaseAccessConditions: &blob.LeaseAccessConditions{LeaseID: &leaseID},
+			ModifiedAccessConditions: &blob.ModifiedAccessConditions{
+				IfMatch: &etag,
+				IfTags:  &ifTags,
+			},
+		},
+		CPKInfo: &blob.CPKInfo{
+			EncryptionAlgorithm: &algorithm,
+			EncryptionKey:       &encryptionKey,
+			EncryptionKeySHA256: &encryptionKeySHA256,
+		},
+	})
+	require.NoError(t, err)
+
+	req := transport.request(0)
+	require.Equal(t, leaseID, getBlobHashHeaderValue(req.Header, "x-ms-lease-id"))
+	require.Equal(t, ifTags, getBlobHashHeaderValue(req.Header, "x-ms-if-tags"))
+	require.Equal(t, string(etag), getBlobHashHeaderValue(req.Header, "If-Match"))
+	require.Equal(t, string(algorithm), getBlobHashHeaderValue(req.Header, "x-ms-encryption-algorithm"))
+	require.Equal(t, encryptionKey, getBlobHashHeaderValue(req.Header, "x-ms-encryption-key"))
+	require.Equal(t, encryptionKeySHA256, getBlobHashHeaderValue(req.Header, "x-ms-encryption-key-sha256"))
+}
+
+func exactHeaderLimitRanges() []blockblob.BlobHashRange {
+	ranges := []blockblob.BlobHashRange{
+		{Offset: 99999999999995, Count: 1},
+		{Offset: 99999999999997, Count: 1},
+		{Offset: 99999999999999, Count: 2},
+	}
+	for i := 0; i < 253; i++ {
+		ranges = append(ranges, blockblob.BlobHashRange{Offset: 100000000000002 + int64(i*2), Count: 1})
+	}
+	return ranges
+}
+
+func TestGetBlobHashBoundaryLimits(t *testing.T) {
+	tests := []struct {
+		name            string
+		ranges          []blockblob.BlobHashRange
+		wantHeaderBytes int
+	}{
+		{name: "256 ranges and 8192-byte header", ranges: exactHeaderLimitRanges(), wantHeaderBytes: 8192},
+		{name: "individual 4000 MiB", ranges: []blockblob.BlobHashRange{{Offset: 0, Count: maxBlobHashBytes}}},
+		{name: "aggregate 4000 MiB", ranges: []blockblob.BlobHashRange{
+			{Offset: 0, Count: maxBlobHashBytes / 2},
+			{Offset: maxBlobHashBytes / 2, Count: maxBlobHashBytes / 2},
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transport := &getBlobHashTransport{responses: []getBlobHashTransportResponse{blobHashResponse(test.ranges)}}
+			client := newGetBlobHashClient(t, "https://fake.blob.core.windows.net/container/blob", transport, nil)
+
+			response, err := client.GetBlobHash(context.Background(), test.ranges, blobHashOptions())
+			require.NoError(t, err)
+			require.Len(t, response.RangeHashes, len(test.ranges))
+			if test.wantHeaderBytes != 0 {
+				require.Len(t, getBlobHashHeaderValue(transport.request(0).Header, "x-ms-multi-range"), test.wantHeaderBytes)
+			}
+		})
+	}
+}
+
+func TestGetBlobHashValidation(t *testing.T) {
+	tooManyRanges := make([]blockblob.BlobHashRange, 257)
+	for i := range tooManyRanges {
+		tooManyRanges[i] = blockblob.BlobHashRange{Offset: int64(i * 2), Count: 1}
+	}
+	oversizedHeader := exactHeaderLimitRanges()
+	oversizedHeader[len(oversizedHeader)-1].Offset = 1000000000000000
+
+	tests := []struct {
+		name    string
+		ranges  []blockblob.BlobHashRange
+		options func() *blockblob.GetBlobHashOptions
+	}{
+		{name: "empty ranges", ranges: nil, options: blobHashOptions},
+		{name: "negative offset", ranges: []blockblob.BlobHashRange{{Offset: -1, Count: 1}}, options: blobHashOptions},
+		{name: "zero count", ranges: []blockblob.BlobHashRange{{Offset: 0, Count: 0}}, options: blobHashOptions},
+		{name: "negative count", ranges: []blockblob.BlobHashRange{{Offset: 0, Count: -1}}, options: blobHashOptions},
+		{name: "range overflow", ranges: []blockblob.BlobHashRange{{Offset: math.MaxInt64, Count: 2}}, options: blobHashOptions},
+		{name: "unsorted ranges", ranges: []blockblob.BlobHashRange{{Offset: 10, Count: 1}, {Offset: 0, Count: 1}}, options: blobHashOptions},
+		{name: "overlapping ranges", ranges: []blockblob.BlobHashRange{{Offset: 0, Count: 10}, {Offset: 9, Count: 2}}, options: blobHashOptions},
+		{name: "257 ranges", ranges: tooManyRanges, options: blobHashOptions},
+		{name: "individual data limit", ranges: []blockblob.BlobHashRange{{Offset: 0, Count: maxBlobHashBytes + 1}}, options: blobHashOptions},
+		{name: "aggregate data limit", ranges: []blockblob.BlobHashRange{
+			{Offset: 0, Count: maxBlobHashBytes / 2},
+			{Offset: maxBlobHashBytes / 2, Count: maxBlobHashBytes/2 + 1},
+		}, options: blobHashOptions},
+		{name: "header size limit", ranges: oversizedHeader, options: blobHashOptions},
+		{name: "nil options", ranges: []blockblob.BlobHashRange{{Offset: 0, Count: 1}}},
+		{name: "nil access conditions", ranges: []blockblob.BlobHashRange{{Offset: 0, Count: 1}}, options: func() *blockblob.GetBlobHashOptions {
+			return &blockblob.GetBlobHashOptions{}
+		}},
+		{name: "nil modified conditions", ranges: []blockblob.BlobHashRange{{Offset: 0, Count: 1}}, options: func() *blockblob.GetBlobHashOptions {
+			return &blockblob.GetBlobHashOptions{AccessConditions: &blob.AccessConditions{}}
+		}},
+		{name: "missing If-Match", ranges: []blockblob.BlobHashRange{{Offset: 0, Count: 1}}, options: func() *blockblob.GetBlobHashOptions {
+			return &blockblob.GetBlobHashOptions{AccessConditions: &blob.AccessConditions{
+				ModifiedAccessConditions: &blob.ModifiedAccessConditions{},
+			}}
+		}},
+		{name: "empty If-Match", ranges: []blockblob.BlobHashRange{{Offset: 0, Count: 1}}, options: func() *blockblob.GetBlobHashOptions {
+			etag := azcore.ETag("")
+			return &blockblob.GetBlobHashOptions{AccessConditions: &blob.AccessConditions{
+				ModifiedAccessConditions: &blob.ModifiedAccessConditions{IfMatch: &etag},
+			}}
+		}},
+		{name: "wildcard If-Match", ranges: []blockblob.BlobHashRange{{Offset: 0, Count: 1}}, options: func() *blockblob.GetBlobHashOptions {
+			etag := azcore.ETagAny
+			return &blockblob.GetBlobHashOptions{AccessConditions: &blob.AccessConditions{
+				ModifiedAccessConditions: &blob.ModifiedAccessConditions{IfMatch: &etag},
+			}}
+		}},
+		{name: "whitespace wildcard If-Match", ranges: []blockblob.BlobHashRange{{Offset: 0, Count: 1}}, options: func() *blockblob.GetBlobHashOptions {
+			etag := azcore.ETag(" * ")
+			return &blockblob.GetBlobHashOptions{AccessConditions: &blob.AccessConditions{
+				ModifiedAccessConditions: &blob.ModifiedAccessConditions{IfMatch: &etag},
+			}}
+		}},
+		{name: "weak If-Match", ranges: []blockblob.BlobHashRange{{Offset: 0, Count: 1}}, options: func() *blockblob.GetBlobHashOptions {
+			etag := azcore.ETag(`W/"etag"`)
+			return &blockblob.GetBlobHashOptions{AccessConditions: &blob.AccessConditions{
+				ModifiedAccessConditions: &blob.ModifiedAccessConditions{IfMatch: &etag},
+			}}
+		}},
+		{name: "If-Match list", ranges: []blockblob.BlobHashRange{{Offset: 0, Count: 1}}, options: func() *blockblob.GetBlobHashOptions {
+			etag := azcore.ETag(`"one","two"`)
+			return &blockblob.GetBlobHashOptions{AccessConditions: &blob.AccessConditions{
+				ModifiedAccessConditions: &blob.ModifiedAccessConditions{IfMatch: &etag},
+			}}
+		}},
+		{name: "unquoted If-Match", ranges: []blockblob.BlobHashRange{{Offset: 0, Count: 1}}, options: func() *blockblob.GetBlobHashOptions {
+			etag := azcore.ETag("etag")
+			return &blockblob.GetBlobHashOptions{AccessConditions: &blob.AccessConditions{
+				ModifiedAccessConditions: &blob.ModifiedAccessConditions{IfMatch: &etag},
+			}}
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transport := &getBlobHashTransport{responses: []getBlobHashTransportResponse{{}}}
+			client := newGetBlobHashClient(t, "https://fake.blob.core.windows.net/container/blob", transport, nil)
+			var options *blockblob.GetBlobHashOptions
+			if test.options != nil {
+				options = test.options()
+			}
+
+			_, err := client.GetBlobHash(context.Background(), test.ranges, options)
+			require.Error(t, err)
+			require.Zero(t, transport.requestCount())
+		})
+	}
+}
+
+func TestGetBlobHashResponseValidation(t *testing.T) {
+	ranges := []blockblob.BlobHashRange{{Offset: 0, Count: 10}, {Offset: 20, Count: 10}}
+	validSHA := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x11}, sha256.Size))
+	shortSHA := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x11}, sha256.Size-1))
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "invalid base64", body: `<RangeHashList><RangeHash><Offset>0</Offset><Length>10</Length><Sha256>not-base64</Sha256></RangeHash><RangeHash><Offset>20</Offset><Length>10</Length><Sha256>` + validSHA + `</Sha256></RangeHash></RangeHashList>`},
+		{name: "wrong SHA256 length", body: `<RangeHashList><RangeHash><Offset>0</Offset><Length>10</Length><Sha256>` + shortSHA + `</Sha256></RangeHash><RangeHash><Offset>20</Offset><Length>10</Length><Sha256>` + validSHA + `</Sha256></RangeHash></RangeHashList>`},
+		{name: "missing SHA256", body: `<RangeHashList><RangeHash><Offset>0</Offset><Length>10</Length></RangeHash><RangeHash><Offset>20</Offset><Length>10</Length><Sha256>` + validSHA + `</Sha256></RangeHash></RangeHashList>`},
+		{name: "missing offset", body: `<RangeHashList><RangeHash><Length>10</Length><Sha256>` + validSHA + `</Sha256></RangeHash><RangeHash><Offset>20</Offset><Length>10</Length><Sha256>` + validSHA + `</Sha256></RangeHash></RangeHashList>`},
+		{name: "missing length", body: `<RangeHashList><RangeHash><Offset>0</Offset><Sha256>` + validSHA + `</Sha256></RangeHash><RangeHash><Offset>20</Offset><Length>10</Length><Sha256>` + validSHA + `</Sha256></RangeHash></RangeHashList>`},
+		{name: "response count mismatch", body: `<RangeHashList><RangeHash><Offset>0</Offset><Length>10</Length><Sha256>` + validSHA + `</Sha256></RangeHash></RangeHashList>`},
+		{name: "response range mismatch", body: `<RangeHashList><RangeHash><Offset>0</Offset><Length>10</Length><Sha256>` + validSHA + `</Sha256></RangeHash><RangeHash><Offset>21</Offset><Length>10</Length><Sha256>` + validSHA + `</Sha256></RangeHash></RangeHashList>`},
+		{name: "duplicate response range", body: `<RangeHashList><RangeHash><Offset>0</Offset><Length>10</Length><Sha256>` + validSHA + `</Sha256></RangeHash><RangeHash><Offset>0</Offset><Length>10</Length><Sha256>` + validSHA + `</Sha256></RangeHash></RangeHashList>`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transport := &getBlobHashTransport{responses: []getBlobHashTransportResponse{{headers: http.Header{"Content-Type": []string{"application/xml"}}, body: test.body}}}
+			client := newGetBlobHashClient(t, "https://fake.blob.core.windows.net/container/blob", transport, nil)
+
+			_, err := client.GetBlobHash(context.Background(), ranges, blobHashOptions())
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestGetBlobHashIgnoresUnknownXMLFields(t *testing.T) {
+	ranges := []blockblob.BlobHashRange{{Offset: 0, Count: 10}}
+	response := blobHashResponse(ranges)
+	response.body = rangeHashXML(ranges, true)
+	transport := &getBlobHashTransport{responses: []getBlobHashTransportResponse{response}}
+	client := newGetBlobHashClient(t, "https://fake.blob.core.windows.net/container/blob", transport, nil)
+
+	result, err := client.GetBlobHash(context.Background(), ranges, blobHashOptions())
+	require.NoError(t, err)
+	require.Len(t, result.RangeHashes, 1)
+	require.Equal(t, blobHashForRange(ranges[0]), result.RangeHashes[0].SHA256)
+}
+
+func TestGetBlobHashSnapshotAndVersionQueries(t *testing.T) {
+	ranges := []blockblob.BlobHashRange{{Offset: 0, Count: 1}}
+	transport := &getBlobHashTransport{responses: []getBlobHashTransportResponse{blobHashResponse(ranges), blobHashResponse(ranges)}}
+	client := newGetBlobHashClient(t, "https://fake.blob.core.windows.net/container/blob?sig=secret", transport, nil)
+
+	snapshotClient, err := client.WithSnapshot("snapshot-value")
+	require.NoError(t, err)
+	_, err = snapshotClient.GetBlobHash(context.Background(), ranges, blobHashOptions())
+	require.NoError(t, err)
+
+	versionClient, err := client.WithVersionID("version-value")
+	require.NoError(t, err)
+	_, err = versionClient.GetBlobHash(context.Background(), ranges, blobHashOptions())
+	require.NoError(t, err)
+
+	require.Equal(t, "snapshot-value", transport.request(0).URL.Query().Get("snapshot"))
+	require.Equal(t, "secret", transport.request(0).URL.Query().Get("sig"))
+	require.Equal(t, "version-value", transport.request(1).URL.Query().Get("versionid"))
+	require.Equal(t, "secret", transport.request(1).URL.Query().Get("sig"))
+}
+
+func TestGetBlobHashErrors(t *testing.T) {
+	tests := []struct {
+		statusCode int
+		errorCode  string
+	}{
+		{statusCode: http.StatusBadRequest, errorCode: "InvalidHeaderValue"},
+		{statusCode: http.StatusNotFound, errorCode: "BlobNotFound"},
+		{statusCode: http.StatusConflict, errorCode: "FeatureVersionMismatch"},
+		{statusCode: http.StatusPreconditionFailed, errorCode: "ConditionNotMet"},
+		{statusCode: http.StatusRequestedRangeNotSatisfiable, errorCode: "InvalidRange"},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%d", test.statusCode), func(t *testing.T) {
+			headers := http.Header{}
+			headers.Set("x-ms-error-code", test.errorCode)
+			transport := &getBlobHashTransport{responses: []getBlobHashTransportResponse{{
+				statusCode: test.statusCode,
+				headers:    headers,
+				body:       `<Error><Code>` + test.errorCode + `</Code><Message>request failed</Message></Error>`,
+			}}}
+			client := newGetBlobHashClient(t, "https://fake.blob.core.windows.net/container/blob", transport, nil)
+
+			_, err := client.GetBlobHash(context.Background(), []blockblob.BlobHashRange{{Offset: 0, Count: 1}}, blobHashOptions())
+			require.Error(t, err)
+			var responseError *azcore.ResponseError
+			require.ErrorAs(t, err, &responseError)
+			require.Equal(t, test.statusCode, responseError.StatusCode)
+			require.Equal(t, test.errorCode, responseError.ErrorCode)
+		})
+	}
+}
+
+func TestGetBlobHashETagMutation(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("x-ms-error-code", "ConditionNotMet")
+	transport := &getBlobHashTransport{responses: []getBlobHashTransportResponse{{
+		statusCode: http.StatusPreconditionFailed,
+		headers:    headers,
+		body:       `<Error><Code>ConditionNotMet</Code><Message>The blob changed.</Message></Error>`,
+	}}}
+	client := newGetBlobHashClient(t, "https://fake.blob.core.windows.net/container/blob", transport, nil)
+
+	_, err := client.GetBlobHash(context.Background(), []blockblob.BlobHashRange{{Offset: 0, Count: 1}}, blobHashOptions())
+	var responseError *azcore.ResponseError
+	require.ErrorAs(t, err, &responseError)
+	require.Equal(t, http.StatusPreconditionFailed, responseError.StatusCode)
+	require.Equal(t, "ConditionNotMet", responseError.ErrorCode)
+}
+
+func TestGetBlobHashCancellation(t *testing.T) {
+	transport := &getBlobHashTransport{responses: []getBlobHashTransportResponse{{}}}
+	client := newGetBlobHashClient(t, "https://fake.blob.core.windows.net/container/blob", transport, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.GetBlobHash(ctx, []blockblob.BlobHashRange{{Offset: 0, Count: 1}}, blobHashOptions())
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.Canceled))
+	require.LessOrEqual(t, transport.requestCount(), 1)
+}
+
+func TestGetBlobHashRetry(t *testing.T) {
+	ranges := []blockblob.BlobHashRange{{Offset: 0, Count: 1}}
+	transport := &getBlobHashTransport{responses: []getBlobHashTransportResponse{
+		{statusCode: http.StatusInternalServerError, body: `<Error><Code>InternalError</Code></Error>`},
+		blobHashResponse(ranges),
+	}}
+	client := newGetBlobHashClient(t, "https://fake.blob.core.windows.net/container/blob", transport, func(options *blockblob.ClientOptions) {
+		options.Retry = policy.RetryOptions{MaxRetries: 1, RetryDelay: time.Millisecond, MaxRetryDelay: time.Millisecond}
+	})
+
+	response, err := client.GetBlobHash(context.Background(), ranges, blobHashOptions())
+	require.NoError(t, err)
+	require.Len(t, response.RangeHashes, 1)
+	require.Equal(t, 2, transport.requestCount())
+	require.Equal(t,
+		getBlobHashHeaderValue(transport.request(0).Header, "x-ms-multi-range"),
+		getBlobHashHeaderValue(transport.request(1).Header, "x-ms-multi-range"))
+}
+
+func TestGetBlockListDoesNotUseGetBlobHashWireContract(t *testing.T) {
+	const body = `<?xml version="1.0" encoding="utf-8"?><BlockList><CommittedBlocks/></BlockList>`
+	transport := &getBlobHashTransport{responses: []getBlobHashTransportResponse{{body: body}}}
+	client := newGetBlobHashClient(t, "https://fake.blob.core.windows.net/container/blob", transport, nil)
+
+	_, err := client.GetBlockList(context.Background(), blockblob.BlockListTypeCommitted, &blockblob.GetBlockListOptions{
+		Include: []blockblob.BlockListIncludeItem{blockblob.BlockListIncludeItemSha256},
+	})
+	require.NoError(t, err)
+	req := transport.request(0)
+	require.Equal(t, "blocklist", req.URL.Query().Get("comp"))
+	require.Equal(t, "sha256", req.URL.Query().Get("include"))
+	require.Empty(t, getBlobHashHeaderValue(req.Header, "x-ms-hash-algorithm"))
+	require.Empty(t, getBlobHashHeaderValue(req.Header, "x-ms-multi-range"))
+	require.Empty(t, getBlobHashHeaderValue(req.Header, "x-ms-sha256-block-indices"))
+}

--- a/sdk/storage/azblob/blockblob/get_block_list_response_test.go
+++ b/sdk/storage/azblob/blockblob/get_block_list_response_test.go
@@ -1,0 +1,66 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package blockblob_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+	"github.com/stretchr/testify/require"
+)
+
+type getBlockListCPUTimeHeadersPolicy struct{}
+
+func (getBlockListCPUTimeHeadersPolicy) Do(req *policy.Request) (*http.Response, error) {
+	headers := http.Header{}
+	headers.Set("x-ms-test-dedupe-crc64-cpu-time-us", "123")
+	headers.Set("x-ms-test-dedupe-sha256-cpu-time-us", "456")
+
+	const body = `<?xml version="1.0" encoding="utf-8"?>
+<BlockList>
+  <CommittedBlocks>
+    <Block>
+      <Name>YmxvY2swMDAwMDE=</Name>
+      <Size>20</Size>
+    </Block>
+  </CommittedBlocks>
+</BlockList>`
+
+	return &http.Response{
+		Request:    req.Raw(),
+		Status:     "200 OK",
+		StatusCode: http.StatusOK,
+		Header:     headers,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+func TestGetBlockListCPUTimeHeaders(t *testing.T) {
+	client, err := blockblob.NewClientWithNoCredential("https://fake.blob.core.windows.net/container/blob", &blockblob.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			PerCallPolicies: []policy.Policy{getBlockListCPUTimeHeadersPolicy{}},
+		},
+	})
+	require.NoError(t, err)
+
+	response, err := client.GetBlockList(context.Background(), blockblob.BlockListTypeCommitted, nil)
+	require.NoError(t, err)
+
+	var crc64CPUTimeUS *int64 = response.CRC64CPUTimeUS
+	var sha256CPUTimeUS *int64 = response.SHA256CPUTimeUS
+	require.Equal(t, int64(123), *crc64CPUTimeUS)
+	require.Equal(t, int64(456), *sha256CPUTimeUS)
+
+	require.Len(t, response.BlockList.CommittedBlocks, 1)
+	require.Equal(t, "YmxvY2swMDAwMDE=", *response.BlockList.CommittedBlocks[0].Name)
+	require.Equal(t, int64(20), *response.BlockList.CommittedBlocks[0].Size)
+}

--- a/sdk/storage/azblob/blockblob/models.go
+++ b/sdk/storage/azblob/blockblob/models.go
@@ -248,6 +248,45 @@ func (o *GetBlockListOptions) format() (*generated.BlockBlobClientGetBlockListOp
 	return &generated.BlockBlobClientGetBlockListOptions{Snapshot: o.Snapshot, Include: o.Include}, leaseAccessConditions, modifiedAccessConditions
 }
 
+// BlobHashRange identifies a byte range to hash.
+type BlobHashRange struct {
+	// Offset is the zero-based start offset in the blob.
+	Offset int64
+
+	// Count is the positive number of bytes to hash.
+	Count int64
+}
+
+// BlobHashResult contains the SHA256 hash returned for a byte range.
+type BlobHashResult struct {
+	// Offset is the zero-based start offset in the blob.
+	Offset int64
+
+	// Count is the number of bytes hashed.
+	Count int64
+
+	// SHA256 is the 32-byte SHA256 hash of the range.
+	SHA256 []byte
+}
+
+// GetBlobHashOptions contains the parameters for the Client.GetBlobHash method.
+type GetBlobHashOptions struct {
+	// AccessConditions must contain an exact IfMatch ETag from the preceding GetBlockList call.
+	AccessConditions *blob.AccessConditions
+
+	// CPKInfo contains the optional customer-provided encryption key.
+	CPKInfo *blob.CPKInfo
+}
+
+func (o *GetBlobHashOptions) format() (*generated.BlockBlobClientGetBlobHashOptions, *generated.LeaseAccessConditions, *generated.CPKInfo, *generated.ModifiedAccessConditions) {
+	if o == nil {
+		return nil, nil, nil, nil
+	}
+
+	leaseAccessConditions, modifiedAccessConditions := exported.FormatBlobAccessConditions(o.AccessConditions)
+	return nil, leaseAccessConditions, o.CPKInfo, modifiedAccessConditions
+}
+
 // ------------------------------------------------------------
 
 // uploadFromReaderOptions identifies options used by the UploadBuffer and UploadFile functions.

--- a/sdk/storage/azblob/blockblob/models.go
+++ b/sdk/storage/azblob/blockblob/models.go
@@ -232,6 +232,11 @@ type CommitBlockListOptions struct {
 type GetBlockListOptions struct {
 	Snapshot         *string
 	AccessConditions *blob.AccessConditions
+
+	// Include specifies additional per-block datasets to return, such as the crc64 and sha256 content
+	// hashes. This requires service-side support (feature-flagged) and is only honored for
+	// BlockListTypeCommitted.
+	Include []BlockListIncludeItem
 }
 
 func (o *GetBlockListOptions) format() (*generated.BlockBlobClientGetBlockListOptions, *generated.LeaseAccessConditions, *generated.ModifiedAccessConditions) {
@@ -240,7 +245,7 @@ func (o *GetBlockListOptions) format() (*generated.BlockBlobClientGetBlockListOp
 	}
 
 	leaseAccessConditions, modifiedAccessConditions := exported.FormatBlobAccessConditions(o.AccessConditions)
-	return &generated.BlockBlobClientGetBlockListOptions{Snapshot: o.Snapshot}, leaseAccessConditions, modifiedAccessConditions
+	return &generated.BlockBlobClientGetBlockListOptions{Snapshot: o.Snapshot, Include: o.Include}, leaseAccessConditions, modifiedAccessConditions
 }
 
 // ------------------------------------------------------------

--- a/sdk/storage/azblob/blockblob/responses.go
+++ b/sdk/storage/azblob/blockblob/responses.go
@@ -28,6 +28,36 @@ type StageBlockFromURLResponse = generated.BlockBlobClientStageBlockFromURLRespo
 // GetBlockListResponse contains the response from method Client.GetBlockList.
 type GetBlockListResponse = generated.BlockBlobClientGetBlockListResponse
 
+// GetBlobHashResponse contains the response from method Client.GetBlobHash.
+type GetBlobHashResponse struct {
+	// RangeHashes contains one result for every requested range.
+	RangeHashes []BlobHashResult
+
+	// ETag contains the blob ETag used to calculate the hashes.
+	ETag *azcore.ETag
+
+	// LastModified contains the blob's last-modified time.
+	LastModified *time.Time
+
+	// BlobContentLength contains the blob's length in bytes.
+	BlobContentLength *int64
+
+	// HashAlgorithm contains the algorithm reported by the service.
+	HashAlgorithm *string
+
+	// RequestID contains the service-generated request ID.
+	RequestID *string
+
+	// SHA256CPUTimeUS contains the server CPU time spent calculating SHA256 hashes, in microseconds.
+	SHA256CPUTimeUS *int64
+
+	// ClientRequestID contains the client-generated request ID.
+	ClientRequestID *string
+
+	// Version contains the service version used for the response.
+	Version *string
+}
+
 // uploadFromReaderResponse contains the response from method Client.UploadBuffer/Client.UploadFile.
 type uploadFromReaderResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.

--- a/sdk/storage/azblob/internal/generated/autorest.md
+++ b/sdk/storage/azblob/internal/generated/autorest.md
@@ -131,6 +131,39 @@ directive:
     $.parameters.push({ "$ref": "#/parameters/GetBlockListInclude" });
 ```
 
+### Add dedupe CPU time response headers to GetBlockList
+``` yaml
+directive:
+- from: swagger-document
+  where: $["x-ms-paths"]["/{containerName}/{blob}?comp=blocklist"].get.responses["200"].headers
+  transform: >
+    $["x-ms-test-dedupe-crc64-cpu-time-us"] = {
+      "x-ms-client-name": "CRC64CPUTimeUS",
+      "type": "integer",
+      "format": "int64",
+      "description": "The server CPU time spent calculating CRC64 hashes, in microseconds."
+    };
+    $["x-ms-test-dedupe-sha256-cpu-time-us"] = {
+      "x-ms-client-name": "SHA256CPUTimeUS",
+      "type": "integer",
+      "format": "int64",
+      "description": "The server CPU time spent calculating SHA256 hashes, in microseconds."
+    };
+```
+
+### Ignore invalid dedupe CPU time response headers
+``` yaml
+directive:
+- from: zz_blockblob_client.go
+  where: $
+  transform: >-
+    return $.
+      replace(/if val := resp\.Header\.Get\("x-ms-test-dedupe-crc64-cpu-time-us"\); val != "" \{\s+cRC64CPUTimeUS, err := strconv\.ParseInt\(val, 10, 64\)\s+if err != nil \{\s+return BlockBlobClientGetBlockListResponse\{\}, err\s+\}\s+result\.CRC64CPUTimeUS = &cRC64CPUTimeUS\s+\}/,
+      `if val := resp.Header.Get("x-ms-test-dedupe-crc64-cpu-time-us"); val != "" {\n\t\tcrc64CPUTimeUS, err := strconv.ParseInt(val, 10, 64)\n\t\tif err == nil && crc64CPUTimeUS >= 0 {\n\t\t\tresult.CRC64CPUTimeUS = &crc64CPUTimeUS\n\t\t}\n\t}`).
+      replace(/if val := resp\.Header\.Get\("x-ms-test-dedupe-sha256-cpu-time-us"\); val != "" \{\s+sHA256CPUTimeUS, err := strconv\.ParseInt\(val, 10, 64\)\s+if err != nil \{\s+return BlockBlobClientGetBlockListResponse\{\}, err\s+\}\s+result\.SHA256CPUTimeUS = &sHA256CPUTimeUS\s+\}/,
+      `if val := resp.Header.Get("x-ms-test-dedupe-sha256-cpu-time-us"); val != "" {\n\t\tsha256CPUTimeUS, err := strconv.ParseInt(val, 10, 64)\n\t\tif err == nil && sha256CPUTimeUS >= 0 {\n\t\t\tresult.SHA256CPUTimeUS = &sha256CPUTimeUS\n\t\t}\n\t}`);
+```
+
 ### Undo breaking change with BlobName 
 ``` yaml
 directive:

--- a/sdk/storage/azblob/internal/generated/autorest.md
+++ b/sdk/storage/azblob/internal/generated/autorest.md
@@ -105,6 +105,32 @@ directive:
     };
 ```
 
+### Add include query parameter to GetBlockList (per-block crc64/sha256 hashes)
+``` yaml
+directive:
+- from: swagger-document
+  where: $.parameters
+  transform: >
+    $.GetBlockListInclude = {
+      "name": "include",
+      "in": "query",
+      "required": false,
+      "type": "array",
+      "collectionFormat": "csv",
+      "items": {
+        "type": "string",
+        "enum": ["crc64", "sha256"],
+        "x-ms-enum": { "name": "BlockListIncludeItem", "modelAsString": false }
+      },
+      "x-ms-parameter-location": "method",
+      "description": "Specifies one or more datasets to include in the response, such as the per-block crc64 and sha256 content hashes. Requires service-side support and is only honored for committed block lists."
+    };
+- from: swagger-document
+  where: $["x-ms-paths"]["/{containerName}/{blob}?comp=blocklist"].get
+  transform: >
+    $.parameters.push({ "$ref": "#/parameters/GetBlockListInclude" });
+```
+
 ### Undo breaking change with BlobName 
 ``` yaml
 directive:

--- a/sdk/storage/azblob/internal/generated/autorest.md
+++ b/sdk/storage/azblob/internal/generated/autorest.md
@@ -82,6 +82,29 @@ directive:
       };
 ```
 
+### Add Offset, Crc64, and Sha256 to the Block definition
+``` yaml
+directive:
+- from: swagger-document
+  where: $.definitions
+  transform: >
+    $.Block.properties["Offset"] = {
+      "type": "integer",
+      "format": "int64",
+      "description": "The block's start offset in the blob, in bytes."
+    };
+    $.Block.properties["Crc64"] = {
+      "type": "string",
+      "format": "byte",
+      "description": "The CRC64 hash of the block."
+    };
+    $.Block.properties["Sha256"] = {
+      "type": "string",
+      "format": "byte",
+      "description": "The SHA256 hash of the block."
+    };
+```
+
 ### Undo breaking change with BlobName 
 ``` yaml
 directive:

--- a/sdk/storage/azblob/internal/generated/autorest.md
+++ b/sdk/storage/azblob/internal/generated/autorest.md
@@ -96,12 +96,49 @@ directive:
     $.Block.properties["Crc64"] = {
       "type": "string",
       "format": "byte",
+      "x-ms-client-name": "Crc64",
       "description": "The CRC64 hash of the block."
     };
     $.Block.properties["Sha256"] = {
       "type": "string",
       "format": "byte",
+      "x-ms-client-name": "Sha256",
       "description": "The SHA256 hash of the block."
+    };
+    $.RangeHash = {
+      "type": "object",
+      "xml": { "name": "RangeHash" },
+      "required": ["Offset", "Length", "Sha256"],
+      "properties": {
+        "Offset": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The range's start offset in the blob, in bytes."
+        },
+        "Length": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The range's length, in bytes."
+        },
+        "Sha256": {
+          "type": "string",
+          "format": "byte",
+          "x-ms-client-name": "Sha256",
+          "description": "The SHA256 hash of the range."
+        }
+      }
+    };
+    $.RangeHashList = {
+      "type": "object",
+      "xml": { "name": "RangeHashList" },
+      "required": ["RangeHash"],
+      "properties": {
+        "RangeHash": {
+          "type": "array",
+          "x-ms-client-name": "RangeHashes",
+          "items": { "$ref": "#/definitions/RangeHash" }
+        }
+      }
     };
 ```
 
@@ -120,7 +157,14 @@ directive:
       "items": {
         "type": "string",
         "enum": ["crc64", "sha256"],
-        "x-ms-enum": { "name": "BlockListIncludeItem", "modelAsString": false }
+        "x-ms-enum": {
+          "name": "BlockListIncludeItem",
+          "modelAsString": false,
+          "values": [
+            { "value": "crc64", "name": "Crc64" },
+            { "value": "sha256", "name": "Sha256" }
+          ]
+        }
       },
       "x-ms-parameter-location": "method",
       "description": "Specifies one or more datasets to include in the response, such as the per-block crc64 and sha256 content hashes. Requires service-side support and is only honored for committed block lists."
@@ -129,6 +173,150 @@ directive:
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=blocklist"].get
   transform: >
     $.parameters.push({ "$ref": "#/parameters/GetBlockListInclude" });
+```
+
+### Preserve the established public dedupe hash names
+``` yaml
+directive:
+- from: zz_constants.go
+  where: $
+  transform: >-
+    return $.
+      replaceAll(`BlockListIncludeItemCRC64`, `BlockListIncludeItemCrc64`).
+      replaceAll(`BlockListIncludeItemSHA256`, `BlockListIncludeItemSha256`);
+- from: zz_models.go
+  where: $
+  transform: >-
+    return $.
+      replace(/\bCRC64 \[\]byte/, `Crc64 []byte`).
+      replace(/\bSHA256 \[\]byte/g, `Sha256 []byte`);
+- from: zz_models_serde.go
+  where: $
+  transform: >-
+    return $.
+      replaceAll(`CRC64`, `Crc64`).
+      replaceAll(`SHA256`, `Sha256`).
+      replaceAll(`if aux.Sha256 != nil {`,
+      `if aux.Sha256 != nil {\n\t\tif len(*aux.Sha256) > 0 && (*aux.Sha256)[0] == '"' && (len(*aux.Sha256) < 2 || (*aux.Sha256)[len(*aux.Sha256)-1] != '"') {\n\t\t\treturn fmt.Errorf("invalid quoted base64 value")\n\t\t}`);
+```
+
+### Add the XStore selective multi-range GetBlobHash operation
+``` yaml
+directive:
+- from: swagger-document
+  where: $.parameters
+  transform: >
+    $.GetBlobHashAlgorithm = {
+      "name": "x-ms-hash-algorithm",
+      "x-ms-client-name": "hashAlgorithm",
+      "in": "header",
+      "required": true,
+      "type": "string",
+      "enum": ["Sha256"],
+      "x-ms-enum": {
+        "name": "BlobHashAlgorithm",
+        "modelAsString": false
+      },
+      "x-ms-parameter-location": "method",
+      "description": "Specifies Sha256 as the hash algorithm for the requested ranges."
+    };
+    $.GetBlobHashMultiRange = {
+      "name": "x-ms-multi-range",
+      "x-ms-client-name": "multiRange",
+      "in": "header",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "description": "Specifies sorted, non-overlapping inclusive byte ranges to hash."
+    };
+- from: swagger-document
+  where: $["x-ms-paths"]
+  transform: >
+    const blockListPath = $["/{containerName}/{blob}?comp=blocklist"];
+    const getBlobHashPath = JSON.parse(JSON.stringify(blockListPath));
+    delete getBlobHashPath.put;
+    getBlobHashPath.parameters[2].enum = ["hash"];
+    getBlobHashPath.get = {
+      "tags": ["blockblob"],
+      "operationId": "BlockBlob_GetBlobHash",
+      "description": "Calculates SHA256 hashes for selected byte ranges in a block blob.",
+      "parameters": [
+        { "$ref": "#/parameters/GetBlobHashAlgorithm" },
+        { "$ref": "#/parameters/GetBlobHashMultiRange" },
+        { "$ref": "#/parameters/Timeout" },
+        { "$ref": "#/parameters/LeaseIdOptional" },
+        { "$ref": "#/parameters/EncryptionKey" },
+        { "$ref": "#/parameters/EncryptionKeySha256" },
+        { "$ref": "#/parameters/EncryptionAlgorithm" },
+        { "$ref": "#/parameters/IfModifiedSince" },
+        { "$ref": "#/parameters/IfUnmodifiedSince" },
+        { "$ref": "#/parameters/IfMatch" },
+        { "$ref": "#/parameters/IfNoneMatch" },
+        { "$ref": "#/parameters/IfTags" },
+        { "$ref": "#/parameters/ApiVersionParameter" },
+        { "$ref": "#/parameters/ClientRequestId" }
+      ],
+      "responses": {
+        "200": {
+          "description": "The SHA256 hashes were calculated.",
+          "headers": {
+            "Last-Modified": {
+              "type": "string",
+              "format": "date-time-rfc1123"
+            },
+            "ETag": {
+              "type": "string"
+            },
+            "x-ms-blob-content-length": {
+              "x-ms-client-name": "BlobContentLength",
+              "type": "integer",
+              "format": "int64"
+            },
+            "x-ms-hash-algorithm": {
+              "x-ms-client-name": "HashAlgorithm",
+              "type": "string"
+            },
+            "x-ms-test-dedupe-sha256-cpu-time-us": {
+              "x-ms-client-name": "SHA256CPUTimeUS",
+              "type": "integer",
+              "format": "int64",
+              "description": "The server CPU time spent calculating SHA256 hashes, in microseconds."
+            },
+            "x-ms-client-request-id": {
+              "x-ms-client-name": "ClientRequestId",
+              "type": "string"
+            },
+            "x-ms-request-id": {
+              "x-ms-client-name": "RequestId",
+              "type": "string"
+            },
+            "x-ms-version": {
+              "x-ms-client-name": "Version",
+              "type": "string"
+            },
+            "Date": {
+              "type": "string",
+              "format": "date-time-rfc1123"
+            }
+          },
+          "schema": { "$ref": "#/definitions/RangeHashList" }
+        },
+        "default": JSON.parse(JSON.stringify(blockListPath.get.responses["default"]))
+      }
+    };
+    $["/{containerName}/{blob}?comp=hash"] = getBlobHashPath;
+```
+
+### Drain GetBlobHash bodies on every response parsing path
+``` yaml
+directive:
+- from: zz_blockblob_client.go
+  where: $
+  transform: >-
+    return $.replace(
+      /func \(client \*BlockBlobClient\) getBlobHashHandleResponse\(resp \*http\.Response\) \(BlockBlobClientGetBlobHashResponse, error\) \{\s+result := BlockBlobClientGetBlobHashResponse\{\}/,
+      `func (client *BlockBlobClient) getBlobHashHandleResponse(resp *http.Response) (BlockBlobClientGetBlobHashResponse, error) {\n\tdefer runtime.Drain(resp)\n\tresult := BlockBlobClientGetBlobHashResponse{}`
+    );
 ```
 
 ### Add dedupe CPU time response headers to GetBlockList
@@ -160,7 +348,7 @@ directive:
     return $.
       replace(/if val := resp\.Header\.Get\("x-ms-test-dedupe-crc64-cpu-time-us"\); val != "" \{\s+cRC64CPUTimeUS, err := strconv\.ParseInt\(val, 10, 64\)\s+if err != nil \{\s+return BlockBlobClientGetBlockListResponse\{\}, err\s+\}\s+result\.CRC64CPUTimeUS = &cRC64CPUTimeUS\s+\}/,
       `if val := resp.Header.Get("x-ms-test-dedupe-crc64-cpu-time-us"); val != "" {\n\t\tcrc64CPUTimeUS, err := strconv.ParseInt(val, 10, 64)\n\t\tif err == nil && crc64CPUTimeUS >= 0 {\n\t\t\tresult.CRC64CPUTimeUS = &crc64CPUTimeUS\n\t\t}\n\t}`).
-      replace(/if val := resp\.Header\.Get\("x-ms-test-dedupe-sha256-cpu-time-us"\); val != "" \{\s+sHA256CPUTimeUS, err := strconv\.ParseInt\(val, 10, 64\)\s+if err != nil \{\s+return BlockBlobClientGetBlockListResponse\{\}, err\s+\}\s+result\.SHA256CPUTimeUS = &sHA256CPUTimeUS\s+\}/,
+      replace(/if val := resp\.Header\.Get\("x-ms-test-dedupe-sha256-cpu-time-us"\); val != "" \{\s+sHA256CPUTimeUS, err := strconv\.ParseInt\(val, 10, 64\)\s+if err != nil \{\s+return BlockBlobClientGet(?:BlobHash|BlockList)Response\{\}, err\s+\}\s+result\.SHA256CPUTimeUS = &sHA256CPUTimeUS\s+\}/g,
       `if val := resp.Header.Get("x-ms-test-dedupe-sha256-cpu-time-us"); val != "" {\n\t\tsha256CPUTimeUS, err := strconv.ParseInt(val, 10, 64)\n\t\tif err == nil && sha256CPUTimeUS >= 0 {\n\t\t\tresult.SHA256CPUTimeUS = &sha256CPUTimeUS\n\t\t}\n\t}`);
 ```
 

--- a/sdk/storage/azblob/internal/generated/block_cpu_time_headers_test.go
+++ b/sdk/storage/azblob/internal/generated/block_cpu_time_headers_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package generated
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const successfulBlockListXML = `<?xml version="1.0" encoding="utf-8"?>
+<BlockList>
+  <CommittedBlocks>
+    <Block>
+      <Name>YmxvY2swMDAwMDE=</Name>
+      <Size>20</Size>
+    </Block>
+  </CommittedBlocks>
+</BlockList>`
+
+func TestGetBlockListCPUTimeHeaders(t *testing.T) {
+	const (
+		crc64Header  = "x-ms-test-dedupe-crc64-cpu-time-us"
+		sha256Header = "x-ms-test-dedupe-sha256-cpu-time-us"
+	)
+
+	int64Ptr := func(value int64) *int64 {
+		return &value
+	}
+
+	tests := []struct {
+		name       string
+		headers    map[string]string
+		wantCRC64  *int64
+		wantSHA256 *int64
+	}{
+		{
+			name:       "both valid positive",
+			headers:    map[string]string{crc64Header: "123", sha256Header: "456"},
+			wantCRC64:  int64Ptr(123),
+			wantSHA256: int64Ptr(456),
+		},
+		{
+			name:       "zero",
+			headers:    map[string]string{crc64Header: "0", sha256Header: "0"},
+			wantCRC64:  int64Ptr(0),
+			wantSHA256: int64Ptr(0),
+		},
+		{
+			name:    "both missing",
+			headers: map[string]string{},
+		},
+		{
+			name:      "SHA256 missing",
+			headers:   map[string]string{crc64Header: "123"},
+			wantCRC64: int64Ptr(123),
+		},
+		{
+			name:       "CRC64 missing",
+			headers:    map[string]string{sha256Header: "456"},
+			wantSHA256: int64Ptr(456),
+		},
+		{
+			name:    "malformed",
+			headers: map[string]string{crc64Header: "not-a-number", sha256Header: "1.5"},
+		},
+		{
+			name:    "negative",
+			headers: map[string]string{crc64Header: "-1", sha256Header: "-2"},
+		},
+		{
+			name:    "int64 overflow",
+			headers: map[string]string{crc64Header: "9223372036854775808", sha256Header: "9223372036854775808"},
+		},
+		{
+			name:      "valid CRC64 and invalid SHA256",
+			headers:   map[string]string{crc64Header: "123", sha256Header: "invalid"},
+			wantCRC64: int64Ptr(123),
+		},
+		{
+			name:       "invalid CRC64 and valid SHA256",
+			headers:    map[string]string{crc64Header: "-1", sha256Header: "456"},
+			wantSHA256: int64Ptr(456),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			headers := http.Header{}
+			for name, value := range test.headers {
+				headers.Set(name, value)
+			}
+
+			httpResponse := &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     headers,
+				Body:       io.NopCloser(strings.NewReader(successfulBlockListXML)),
+			}
+
+			response, err := (&BlockBlobClient{}).getBlockListHandleResponse(httpResponse)
+			require.NoError(t, err)
+			require.Equal(t, test.wantCRC64, response.CRC64CPUTimeUS)
+			require.Equal(t, test.wantSHA256, response.SHA256CPUTimeUS)
+
+			require.Len(t, response.BlockList.CommittedBlocks, 1)
+			require.Equal(t, "YmxvY2swMDAwMDE=", *response.BlockList.CommittedBlocks[0].Name)
+			require.Equal(t, int64(20), *response.BlockList.CommittedBlocks[0].Size)
+		})
+	}
+}

--- a/sdk/storage/azblob/internal/generated/block_serde_test.go
+++ b/sdk/storage/azblob/internal/generated/block_serde_test.go
@@ -4,6 +4,7 @@
 package generated
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/xml"
 	"testing"
@@ -81,4 +82,31 @@ func TestBlockListUnmarshalXMLWithoutHashes(t *testing.T) {
 	require.Nil(t, block.Offset)
 	require.Nil(t, block.Crc64)
 	require.Nil(t, block.Sha256)
+}
+
+// TestGetBlockListCreateRequestInclude verifies that GetBlockList emits the
+// include=crc64,sha256 query parameter (which XStore gates the hashes on) only
+// when the Include option is set, and omits it otherwise for back-compat.
+func TestGetBlockListCreateRequestInclude(t *testing.T) {
+	client := &BlockBlobClient{endpoint: "https://acct.blob.core.windows.net/container/blob"}
+
+	req, err := client.getBlockListCreateRequest(
+		context.Background(),
+		BlockListTypeCommitted,
+		&BlockBlobClientGetBlockListOptions{
+			Include: []BlockListIncludeItem{BlockListIncludeItemCrc64, BlockListIncludeItemSha256},
+		},
+		nil, nil)
+	require.NoError(t, err)
+	q := req.Raw().URL.Query()
+	require.Equal(t, "committed", q.Get("blocklisttype"))
+	require.Equal(t, "blocklist", q.Get("comp"))
+	require.Equal(t, "crc64,sha256", q.Get("include"))
+
+	req, err = client.getBlockListCreateRequest(
+		context.Background(),
+		BlockListTypeCommitted,
+		nil, nil, nil)
+	require.NoError(t, err)
+	require.Empty(t, req.Raw().URL.Query().Get("include"))
 }

--- a/sdk/storage/azblob/internal/generated/block_serde_test.go
+++ b/sdk/storage/azblob/internal/generated/block_serde_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package generated
+
+import (
+	"encoding/base64"
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBlockListUnmarshalXMLWithHashes verifies that GetBlockList responses
+// containing the per-block Offset, Crc64, and Sha256 elements are decoded into
+// the Block model, with the base64-encoded hashes decoded to raw bytes.
+func TestBlockListUnmarshalXMLWithHashes(t *testing.T) {
+	const body = `<?xml version="1.0" encoding="utf-8"?>
+<BlockList>
+  <CommittedBlocks>
+    <Block>
+      <Name>YmxvY2stMDAwMDAx</Name>
+      <Size>4194304</Size>
+      <Offset>0</Offset>
+      <Crc64>q83vEjRWeJA=</Crc64>
+      <Sha256>7j3H4Y7l0QFvZ2f9Pq6c8oP2Y9W3xV8QmQkF0x9abcA=</Sha256>
+    </Block>
+    <Block>
+      <Name>YmxvY2stMDAwMDAy</Name>
+      <Size>8388608</Size>
+      <Offset>4194304</Offset>
+      <Crc64>AbCdEfGhIjk=</Crc64>
+      <Sha256>rM2L7p8s9q0tU1vW2xY3zA4bC5dE6fG7hI8jK9lMnO0=</Sha256>
+    </Block>
+  </CommittedBlocks>
+</BlockList>`
+
+	var bl BlockList
+	require.NoError(t, xml.Unmarshal([]byte(body), &bl))
+	require.Len(t, bl.CommittedBlocks, 2)
+	require.Empty(t, bl.UncommittedBlocks)
+
+	first := bl.CommittedBlocks[0]
+	require.Equal(t, "YmxvY2stMDAwMDAx", *first.Name)
+	require.Equal(t, int64(4194304), *first.Size)
+	require.Equal(t, int64(0), *first.Offset)
+	require.Len(t, first.Crc64, 8)
+	require.Len(t, first.Sha256, 32)
+	require.Equal(t, "q83vEjRWeJA=", base64.StdEncoding.EncodeToString(first.Crc64))
+	require.Equal(t, "7j3H4Y7l0QFvZ2f9Pq6c8oP2Y9W3xV8QmQkF0x9abcA=", base64.StdEncoding.EncodeToString(first.Sha256))
+
+	second := bl.CommittedBlocks[1]
+	require.Equal(t, "YmxvY2stMDAwMDAy", *second.Name)
+	require.Equal(t, int64(8388608), *second.Size)
+	require.Equal(t, int64(4194304), *second.Offset)
+	require.Equal(t, "AbCdEfGhIjk=", base64.StdEncoding.EncodeToString(second.Crc64))
+	require.Equal(t, "rM2L7p8s9q0tU1vW2xY3zA4bC5dE6fG7hI8jK9lMnO0=", base64.StdEncoding.EncodeToString(second.Sha256))
+}
+
+// TestBlockListUnmarshalXMLWithoutHashes verifies that the legacy GetBlockList
+// response (without Offset/Crc64/Sha256) still decodes, leaving the new fields
+// nil for backward compatibility.
+func TestBlockListUnmarshalXMLWithoutHashes(t *testing.T) {
+	const body = `<?xml version="1.0" encoding="utf-8"?>
+<BlockList>
+  <CommittedBlocks>
+    <Block>
+      <Name>YmxvY2stMDAwMDAx</Name>
+      <Size>4194304</Size>
+    </Block>
+  </CommittedBlocks>
+</BlockList>`
+
+	var bl BlockList
+	require.NoError(t, xml.Unmarshal([]byte(body), &bl))
+	require.Len(t, bl.CommittedBlocks, 1)
+
+	block := bl.CommittedBlocks[0]
+	require.Equal(t, "YmxvY2stMDAwMDAx", *block.Name)
+	require.Equal(t, int64(4194304), *block.Size)
+	require.Nil(t, block.Offset)
+	require.Nil(t, block.Crc64)
+	require.Nil(t, block.Sha256)
+}

--- a/sdk/storage/azblob/internal/generated/block_serde_test.go
+++ b/sdk/storage/azblob/internal/generated/block_serde_test.go
@@ -20,42 +20,28 @@ func TestBlockListUnmarshalXMLWithHashes(t *testing.T) {
 <BlockList>
   <CommittedBlocks>
     <Block>
-      <Name>YmxvY2stMDAwMDAx</Name>
-      <Size>4194304</Size>
+      <Name>YmxvY2swMDAwMDE=</Name>
+      <Size>20</Size>
       <Offset>0</Offset>
-      <Crc64>q83vEjRWeJA=</Crc64>
-      <Sha256>7j3H4Y7l0QFvZ2f9Pq6c8oP2Y9W3xV8QmQkF0x9abcA=</Sha256>
-    </Block>
-    <Block>
-      <Name>YmxvY2stMDAwMDAy</Name>
-      <Size>8388608</Size>
-      <Offset>4194304</Offset>
-      <Crc64>AbCdEfGhIjk=</Crc64>
-      <Sha256>rM2L7p8s9q0tU1vW2xY3zA4bC5dE6fG7hI8jK9lMnO0=</Sha256>
+      <Crc64>sQubqsIYts8=</Crc64>
+      <Sha256>NuGbnsTrCCJI1bP0hkUFnwAs1HIQTZc4NXcftp1cS60=</Sha256>
     </Block>
   </CommittedBlocks>
 </BlockList>`
 
 	var bl BlockList
 	require.NoError(t, xml.Unmarshal([]byte(body), &bl))
-	require.Len(t, bl.CommittedBlocks, 2)
+	require.Len(t, bl.CommittedBlocks, 1)
 	require.Empty(t, bl.UncommittedBlocks)
 
 	first := bl.CommittedBlocks[0]
-	require.Equal(t, "YmxvY2stMDAwMDAx", *first.Name)
-	require.Equal(t, int64(4194304), *first.Size)
+	require.Equal(t, "YmxvY2swMDAwMDE=", *first.Name)
+	require.Equal(t, int64(20), *first.Size)
 	require.Equal(t, int64(0), *first.Offset)
 	require.Len(t, first.Crc64, 8)
 	require.Len(t, first.Sha256, 32)
-	require.Equal(t, "q83vEjRWeJA=", base64.StdEncoding.EncodeToString(first.Crc64))
-	require.Equal(t, "7j3H4Y7l0QFvZ2f9Pq6c8oP2Y9W3xV8QmQkF0x9abcA=", base64.StdEncoding.EncodeToString(first.Sha256))
-
-	second := bl.CommittedBlocks[1]
-	require.Equal(t, "YmxvY2stMDAwMDAy", *second.Name)
-	require.Equal(t, int64(8388608), *second.Size)
-	require.Equal(t, int64(4194304), *second.Offset)
-	require.Equal(t, "AbCdEfGhIjk=", base64.StdEncoding.EncodeToString(second.Crc64))
-	require.Equal(t, "rM2L7p8s9q0tU1vW2xY3zA4bC5dE6fG7hI8jK9lMnO0=", base64.StdEncoding.EncodeToString(second.Sha256))
+	require.Equal(t, "sQubqsIYts8=", base64.StdEncoding.EncodeToString(first.Crc64))
+	require.Equal(t, "NuGbnsTrCCJI1bP0hkUFnwAs1HIQTZc4NXcftp1cS60=", base64.StdEncoding.EncodeToString(first.Sha256))
 }
 
 // TestBlockListUnmarshalXMLWithoutHashes verifies that the legacy GetBlockList

--- a/sdk/storage/azblob/internal/generated/get_blob_hash_test.go
+++ b/sdk/storage/azblob/internal/generated/get_blob_hash_test.go
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package generated
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/stretchr/testify/require"
+)
+
+type trackingGetBlobHashBody struct {
+	*strings.Reader
+	closed bool
+}
+
+func (b *trackingGetBlobHashBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+func getBlobHashHeaderValue(header http.Header, name string) string {
+	for headerName, values := range header {
+		if strings.EqualFold(headerName, name) && len(values) > 0 {
+			return values[0]
+		}
+	}
+	return ""
+}
+
+func TestGetBlobHashCreateRequest(t *testing.T) {
+	client := &BlockBlobClient{endpoint: "https://acct.blob.core.windows.net/container/blob?snapshot=snapshot-value&sig=secret"}
+	etag := azcore.ETag(`"opaque-epoch"`)
+	ifTags := `"tag" = 'value'`
+	leaseID := "lease-id"
+	requestID := "client-request"
+	timeout := int32(30)
+	algorithm := EncryptionAlgorithmTypeAES256
+	encryptionKey := "base64-key"
+	encryptionKeySHA256 := "base64-key-sha256"
+
+	req, err := client.getBlobHashCreateRequest(
+		context.Background(),
+		"bytes=0-1023,4096-6143",
+		&BlockBlobClientGetBlobHashOptions{RequestID: &requestID, Timeout: &timeout},
+		&LeaseAccessConditions{LeaseID: &leaseID},
+		&CPKInfo{
+			EncryptionAlgorithm: &algorithm,
+			EncryptionKey:       &encryptionKey,
+			EncryptionKeySHA256: &encryptionKeySHA256,
+		},
+		&ModifiedAccessConditions{IfMatch: &etag, IfTags: &ifTags},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.MethodGet, req.Raw().Method)
+	require.Equal(t, "hash", req.Raw().URL.Query().Get("comp"))
+	require.Equal(t, "snapshot-value", req.Raw().URL.Query().Get("snapshot"))
+	require.Equal(t, "secret", req.Raw().URL.Query().Get("sig"))
+	require.Equal(t, "30", req.Raw().URL.Query().Get("timeout"))
+	require.Equal(t, "Sha256", getBlobHashHeaderValue(req.Raw().Header, "x-ms-hash-algorithm"))
+	require.Equal(t, "bytes=0-1023,4096-6143", getBlobHashHeaderValue(req.Raw().Header, "x-ms-multi-range"))
+	require.Equal(t, string(etag), getBlobHashHeaderValue(req.Raw().Header, "If-Match"))
+	require.Equal(t, ifTags, getBlobHashHeaderValue(req.Raw().Header, "x-ms-if-tags"))
+	require.Equal(t, leaseID, getBlobHashHeaderValue(req.Raw().Header, "x-ms-lease-id"))
+	require.Equal(t, string(algorithm), getBlobHashHeaderValue(req.Raw().Header, "x-ms-encryption-algorithm"))
+	require.Equal(t, encryptionKey, getBlobHashHeaderValue(req.Raw().Header, "x-ms-encryption-key"))
+	require.Equal(t, encryptionKeySHA256, getBlobHashHeaderValue(req.Raw().Header, "x-ms-encryption-key-sha256"))
+	require.Equal(t, requestID, getBlobHashHeaderValue(req.Raw().Header, "x-ms-client-request-id"))
+	require.Equal(t, "2025-11-05", getBlobHashHeaderValue(req.Raw().Header, "x-ms-version"))
+	require.True(t, req.Raw().Body == nil || req.Raw().Body == http.NoBody)
+	require.Zero(t, req.Raw().ContentLength)
+}
+
+func TestGetBlobHashHandleResponse(t *testing.T) {
+	firstHash := bytes.Repeat([]byte{0x11}, sha256.Size)
+	secondHash := bytes.Repeat([]byte{0x22}, sha256.Size)
+	body := `<RangeHashList>
+		<FutureRootField>ignored</FutureRootField>
+		<RangeHash><Offset>0</Offset><Length>1024</Length><Sha256>` + base64.StdEncoding.EncodeToString(firstHash) + `</Sha256><FutureRangeField>ignored</FutureRangeField></RangeHash>
+		<RangeHash><Offset>4096</Offset><Length>2048</Length><Sha256>` + base64.StdEncoding.EncodeToString(secondHash) + `</Sha256></RangeHash>
+	</RangeHashList>`
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/xml")
+	headers.Set("ETag", `"opaque-epoch"`)
+	headers.Set("Last-Modified", "Mon, 02 Jan 2006 15:04:05 GMT")
+	headers.Set("x-ms-blob-content-length", "8192")
+	headers.Set("x-ms-hash-algorithm", "Sha256")
+	headers.Set("x-ms-request-id", "service-request")
+	headers.Set("x-ms-client-request-id", "client-request")
+	headers.Set("x-ms-test-dedupe-sha256-cpu-time-us", "123")
+	headers.Set("x-ms-version", "2025-11-05")
+
+	response, err := (&BlockBlobClient{}).getBlobHashHandleResponse(&http.Response{
+		StatusCode: http.StatusOK,
+		Header:     headers,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	})
+	require.NoError(t, err)
+	require.Len(t, response.RangeHashes, 2)
+	require.Equal(t, int64(0), *response.RangeHashes[0].Offset)
+	require.Equal(t, int64(1024), *response.RangeHashes[0].Length)
+	require.Equal(t, firstHash, response.RangeHashes[0].Sha256)
+	require.Equal(t, int64(4096), *response.RangeHashes[1].Offset)
+	require.Equal(t, int64(2048), *response.RangeHashes[1].Length)
+	require.Equal(t, secondHash, response.RangeHashes[1].Sha256)
+	require.Equal(t, azcore.ETag(`"opaque-epoch"`), *response.ETag)
+	require.Equal(t, int64(8192), *response.BlobContentLength)
+	require.Equal(t, "Sha256", *response.HashAlgorithm)
+	require.Equal(t, "service-request", *response.RequestID)
+	require.Equal(t, "client-request", *response.ClientRequestID)
+	require.Equal(t, int64(123), *response.SHA256CPUTimeUS)
+	require.Equal(t, "2025-11-05", *response.Version)
+	require.True(t, response.LastModified.Equal(time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC)))
+}
+
+func TestGetBlobHashHandleResponseToleratesInvalidCPUTime(t *testing.T) {
+	hash := bytes.Repeat([]byte{0x11}, sha256.Size)
+	body := `<RangeHashList><RangeHash><Offset>0</Offset><Length>1</Length><Sha256>` +
+		base64.StdEncoding.EncodeToString(hash) +
+		`</Sha256></RangeHash></RangeHashList>`
+
+	for _, value := range []string{"", "-1", "not-a-number", "9223372036854775808"} {
+		t.Run(value, func(t *testing.T) {
+			headers := http.Header{"Content-Type": []string{"application/xml"}}
+			if value != "" {
+				headers.Set("x-ms-test-dedupe-sha256-cpu-time-us", value)
+			}
+			response, err := (&BlockBlobClient{}).getBlobHashHandleResponse(&http.Response{
+				StatusCode: http.StatusOK,
+				Header:     headers,
+				Body:       io.NopCloser(strings.NewReader(body)),
+			})
+			require.NoError(t, err)
+			require.Nil(t, response.SHA256CPUTimeUS)
+		})
+	}
+
+	headers := http.Header{"Content-Type": []string{"application/xml"}}
+	headers.Set("x-ms-test-dedupe-sha256-cpu-time-us", "0")
+	response, err := (&BlockBlobClient{}).getBlobHashHandleResponse(&http.Response{
+		StatusCode: http.StatusOK,
+		Header:     headers,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(0), *response.SHA256CPUTimeUS)
+}
+
+func TestGetBlobHashHandleResponseRejectsInvalidBase64(t *testing.T) {
+	for _, value := range []string{"not-base64", "&quot;"} {
+		t.Run(value, func(t *testing.T) {
+			body := `<RangeHashList><RangeHash><Offset>0</Offset><Length>1</Length><Sha256>` + value + `</Sha256></RangeHash></RangeHashList>`
+			_, err := (&BlockBlobClient{}).getBlobHashHandleResponse(&http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/xml"}},
+				Body:       io.NopCloser(strings.NewReader(body)),
+			})
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestGetBlobHashHandleResponseDrainsBodyOnHeaderError(t *testing.T) {
+	body := &trackingGetBlobHashBody{Reader: strings.NewReader("response payload")}
+	headers := http.Header{}
+	headers.Set("x-ms-blob-content-length", "not-an-integer")
+
+	_, err := (&BlockBlobClient{}).getBlobHashHandleResponse(&http.Response{
+		StatusCode: http.StatusOK,
+		Header:     headers,
+		Body:       body,
+	})
+
+	require.Error(t, err)
+	require.True(t, body.closed)
+	require.Zero(t, body.Len())
+}

--- a/sdk/storage/azblob/internal/generated/zz_blockblob_client.go
+++ b/sdk/storage/azblob/internal/generated/zz_blockblob_client.go
@@ -289,6 +289,12 @@ func (client *BlockBlobClient) getBlockListHandleResponse(resp *http.Response) (
 		}
 		result.BlobContentLength = &blobContentLength
 	}
+	if val := resp.Header.Get("x-ms-test-dedupe-crc64-cpu-time-us"); val != "" {
+		crc64CPUTimeUS, err := strconv.ParseInt(val, 10, 64)
+		if err == nil && crc64CPUTimeUS >= 0 {
+			result.CRC64CPUTimeUS = &crc64CPUTimeUS
+		}
+	}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -314,6 +320,12 @@ func (client *BlockBlobClient) getBlockListHandleResponse(resp *http.Response) (
 	}
 	if val := resp.Header.Get("x-ms-request-id"); val != "" {
 		result.RequestID = &val
+	}
+	if val := resp.Header.Get("x-ms-test-dedupe-sha256-cpu-time-us"); val != "" {
+		sha256CPUTimeUS, err := strconv.ParseInt(val, 10, 64)
+		if err == nil && sha256CPUTimeUS >= 0 {
+			result.SHA256CPUTimeUS = &sha256CPUTimeUS
+		}
 	}
 	if val := resp.Header.Get("x-ms-version"); val != "" {
 		result.Version = &val

--- a/sdk/storage/azblob/internal/generated/zz_blockblob_client.go
+++ b/sdk/storage/azblob/internal/generated/zz_blockblob_client.go
@@ -8,6 +8,7 @@ package generated
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -254,6 +255,9 @@ func (client *BlockBlobClient) getBlockListCreateRequest(ctx context.Context, li
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("blocklisttype", string(listType))
 	reqQP.Set("comp", "blocklist")
+	if options != nil && options.Include != nil {
+		reqQP.Set("include", strings.Join(strings.Fields(strings.Trim(fmt.Sprint(options.Include), "[]")), ","))
+	}
 	if options != nil && options.Snapshot != nil {
 		reqQP.Set("snapshot", *options.Snapshot)
 	}

--- a/sdk/storage/azblob/internal/generated/zz_blockblob_client.go
+++ b/sdk/storage/azblob/internal/generated/zz_blockblob_client.go
@@ -222,6 +222,134 @@ func (client *BlockBlobClient) commitBlockListHandleResponse(resp *http.Response
 	return result, nil
 }
 
+// GetBlobHash - Calculates SHA256 hashes for selected byte ranges in a block blob.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2025-11-05
+//   - multiRange - Specifies sorted, non-overlapping inclusive byte ranges to hash.
+//   - options - BlockBlobClientGetBlobHashOptions contains the optional parameters for the BlockBlobClient.GetBlobHash method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - CPKInfo - CPKInfo contains a group of parameters for the BlobClient.Download method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *BlockBlobClient) GetBlobHash(ctx context.Context, multiRange string, options *BlockBlobClientGetBlobHashOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CPKInfo, modifiedAccessConditions *ModifiedAccessConditions) (BlockBlobClientGetBlobHashResponse, error) {
+	var err error
+	req, err := client.getBlobHashCreateRequest(ctx, multiRange, options, leaseAccessConditions, cpkInfo, modifiedAccessConditions)
+	if err != nil {
+		return BlockBlobClientGetBlobHashResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return BlockBlobClientGetBlobHashResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
+		err = runtime.NewResponseError(httpResp)
+		return BlockBlobClientGetBlobHashResponse{}, err
+	}
+	resp, err := client.getBlobHashHandleResponse(httpResp)
+	return resp, err
+}
+
+// getBlobHashCreateRequest creates the GetBlobHash request.
+func (client *BlockBlobClient) getBlobHashCreateRequest(ctx context.Context, multiRange string, options *BlockBlobClientGetBlobHashOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CPKInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("comp", "hash")
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
+	}
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	req.Raw().Header["Accept"] = []string{"application/xml"}
+	if modifiedAccessConditions != nil && modifiedAccessConditions.IfMatch != nil {
+		req.Raw().Header["If-Match"] = []string{string(*modifiedAccessConditions.IfMatch)}
+	}
+	if modifiedAccessConditions != nil && modifiedAccessConditions.IfModifiedSince != nil {
+		req.Raw().Header["If-Modified-Since"] = []string{(*modifiedAccessConditions.IfModifiedSince).In(gmt).Format(time.RFC1123)}
+	}
+	if modifiedAccessConditions != nil && modifiedAccessConditions.IfNoneMatch != nil {
+		req.Raw().Header["If-None-Match"] = []string{string(*modifiedAccessConditions.IfNoneMatch)}
+	}
+	if modifiedAccessConditions != nil && modifiedAccessConditions.IfUnmodifiedSince != nil {
+		req.Raw().Header["If-Unmodified-Since"] = []string{(*modifiedAccessConditions.IfUnmodifiedSince).In(gmt).Format(time.RFC1123)}
+	}
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
+	}
+	if cpkInfo != nil && cpkInfo.EncryptionAlgorithm != nil {
+		req.Raw().Header["x-ms-encryption-algorithm"] = []string{string(*cpkInfo.EncryptionAlgorithm)}
+	}
+	if cpkInfo != nil && cpkInfo.EncryptionKey != nil {
+		req.Raw().Header["x-ms-encryption-key"] = []string{*cpkInfo.EncryptionKey}
+	}
+	if cpkInfo != nil && cpkInfo.EncryptionKeySHA256 != nil {
+		req.Raw().Header["x-ms-encryption-key-sha256"] = []string{*cpkInfo.EncryptionKeySHA256}
+	}
+	req.Raw().Header["x-ms-hash-algorithm"] = []string{"Sha256"}
+	if modifiedAccessConditions != nil && modifiedAccessConditions.IfTags != nil {
+		req.Raw().Header["x-ms-if-tags"] = []string{*modifiedAccessConditions.IfTags}
+	}
+	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
+		req.Raw().Header["x-ms-lease-id"] = []string{*leaseAccessConditions.LeaseID}
+	}
+	req.Raw().Header["x-ms-multi-range"] = []string{multiRange}
+	req.Raw().Header["x-ms-version"] = []string{"2025-11-05"}
+	return req, nil
+}
+
+// getBlobHashHandleResponse handles the GetBlobHash response.
+func (client *BlockBlobClient) getBlobHashHandleResponse(resp *http.Response) (BlockBlobClientGetBlobHashResponse, error) {
+	defer runtime.Drain(resp)
+	result := BlockBlobClientGetBlobHashResponse{}
+	if val := resp.Header.Get("x-ms-blob-content-length"); val != "" {
+		blobContentLength, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return BlockBlobClientGetBlobHashResponse{}, err
+		}
+		result.BlobContentLength = &blobContentLength
+	}
+	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
+		result.ClientRequestID = &val
+	}
+	if val := resp.Header.Get("Date"); val != "" {
+		date, err := time.Parse(time.RFC1123, val)
+		if err != nil {
+			return BlockBlobClientGetBlobHashResponse{}, err
+		}
+		result.Date = &date
+	}
+	if val := resp.Header.Get("ETag"); val != "" {
+		result.ETag = (*azcore.ETag)(&val)
+	}
+	if val := resp.Header.Get("x-ms-hash-algorithm"); val != "" {
+		result.HashAlgorithm = &val
+	}
+	if val := resp.Header.Get("Last-Modified"); val != "" {
+		lastModified, err := time.Parse(time.RFC1123, val)
+		if err != nil {
+			return BlockBlobClientGetBlobHashResponse{}, err
+		}
+		result.LastModified = &lastModified
+	}
+	if val := resp.Header.Get("x-ms-request-id"); val != "" {
+		result.RequestID = &val
+	}
+	if val := resp.Header.Get("x-ms-test-dedupe-sha256-cpu-time-us"); val != "" {
+		sha256CPUTimeUS, err := strconv.ParseInt(val, 10, 64)
+		if err == nil && sha256CPUTimeUS >= 0 {
+			result.SHA256CPUTimeUS = &sha256CPUTimeUS
+		}
+	}
+	if val := resp.Header.Get("x-ms-version"); val != "" {
+		result.Version = &val
+	}
+	if err := runtime.UnmarshalAsXML(resp, &result.RangeHashList); err != nil {
+		return BlockBlobClientGetBlobHashResponse{}, err
+	}
+	return result, nil
+}
+
 // GetBlockList - The Get Block List operation retrieves the list of blocks that have been uploaded as part of a block blob
 // If the operation fails it returns an *azcore.ResponseError type.
 //   - listType - Specifies whether to return the list of committed blocks, the list of uncommitted blocks, or both lists together.

--- a/sdk/storage/azblob/internal/generated/zz_constants.go
+++ b/sdk/storage/azblob/internal/generated/zz_constants.go
@@ -140,6 +140,21 @@ func PossibleBlobTypeValues() []BlobType {
 	}
 }
 
+type BlockListIncludeItem string
+
+const (
+	BlockListIncludeItemCrc64  BlockListIncludeItem = "crc64"
+	BlockListIncludeItemSha256 BlockListIncludeItem = "sha256"
+)
+
+// PossibleBlockListIncludeItemValues returns the possible values for the BlockListIncludeItem const type.
+func PossibleBlockListIncludeItemValues() []BlockListIncludeItem {
+	return []BlockListIncludeItem{
+		BlockListIncludeItemCrc64,
+		BlockListIncludeItemSha256,
+	}
+}
+
 type BlockListType string
 
 const (

--- a/sdk/storage/azblob/internal/generated/zz_models.go
+++ b/sdk/storage/azblob/internal/generated/zz_models.go
@@ -465,6 +465,22 @@ type QuerySerialization struct {
 	Format *QueryFormat `xml:"Format"`
 }
 
+type RangeHash struct {
+	// REQUIRED; The range's length, in bytes.
+	Length *int64 `xml:"Length"`
+
+	// REQUIRED; The range's start offset in the blob, in bytes.
+	Offset *int64 `xml:"Offset"`
+
+	// REQUIRED; The SHA256 hash of the range.
+	Sha256 []byte `xml:"Sha256"`
+}
+
+type RangeHashList struct {
+	// REQUIRED
+	RangeHashes []*RangeHash `xml:"RangeHash"`
+}
+
 // RetentionPolicy - the retention policy which determines how long the associated data should persist
 type RetentionPolicy struct {
 	// REQUIRED; Indicates whether a retention policy is enabled for the storage service

--- a/sdk/storage/azblob/internal/generated/zz_models.go
+++ b/sdk/storage/azblob/internal/generated/zz_models.go
@@ -172,6 +172,15 @@ type Block struct {
 
 	// REQUIRED; The block size in bytes.
 	Size *int64 `xml:"Size"`
+
+	// The CRC64 hash of the block.
+	Crc64 []byte `xml:"Crc64"`
+
+	// The block's start offset in the blob, in bytes.
+	Offset *int64 `xml:"Offset"`
+
+	// The SHA256 hash of the block.
+	Sha256 []byte `xml:"Sha256"`
 }
 
 type BlockList struct {

--- a/sdk/storage/azblob/internal/generated/zz_models_serde.go
+++ b/sdk/storage/azblob/internal/generated/zz_models_serde.go
@@ -269,6 +269,9 @@ func (b *Block) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 		}
 	}
 	if aux.Sha256 != nil {
+		if len(*aux.Sha256) > 0 && (*aux.Sha256)[0] == '"' && (len(*aux.Sha256) < 2 || (*aux.Sha256)[len(*aux.Sha256)-1] != '"') {
+			return fmt.Errorf("invalid quoted base64 value")
+		}
 		if err := runtime.DecodeByteArray(*aux.Sha256, &b.Sha256, runtime.Base64StdFormat); err != nil {
 			return err
 		}
@@ -512,6 +515,60 @@ func (p PageList) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	}
 	if p.PageRange != nil {
 		aux.PageRange = &p.PageRange
+	}
+	return enc.EncodeElement(aux, start)
+}
+
+// MarshalXML implements the xml.Marshaller interface for type RangeHash.
+func (r RangeHash) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	type alias RangeHash
+	aux := &struct {
+		*alias
+		Sha256 *string `xml:"Sha256"`
+	}{
+		alias: (*alias)(&r),
+	}
+	if r.Sha256 != nil {
+		encodedSha256 := runtime.EncodeByteArray(r.Sha256, runtime.Base64StdFormat)
+		aux.Sha256 = &encodedSha256
+	}
+	return enc.EncodeElement(aux, start)
+}
+
+// UnmarshalXML implements the xml.Unmarshaller interface for type RangeHash.
+func (r *RangeHash) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	type alias RangeHash
+	aux := &struct {
+		*alias
+		Sha256 *string `xml:"Sha256"`
+	}{
+		alias: (*alias)(r),
+	}
+	if err := dec.DecodeElement(aux, &start); err != nil {
+		return err
+	}
+	if aux.Sha256 != nil {
+		if len(*aux.Sha256) > 0 && (*aux.Sha256)[0] == '"' && (len(*aux.Sha256) < 2 || (*aux.Sha256)[len(*aux.Sha256)-1] != '"') {
+			return fmt.Errorf("invalid quoted base64 value")
+		}
+		if err := runtime.DecodeByteArray(*aux.Sha256, &r.Sha256, runtime.Base64StdFormat); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MarshalXML implements the xml.Marshaller interface for type RangeHashList.
+func (r RangeHashList) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	type alias RangeHashList
+	aux := &struct {
+		*alias
+		RangeHashes *[]*RangeHash `xml:"RangeHash"`
+	}{
+		alias: (*alias)(&r),
+	}
+	if r.RangeHashes != nil {
+		aux.RangeHashes = &r.RangeHashes
 	}
 	return enc.EncodeElement(aux, start)
 }

--- a/sdk/storage/azblob/internal/generated/zz_models_serde.go
+++ b/sdk/storage/azblob/internal/generated/zz_models_serde.go
@@ -229,6 +229,53 @@ func (b BlobTags) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	return enc.EncodeElement(aux, start)
 }
 
+// MarshalXML implements the xml.Marshaller interface for type Block.
+func (b Block) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	type alias Block
+	aux := &struct {
+		*alias
+		Crc64  *string `xml:"Crc64"`
+		Sha256 *string `xml:"Sha256"`
+	}{
+		alias: (*alias)(&b),
+	}
+	if b.Crc64 != nil {
+		encodedCrc64 := runtime.EncodeByteArray(b.Crc64, runtime.Base64StdFormat)
+		aux.Crc64 = &encodedCrc64
+	}
+	if b.Sha256 != nil {
+		encodedSha256 := runtime.EncodeByteArray(b.Sha256, runtime.Base64StdFormat)
+		aux.Sha256 = &encodedSha256
+	}
+	return enc.EncodeElement(aux, start)
+}
+
+// UnmarshalXML implements the xml.Unmarshaller interface for type Block.
+func (b *Block) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	type alias Block
+	aux := &struct {
+		*alias
+		Crc64  *string `xml:"Crc64"`
+		Sha256 *string `xml:"Sha256"`
+	}{
+		alias: (*alias)(b),
+	}
+	if err := dec.DecodeElement(aux, &start); err != nil {
+		return err
+	}
+	if aux.Crc64 != nil {
+		if err := runtime.DecodeByteArray(*aux.Crc64, &b.Crc64, runtime.Base64StdFormat); err != nil {
+			return err
+		}
+	}
+	if aux.Sha256 != nil {
+		if err := runtime.DecodeByteArray(*aux.Sha256, &b.Sha256, runtime.Base64StdFormat); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // MarshalXML implements the xml.Marshaller interface for type BlockList.
 func (b BlockList) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias BlockList

--- a/sdk/storage/azblob/internal/generated/zz_options.go
+++ b/sdk/storage/azblob/internal/generated/zz_options.go
@@ -688,9 +688,21 @@ type BlockBlobClientCommitBlockListOptions struct {
 	TransactionalContentMD5 []byte
 }
 
+// BlockBlobClientGetBlobHashOptions contains the optional parameters for the BlockBlobClient.GetBlobHash method.
+type BlockBlobClientGetBlobHashOptions struct {
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://learn.microsoft.com/rest/api/storageservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
 // BlockBlobClientGetBlockListOptions contains the optional parameters for the BlockBlobClient.GetBlockList method.
 type BlockBlobClientGetBlockListOptions struct {
-	// Specifies one or more datasets to include in the response, such as the per-block crc64 and sha256 content hashes.
+	// Specifies one or more datasets to include in the response, such as the per-block crc64 and sha256 content hashes. Requires
+	// service-side support and is only honored for committed block lists.
 	Include []BlockListIncludeItem
 
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage

--- a/sdk/storage/azblob/internal/generated/zz_options.go
+++ b/sdk/storage/azblob/internal/generated/zz_options.go
@@ -690,6 +690,9 @@ type BlockBlobClientCommitBlockListOptions struct {
 
 // BlockBlobClientGetBlockListOptions contains the optional parameters for the BlockBlobClient.GetBlockList method.
 type BlockBlobClientGetBlockListOptions struct {
+	// Specifies one or more datasets to include in the response, such as the per-block crc64 and sha256 content hashes.
+	Include []BlockListIncludeItem
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string

--- a/sdk/storage/azblob/internal/generated/zz_responses.go
+++ b/sdk/storage/azblob/internal/generated/zz_responses.go
@@ -1080,6 +1080,9 @@ type BlockBlobClientGetBlockListResponse struct {
 	// BlobContentLength contains the information returned from the x-ms-blob-content-length header response.
 	BlobContentLength *int64
 
+	// CRC64CPUTimeUS contains the information returned from the x-ms-test-dedupe-crc64-cpu-time-us header response.
+	CRC64CPUTimeUS *int64
+
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
 
@@ -1097,6 +1100,9 @@ type BlockBlobClientGetBlockListResponse struct {
 
 	// RequestID contains the information returned from the x-ms-request-id header response.
 	RequestID *string
+
+	// SHA256CPUTimeUS contains the information returned from the x-ms-test-dedupe-sha256-cpu-time-us header response.
+	SHA256CPUTimeUS *int64
 
 	// Version contains the information returned from the x-ms-version header response.
 	Version *string

--- a/sdk/storage/azblob/internal/generated/zz_responses.go
+++ b/sdk/storage/azblob/internal/generated/zz_responses.go
@@ -1073,6 +1073,38 @@ type BlockBlobClientCommitBlockListResponse struct {
 	VersionID *string
 }
 
+// BlockBlobClientGetBlobHashResponse contains the response from method BlockBlobClient.GetBlobHash.
+type BlockBlobClientGetBlobHashResponse struct {
+	RangeHashList
+
+	// BlobContentLength contains the information returned from the x-ms-blob-content-length header response.
+	BlobContentLength *int64
+
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// ETag contains the information returned from the ETag header response.
+	ETag *azcore.ETag
+
+	// HashAlgorithm contains the information returned from the x-ms-hash-algorithm header response.
+	HashAlgorithm *string
+
+	// LastModified contains the information returned from the Last-Modified header response.
+	LastModified *time.Time
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// SHA256CPUTimeUS contains the information returned from the x-ms-test-dedupe-sha256-cpu-time-us header response.
+	SHA256CPUTimeUS *int64
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
 // BlockBlobClientGetBlockListResponse contains the response from method BlockBlobClient.GetBlockList.
 type BlockBlobClientGetBlockListResponse struct {
 	BlockList


### PR DESCRIPTION
## Review intent

**This draft PR is for code review only and is not intended to be merged as-is.**

The branch is based on the azblob 1.6.x source used by the Storage Mover/AzCopy
prototype. Current `main` has moved forward substantially, so this work must be
rebased onto the current generated SDK/spec before it could be considered for
merge.

## What this prototype adds

- Adds `include=crc64,sha256` support to `GetBlockList`.
- Exposes per-block values returned by the XStore prototype:
  - `Offset`
  - `Crc64`
  - `Sha256`
- Decodes the base64 CRC64 and SHA256 XML values into byte slices.
- Exposes the XStore request-level CPU timing headers:
  - `x-ms-test-dedupe-crc64-cpu-time-us`
  - `x-ms-test-dedupe-sha256-cpu-time-us`
- Publishes them as optional response fields:
  - `CRC64CPUTimeUS *int64`
  - `SHA256CPUTimeUS *int64`

## Compatibility behavior

- Legacy block-list responses without offset/hash fields continue to decode.
- Missing CPU timing headers remain `nil`.
- Explicit zero timing values remain valid.
- Malformed, negative, or overflowing experimental timing headers are ignored
  rather than failing an otherwise successful `GetBlockList`.

## Consumer

The ProgramPedro AzCopy fork consumes these fields to:

- align transfer chunks with XStore committed-block offsets;
- match blocks by CRC64 plus SHA256;
- reuse already-committed destination ranges; and
- report per-request and cumulative hash CPU time.

## Validation

- Generated block-list XML tests cover responses with and without the custom
  block fields.
- Generated response-handler tests cover valid, zero, missing, malformed,
  negative, overflowing, and mixed CPU timing headers.
- Public `blockblob.GetBlockListResponse` tests verify both timing fields are
  exposed through the package alias.
- Focused `internal/generated` and `blockblob` package tests pass.

## Merge readiness

This branch is intentionally review-only:

- it is based on an older azblob generation baseline;
- current `main` has newer generated models/specs;
- generated-file conflicts must be resolved through the current generation
  workflow; and
- the experimental XStore response contract is not an upstream Azure Storage
  service contract.
