### PR TITLE
[azcore] support relative next link when paging

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+* `runtime.FetcherForNextLinkOptions` has a new field `Endpoint`, the service endpoint used to resolve a relative next link.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/azcore/runtime/pager.go
+++ b/sdk/azcore/runtime/pager.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
@@ -184,18 +183,5 @@ func resolveNextLink(endpoint, nextLink string) string {
 		// a malformed next link is passed through so the failure surfaces when creating the request
 		return nextLink
 	}
-	// join the raw strings so that any percent-encoding in nextLink is preserved
-	rawPath, rawQuery, hasQuery := strings.Cut(nextLink, "?")
-	resolved := endpoint
-	if rawPath != "" {
-		resolved = JoinPaths(endpoint, rawPath)
-	}
-	if hasQuery {
-		sep := "?"
-		if strings.Contains(resolved, "?") {
-			sep = "&"
-		}
-		resolved += sep + rawQuery
-	}
-	return resolved
+	return JoinPaths(endpoint, nextLink)
 }

--- a/sdk/azcore/runtime/pager.go
+++ b/sdk/azcore/runtime/pager.go
@@ -9,7 +9,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
@@ -124,12 +126,17 @@ type FetcherForNextLinkOptions struct {
 	// The default value is http.MethodGet.
 	// This field is only used when NextReq is not specified.
 	HTTPVerb string
+
+	// Endpoint is the service endpoint used to resolve a relative next link,
+	// e.g. "https://contoso.com". It's ignored when the next link is absolute.
+	Endpoint string
 }
 
 // FetcherForNextLink is a helper containing boilerplate code to simplify creating a PagingHandler[T].Fetcher from a next link URL.
 //   - ctx is the [context.Context] controlling the lifetime of the HTTP operation
 //   - pl is the [Pipeline] used to dispatch the HTTP request
