### PR TITLE
internal/recording: correct the tar extractor's path containment check

### DIFF
--- a/sdk/internal/recording/server.go
+++ b/sdk/internal/recording/server.go
@@ -45,6 +45,24 @@ func getTestProxyDownloadFile() (string, error) {
 	}
 }
 
+// resolveExtractPath joins an archive entry name onto dir and verifies that the
+// result stays inside dir. It rejects entries that traverse upwards as well as
+// entries whose resolved path merely shares a textual prefix with dir, such as
+// a "dir-backup" sibling of "dir".
+func resolveExtractPath(dir string, name string) (string, error) {
+	target := filepath.Join(dir, name)
+
+	rel, err := filepath.Rel(dir, target)
+	if err != nil {
+		return "", fmt.Errorf("illegal file path: %q", name)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("illegal file path: %q", name)
+	}
+
+	return target, nil
+}
+
 // Modified from https://stackoverflow.com/a/24792688
 func extractTestProxyZip(src string, dest string) error {
 	r, err := zip.OpenReader(src)
@@ -73,13 +91,13 @@ func extractTestProxyZip(src string, dest string) error {
 			}
 		}()
 
-		path := filepath.Join(dest, f.Name)
-		log.Println("Extracting", path)
-
 		// Check for ZipSlip (Directory traversal)