-//   - nextLink is the URL used to fetch the next page. the empty string indicates the first page is to be requested
+//   - nextLink is the URL used to fetch the next page. the empty string indicates the first page is to be requested.
+//     a relative next link is resolved against FetcherForNextLinkOptions.Endpoint
 //   - firstReq is the func to be called when creating the request for the first page
 //   - options contains any optional parameters, pass nil to accept the default values
 func FetcherForNextLink(ctx context.Context, pl Pipeline, nextLink string, firstReq func(context.Context) (*policy.Request, error), options *FetcherForNextLinkOptions) (*http.Response, error) {
@@ -140,7 +147,7 @@ func FetcherForNextLink(ctx context.Context, pl Pipeline, nextLink string, first
 	}
 	if nextLink == "" {
 		req, err = firstReq(ctx)
-	} else if nextLink, err = EncodeQueryParams(nextLink); err == nil {
+	} else if nextLink, err = EncodeQueryParams(resolveNextLink(options.Endpoint, nextLink)); err == nil {
 		if options.NextReq != nil {
 			req, err = options.NextReq(ctx, nextLink)
 		} else {
@@ -164,4 +171,31 @@ func FetcherForNextLink(ctx context.Context, pl Pipeline, nextLink string, first
 		return nil, NewResponseError(resp)
 	}
 	return resp, nil
+}
+
+// resolveNextLink joins a relative nextLink to endpoint, preserving nextLink's query params.
+// nextLink is returned unmodified when it's absolute or when endpoint is empty.
+func resolveNextLink(endpoint, nextLink string) string {
+	if endpoint == "" {
+		return nextLink
+	}
+	u, err := url.Parse(nextLink)
+	if err != nil || u.IsAbs() {
+		// a malformed next link is passed through so the failure surfaces when creating the request
+		return nextLink
+	}
+	// join the raw strings so that any percent-encoding in nextLink is preserved
+	rawPath, rawQuery, hasQuery := strings.Cut(nextLink, "?")
+	resolved := endpoint
+	if rawPath != "" {
+		resolved = JoinPaths(endpoint, rawPath)
+	}
+	if hasQuery {
+		sep := "?"
+		if strings.Contains(resolved, "?") {
+			sep = "&"
+		}
+		resolved += sep + rawQuery
+	}
+	return resolved
 }

--- a/sdk/azcore/runtime/pager_test.go
+++ b/sdk/azcore/runtime/pager_test.go
@@ -525,9 +525,9 @@ func TestResolveNextLink(t *testing.T) {
 		{"https://contoso.com/", "/page/2", "https://contoso.com/page/2"},
 		{"https://contoso.com/api/v1", "/page/2", "https://contoso.com/api/v1/page/2"},
 		{"https://contoso.com/api/v1", "page/2", "https://contoso.com/api/v1/page/2"},
-		{"https://contoso.com", "/page/2?skip=1&url=https://fabrikam.com", "https://contoso.com/page/2?skip=1&url=https://fabrikam.com"},
+		{"https://contoso.com", "/page/2?skip=1&url=https%3A%2F%2Ffabrikam.com", "https://contoso.com/page/2?skip=1&url=https%3A%2F%2Ffabrikam.com"},
 		{"https://contoso.com", "?skip=1", "https://contoso.com?skip=1"},
-		{"https://contoso.com?api-version=1.0", "/page/2?skip=1", "https://contoso.com/page/2?api-version=1.0&skip=1"},
+		{"https://contoso.com?api-version=1.0", "/page/2?skip=1", "https://contoso.com/page/2?skip=1&api-version=1.0"},
 		{"https://contoso.com", "/page/it%2Fem", "https://contoso.com/page/it%2Fem"},
 		// a malformed next link is passed through so the failure surfaces when creating the request
 		{"https://contoso.com", "/page/\x7f", "/page/\x7f"},

--- a/sdk/azcore/runtime/pager_test.go
+++ b/sdk/azcore/runtime/pager_test.go
@@ -471,3 +471,67 @@ func TestFetcherForNextLinkWithHTTPMethod(t *testing.T) {
 	require.NotNil(t, resp)
 	require.EqualValues(t, http.StatusOK, resp.StatusCode)
 }
+
+func TestFetcherForNextLinkRelative(t *testing.T) {
+	srv, close := mock.NewServer()
+	defer close()
+	pl := exported.NewPipeline(srv)
+
+	var gotURL string
+	capture := mock.WithPredicate(func(req *http.Request) bool {
+		gotURL = "http://" + req.Host + req.URL.RequestURI()
+		return true
+	})
+
+	// a relative next link is resolved against the endpoint
+	srv.AppendResponse(capture, mock.WithStatusCode(http.StatusOK))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusBadRequest)) // predicate failure response
+	resp, err := FetcherForNextLink(context.Background(), pl, "/page/2?api-version=1.0", func(ctx context.Context) (*policy.Request, error) {
+		t.Fatal("first page shouldn't be requested")
+		return nil, nil
+	}, &FetcherForNextLinkOptions{Endpoint: srv.URL()})
+	require.NoError(t, err)
+	require.EqualValues(t, http.StatusOK, resp.StatusCode)
+	require.EqualValues(t, srv.URL()+"/page/2?api-version=1.0", gotURL)
+
+	// an absolute next link ignores the endpoint
+	srv.AppendResponse(capture, mock.WithStatusCode(http.StatusOK))
+	srv.AppendResponse(mock.WithStatusCode(http.StatusBadRequest)) // predicate failure response
+	resp, err = FetcherForNextLink(context.Background(), pl, srv.URL()+"/page/3", func(ctx context.Context) (*policy.Request, error) {
+		t.Fatal("first page shouldn't be requested")
+		return nil, nil
+	}, &FetcherForNextLinkOptions{Endpoint: "https://microsoft.com"})
+	require.NoError(t, err)
+	require.EqualValues(t, http.StatusOK, resp.StatusCode)
+	require.EqualValues(t, srv.URL()+"/page/3", gotURL)
+
+	// a relative next link without an endpoint fails as before
+	_, err = FetcherForNextLink(context.Background(), pl, "/page/2", func(ctx context.Context) (*policy.Request, error) {
+		t.Fatal("first page shouldn't be requested")
+		return nil, nil
+	}, nil)
+	require.Error(t, err)
+}
+
+func TestResolveNextLink(t *testing.T) {
+	for _, test := range []struct {
+		endpoint string
+		nextLink string
+		want     string
+	}{
+		{"https://contoso.com", "https://fabrikam.com/page/2", "https://fabrikam.com/page/2"},
+		{"", "/page/2", "/page/2"},
+		{"https://contoso.com", "/page/2", "https://contoso.com/page/2"},
+		{"https://contoso.com/", "/page/2", "https://contoso.com/page/2"},
+		{"https://contoso.com/api/v1", "/page/2", "https://contoso.com/api/v1/page/2"},
+		{"https://contoso.com/api/v1", "page/2", "https://contoso.com/api/v1/page/2"},
+		{"https://contoso.com", "/page/2?skip=1&url=https://fabrikam.com", "https://contoso.com/page/2?skip=1&url=https://fabrikam.com"},
+		{"https://contoso.com", "?skip=1", "https://contoso.com?skip=1"},
+		{"https://contoso.com?api-version=1.0", "/page/2?skip=1", "https://contoso.com/page/2?api-version=1.0&skip=1"},
+		{"https://contoso.com", "/page/it%2Fem", "https://contoso.com/page/it%2Fem"},
+		// a malformed next link is passed through so the failure surfaces when creating the request
+		{"https://contoso.com", "/page/\x7f", "/page/\x7f"},
+	} {
+		require.EqualValues(t, test.want, resolveNextLink(test.endpoint, test.nextLink), "%s + %s", test.endpoint, test.nextLink)
+	}
+}


### PR DESCRIPTION
### Summary

Adds support for paging over a **relative** `nextLink`, e.g. `"/azure/core/page/with-relative-next-link/page/2"`. Today this fails with `no Host in request URL`.

`FetcherForNextLinkOptions` gains an `Endpoint` field. When the next link isn't absolute, it's joined to `Endpoint` before the request is built; absolute next links are untouched.

```go
runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), page.NextLink, req, &runtime.FetcherForNextLinkOptions{
    Endpoint: client.endpoint,
})
```

### Notes

- Resolution uses `runtime.JoinPaths` (append to the endpoint) rather than RFC 3986 reference resolution, matching how the Go SDK builds every other request URL and matching the JS/Python emitters.
- `url.Parse` determines whether the next link is absolute; a malformed link is passed through unchanged so the failure surfaces from `NewRequest` as it does today. The path/query are joined from the raw strings rather than the parsed components so that percent-encoding (e.g. `%2F`) is preserved.
- Behavior is unchanged when `Endpoint` is empty, so this is purely additive.

### Context

Required by [Azure/typespec-azure#4994](https://github.com/Azure/typespec-azure/issues/4994) / [Azure/typespec-azure#5079](https://github.com/Azure/typespec-azure/pull/5079), where centralizing the logic here was suggested over emitting it at every codegen call site. The emitter PR passes the client endpoint through the new option.

Spec scenario: `Azure_Core_Page_withRelativeNextLink` in azure-http-specs.