-		if !strings.HasPrefix(path, filepath.Clean(dest)+string(os.PathSeparator)) {
-			return fmt.Errorf("illegal file path: %s", path)
+		path, err := resolveExtractPath(dest, f.Name)
+		if err != nil {
+			return err
 		}
+
+		log.Println("Extracting", path)
 
 		if f.FileInfo().IsDir() {
 			if err := os.MkdirAll(path, f.Mode()); err != nil {
@@ -146,9 +164,9 @@ func extractTestProxyArchive(archivePath string, outputDir string) error {
 			return err
 		}
 
-		targetPath := filepath.Join(outputDir, header.Name)
-		if !strings.HasPrefix(targetPath, filepath.Clean(outputDir)) {
-			return fmt.Errorf("illegal file path: %q", header.Name)
+		targetPath, err := resolveExtractPath(outputDir, header.Name)
+		if err != nil {
+			return err
 		}
 
 		log.Println("Extracting", targetPath)

--- a/sdk/internal/recording/server_test.go
+++ b/sdk/internal/recording/server_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -113,4 +114,95 @@ func (s *serverTests) TestExtractInsecurePath() {
 		err = installTestProxy(p, td, td)
 		require.ErrorContains(t, err, "illegal file path")
 	})
+}
+
+// TestExtractSiblingPrefixPath covers entries that do not traverse upwards out
+// of the destination's parent, but do land in a sibling directory whose name
+// begins with the destination's name. "out-evil" shares the textual prefix
+// "out", so a containment check written as a plain string prefix accepts it.
+func (s *serverTests) TestExtractSiblingPrefixPath() {
+	// filepath.Join cleans the "..", so the resolved path is <td>/out-evil/file
+	// rather than anything containing "..".
+	const entryName = "../out-evil/file"
+
+	s.T().Run("tar", func(t *testing.T) {
+		td := t.TempDir()
+		dest := filepath.Join(td, "out")
+		require.NoError(t, os.MkdirAll(dest, 0755))
+
+		p := filepath.Join(td, "test.tar.gz")
+		f, err := os.Create(p)
+		require.NoError(t, err)
+		zw := gzip.NewWriter(f)
+		tw := tar.NewWriter(zw)
+		b := []byte("_")
+		err = tw.WriteHeader(&tar.Header{
+			Name: entryName,
+			Size: int64(len(b)),
+		})
+		require.NoError(t, err)
+		_, err = tw.Write(b)
+		require.NoError(t, err)
+		require.NoError(t, tw.Close())
+		require.NoError(t, zw.Close())
+		require.NoError(t, f.Close())
+
+		err = extractTestProxyArchive(p, dest)
+		require.ErrorContains(t, err, "illegal file path")
+		require.NoFileExists(t, filepath.Join(td, "out-evil", "file"))
+	})
+
+	s.T().Run("zip", func(t *testing.T) {
+		td := t.TempDir()
+		dest := filepath.Join(td, "out")
+		require.NoError(t, os.MkdirAll(dest, 0755))
+
+		p := filepath.Join(td, "test.zip")
+		f, err := os.Create(p)
+		require.NoError(t, err)
+		zw := zip.NewWriter(f)
+		w, err := zw.Create(entryName)
+		require.NoError(t, err)
+		_, err = w.Write([]byte("_"))
+		require.NoError(t, err)
+		require.NoError(t, zw.Close())
+		require.NoError(t, f.Close())
+
+		err = extractTestProxyZip(p, dest)
+		require.ErrorContains(t, err, "illegal file path")
+		require.NoFileExists(t, filepath.Join(td, "out-evil", "file"))
+	})
+}
+
+func TestResolveExtractPath(t *testing.T) {
+	dir := filepath.Join("tmp", "out")
+
+	for _, tt := range []struct {
+		name    string
+		entry   string
+		wantErr bool
+	}{
+		{name: "plain file", entry: "file"},
+		{name: "nested file", entry: filepath.Join("a", "b", "file")},
+		{name: "archive root", entry: "."},
+		{name: "interior dot dot resolving inside", entry: filepath.Join("a", "..", "file")},
+		{name: "parent", entry: "..", wantErr: true},
+		{name: "traversal", entry: filepath.Join("..", "file"), wantErr: true},
+		{name: "deep traversal", entry: filepath.Join("..", "..", "file"), wantErr: true},
+		{name: "sibling sharing a prefix", entry: filepath.Join("..", "out-evil", "file"), wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveExtractPath(dir, tt.entry)
+			if tt.wantErr {
+				require.ErrorContains(t, err, "illegal file path")
+				require.Empty(t, got)
+				return
+			}
+			require.NoError(t, err)
+			// Everything permitted must resolve to dir itself or below it.
+			rel, err := filepath.Rel(dir, got)
+			require.NoError(t, err)
+			require.False(t, rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
+		})
+	}
 }


### PR DESCRIPTION
### What

`sdk/internal/recording/server.go` contains two archive extractors, and they check entry-path containment differently.

`extractTestProxyZip` compares against the destination plus a trailing path separator:

```go
if !strings.HasPrefix(path, filepath.Clean(dest)+string(os.PathSeparator)) {
```

`extractTestProxyArchive`, seventy lines below, omits the separator:

```go
if !strings.HasPrefix(targetPath, filepath.Clean(outputDir)) {
```

Dropping the separator reduces the test to a plain textual prefix match, so the tar extractor accepts any entry resolving into a sibling directory whose name begins with the destination's name. Given an `outputDir` of `/tmp/out`, the entry `../out-evil/file` resolves through `filepath.Join` to `/tmp/out-evil/file`, satisfies `HasPrefix(..., "/tmp/out")`, and lands outside the destination.

`filepath.Join` cleans the `..` away, so the resolved path holds no traversal sequence by the time it reaches the check. Upward traversal already fails, and `TestExtractInsecurePath` already covers it. The sibling-prefix case is the one nothing covered.

### Why fix it

The extractor downloads its archive from a hardcoded HTTPS release URL, so reaching this would take a compromised release or a broken TLS connection. The fix costs two lines. Of two containment checks in one file, the weaker one is what somebody copies next.

### Change

Both call sites now route through a single helper:

```go
func resolveExtractPath(dir string, name string) (string, error) {
	target := filepath.Join(dir, name)

	rel, err := filepath.Rel(dir, target)
	if err != nil {
		return "", fmt.Errorf("illegal file path: %q", name)
	}
	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
		return "", fmt.Errorf("illegal file path: %q", name)
	}

	return target, nil
}
```

The helper uses `filepath.Rel` rather than copying the zip form, because a literal prefix-plus-separator comparison also rejects an entry named `.`, which legitimately resolves to the destination itself. `Rel` admits that case and still rejects everything at or above the destination.

### Tests

- `TestExtractSiblingPrefixPath` — new. Runs `../out-evil/file` through both extractors and asserts the sibling directory stays empty.
- `TestResolveExtractPath` — new table test covering plain, nested, `.`, an interior `..` that resolves back inside, `..`, `../file`, `../../file`, and the sibling prefix.
- `TestExtractInsecurePath` — unchanged, still passing.

The new test fails on the current code and passes with the change. On current code the tar subtest reports `open .../out-evil/file: no such file or directory`, which shows the check admitted the path and extraction proceeded; only a missing parent directory prevented the write. An archive carrying a `TypeDir` entry first creates that directory through `MkdirAll`, and the write lands.

`gofmt` and `go vet` are clean, and the full `sdk/internal/recording` suite passes.
