### PR TITLE
FetcherForNextLink can inject query parameters

### DIFF
--- a/sdk/azcore/CHANGELOG.md
+++ b/sdk/azcore/CHANGELOG.md
@@ -4,13 +4,16 @@
 
 ### Features Added
 
-* `runtime.FetcherForNextLinkOptions` has a new field `Endpoint`, the service endpoint used to resolve a relative next link.
+* New fields in `runtime.FetcherForNextLinkOptions`
+  * `Endpoint` is the service endpoint used to resolve a relative next link.
+  * `Parameters` contains additional query parameters to inject into the next link.
 
 ### Breaking Changes
 
 ### Bugs Fixed
 
 * Fixed an issue where `runtime.Pager[T].More` could return `true` indefinitely after `NextPage` failed to retrieve the first page, causing `for pager.More()` loops to spin. After a page fetch returns an error the `Pager` now enters a terminal state: `More` returns `false` and subsequent `NextPage` calls return the same error without invoking the fetcher again.
+* Fixed `runtime.EncodeQueryParams()` to replace `+` characters with `%20` after calling `url.Values.Encode()`.
 
 ### Other Changes
 

--- a/sdk/azcore/internal/exported/request.go
+++ b/sdk/azcore/internal/exported/request.go
@@ -11,8 +11,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/shared"
 )
@@ -256,4 +258,46 @@ func SetBody(req *Request, body io.ReadSeekCloser, contentType string, clobberCo
 		req.req.Header.Set(shared.HeaderContentType, contentType)
 	}
 	return nil
+}
+
+// EncodeQueryParamsOptions contains the optional values for [EncodeQueryParams].
+type EncodeQueryParamsOptions struct {
+	// Parameters contains any additional query parameters to inject into the URL.
+	Parameters url.Values
+}
+
+// EncodeQueryParams will parse and encode any query parameters in the specified URL.
+// Any semicolons will automatically be escaped.
+func EncodeQueryParams(u string, o *EncodeQueryParamsOptions) (string, error) {
+	if o == nil {
+		o = &EncodeQueryParamsOptions{}
+	}
+
+	before, after, found := strings.Cut(u, "?")
+	qp := url.Values{}
+	if found {
+		// starting in Go 1.17, url.ParseQuery will reject semicolons in query params.
+		// so, we must escape them first. note that this assumes that semicolons aren't
+		// being used as query param separators which is per the current RFC.
+		// for more info:
+		// https://github.com/golang/go/issues/25192
+		// https://github.com/golang/go/issues/50034
+		var err error
+		qp, err = url.ParseQuery(strings.ReplaceAll(after, ";", "%3B"))
+		if err != nil {
+			return "", err
+		}
+	}
+	// inject any additional query parameters from the options, overwriting any
+	// existing values for a given key
+	for k, vs := range o.Parameters {
+		qp.Del(k)
+		for _, v := range vs {
+			qp.Add(k, v)
+		}
+	}
+	if len(qp) == 0 {
+		return before, nil
+	}
+	return before + "?" + strings.ReplaceAll(qp.Encode(), "+", "%20"), nil
 }

--- a/sdk/azcore/internal/exported/request_test.go
+++ b/sdk/azcore/internal/exported/request_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -226,4 +227,127 @@ func TestSetBodyWithNoClobber(t *testing.T) {
 	req.req.Header.Set(shared.HeaderContentType, mergePatch)
 	require.NoError(t, SetBody(req, NopCloser(strings.NewReader(`"json-string"`)), shared.ContentTypeAppJSON, false))
 	require.EqualValues(t, mergePatch, req.req.Header.Get(shared.HeaderContentType))
+}
+
+func TestEncodeQueryParams(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		url     string
+		options *EncodeQueryParamsOptions
+		want    string
+	}{
+		{
+			name: "no query params",
+			url:  "https://contoso.com/path",
+			want: "https://contoso.com/path",
+		},
+		{
+			name: "empty query string",
+			url:  "https://contoso.com/path?",
+			want: "https://contoso.com/path",
+		},
+		{
+			name: "existing params are re-encoded",
+			url:  "https://contoso.com/path?b=2&a=1",
+			want: "https://contoso.com/path?a=1&b=2",
+		},
+		{
+			name: "semicolon in existing value is escaped",
+			url:  "https://contoso.com/path?a=1;2",
+			want: "https://contoso.com/path?a=1%3B2",
+		},
+		{
+			name: "space in existing value uses %20 not +",
+			url:  "https://contoso.com/path?a=hello world",
+			want: "https://contoso.com/path?a=hello%20world",
+		},
+		{
+			name: "plus in existing value is treated as a space and encoded as %20",
+			url:  "https://contoso.com/path?a=1+2",
+			want: "https://contoso.com/path?a=1%202",
+		},
+		{
+			name:    "literal plus in option value is escaped as %2B",
+			url:     "https://contoso.com/path",
+			options: &EncodeQueryParamsOptions{Parameters: url.Values{"a": {"1+2"}}},
+			want:    "https://contoso.com/path?a=1%2B2",
+		},
+		{
+			name: "reserved characters in existing value are escaped",
+			url:  "https://contoso.com/path?a=a b&c=d/e",
+			want: "https://contoso.com/path?a=a%20b&c=d%2Fe",
+		},
+		{
+			name:    "nil options is a no-op",
+			url:     "https://contoso.com/path?a=1",
+			options: nil,
+			want:    "https://contoso.com/path?a=1",
+		},
+		{
+			name:    "options params added to URL with no query string",
+			url:     "https://contoso.com/path",
+			options: &EncodeQueryParamsOptions{Parameters: url.Values{"a": {"1"}}},
+			want:    "https://contoso.com/path?a=1",
+		},
+		{
+			name:    "options params added to URL with trailing ?",
+			url:     "https://contoso.com/path?",
+			options: &EncodeQueryParamsOptions{Parameters: url.Values{"a": {"1"}}},
+			want:    "https://contoso.com/path?a=1",
+		},
+		{
+			name:    "options params merged with existing params",
+			url:     "https://contoso.com/path?a=1",
+			options: &EncodeQueryParamsOptions{Parameters: url.Values{"b": {"2"}}},
+			want:    "https://contoso.com/path?a=1&b=2",
+		},
+		{
+			name:    "options overwrite an existing single-valued key",
+			url:     "https://contoso.com/path?a=1",
+			options: &EncodeQueryParamsOptions{Parameters: url.Values{"a": {"2"}}},
+			want:    "https://contoso.com/path?a=2",
+		},
+		{
+			name:    "options overwrite an existing multi-valued key",
+			url:     "https://contoso.com/path?a=1&a=2",
+			options: &EncodeQueryParamsOptions{Parameters: url.Values{"a": {"3"}}},
+			want:    "https://contoso.com/path?a=3",
+		},
+		{
+			name:    "options overwrite an existing key with multiple new values",
+			url:     "https://contoso.com/path?a=1",
+			options: &EncodeQueryParamsOptions{Parameters: url.Values{"a": {"2", "3"}}},
+			want:    "https://contoso.com/path?a=2&a=3",
+		},
+		{
+			name:    "multiple option values for a key",
+			url:     "https://contoso.com/path",
+			options: &EncodeQueryParamsOptions{Parameters: url.Values{"a": {"1", "2"}}},
+			want:    "https://contoso.com/path?a=1&a=2",
+		},
+		{
+			name:    "option values with special characters are escaped",
+			url:     "https://contoso.com/path",
+			options: &EncodeQueryParamsOptions{Parameters: url.Values{"a": {"x;y z"}}},
+			want:    "https://contoso.com/path?a=x%3By%20z",
+		},
+		{
+			name:    "empty options parameters is a no-op",
+			url:     "https://contoso.com/path?a=1",
+			options: &EncodeQueryParamsOptions{Parameters: url.Values{}},
+			want:    "https://contoso.com/path?a=1",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := EncodeQueryParams(test.url, test.options)
+			require.NoError(t, err)
+			require.EqualValues(t, test.want, got)
+		})
+	}
+}
+
+func TestEncodeQueryParamsInvalid(t *testing.T) {
+	// an invalid percent-encoding in the existing query string surfaces as an error
+	_, err := EncodeQueryParams("https://contoso.com/path?a=%zz", nil)
+	require.Error(t, err)
 }

--- a/sdk/azcore/runtime/pager.go
+++ b/sdk/azcore/runtime/pager.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"reflect"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/tracing"
 )
@@ -128,7 +129,13 @@ type FetcherForNextLinkOptions struct {
 
 	// Endpoint is the service endpoint used to resolve a relative next link,
 	// e.g. "https://contoso.com". It's ignored when the next link is absolute.
+	// This field is only used when NextReq is not specified.
 	Endpoint string
+
+	// Parameters contains any additional query parameters to inject into the request.
+	// Any overlapping query parameters in nextLink will be overwritten.
+	// This field is only used when NextReq is not specified.
+	Parameters url.Values
 }
 
 // FetcherForNextLink is a helper containing boilerplate code to simplify creating a PagingHandler[T].Fetcher from a next link URL.
@@ -146,10 +153,13 @@ func FetcherForNextLink(ctx context.Context, pl Pipeline, nextLink string, first
 	}
 	if nextLink == "" {
 		req, err = firstReq(ctx)
-	} else if nextLink, err = EncodeQueryParams(resolveNextLink(options.Endpoint, nextLink)); err == nil {
-		if options.NextReq != nil {
-			req, err = options.NextReq(ctx, nextLink)
-		} else {
+	} else if options.NextReq != nil {
+		req, err = options.NextReq(ctx, nextLink)
+	} else {
+		nextLink, err = exported.EncodeQueryParams(resolveNextLink(options.Endpoint, nextLink), &exported.EncodeQueryParamsOptions{
+			Parameters: options.Parameters,
+		})
+		if err == nil {
 			verb := http.MethodGet
 			if options.HTTPVerb != "" {
 				verb = options.HTTPVerb
@@ -175,13 +185,30 @@ func FetcherForNextLink(ctx context.Context, pl Pipeline, nextLink string, first
 // resolveNextLink joins a relative nextLink to endpoint, preserving nextLink's query params.
 // nextLink is returned unmodified when it's absolute or when endpoint is empty.
 func resolveNextLink(endpoint, nextLink string) string {
-	if endpoint == "" {
-		return nextLink
-	}
-	u, err := url.Parse(nextLink)
-	if err != nil || u.IsAbs() {
-		// a malformed next link is passed through so the failure surfaces when creating the request
+	if endpoint == "" || hasScheme(nextLink) {
 		return nextLink
 	}
 	return JoinPaths(endpoint, nextLink)
+}
+
+// hasScheme reports whether s begins with a URI scheme, i.e. is an absolute URI.
+// Per RFC 3986: scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) ":".
+// This avoids the allocations of url.Parse when we only need to know if the URI is absolute.
+func hasScheme(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z':
+			// always valid
+		case c == ':':
+			return i > 0
+		case i == 0:
+			return false
+		case c >= '0' && c <= '9', c == '+', c == '-', c == '.':
+			// valid after the first character
+		default:
+			return false
+		}
+	}
+	return false
 }

--- a/sdk/azcore/runtime/pager_test.go
+++ b/sdk/azcore/runtime/pager_test.go
@@ -529,8 +529,8 @@ func TestResolveNextLink(t *testing.T) {
 		{"https://contoso.com", "?skip=1", "https://contoso.com?skip=1"},
 		{"https://contoso.com?api-version=1.0", "/page/2?skip=1", "https://contoso.com/page/2?skip=1&api-version=1.0"},
 		{"https://contoso.com", "/page/it%2Fem", "https://contoso.com/page/it%2Fem"},
-		// a malformed next link is passed through so the failure surfaces when creating the request
-		{"https://contoso.com", "/page/\x7f", "/page/\x7f"},
+		// a malformed next link is joined and passed through; the failure surfaces when creating the request
+		{"https://contoso.com", "/page/\x7f", "https://contoso.com/page/\x7f"},
 	} {
 		require.EqualValues(t, test.want, resolveNextLink(test.endpoint, test.nextLink), "%s + %s", test.endpoint, test.nextLink)
 	}

--- a/sdk/azcore/runtime/request.go
+++ b/sdk/azcore/runtime/request.go
@@ -14,7 +14,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
-	"net/url"
 	"path"
 	"strings"
 
@@ -51,21 +50,7 @@ func NewRequestFromRequest(req *http.Request) (*policy.Request, error) {
 // EncodeQueryParams will parse and encode any query parameters in the specified URL.
 // Any semicolons will automatically be escaped.
 func EncodeQueryParams(u string) (string, error) {
-	before, after, found := strings.Cut(u, "?")
-	if !found {
-		return u, nil
-	}
-	// starting in Go 1.17, url.ParseQuery will reject semicolons in query params.
-	// so, we must escape them first. note that this assumes that semicolons aren't
-	// being used as query param separators which is per the current RFC.
-	// for more info:
-	// https://github.com/golang/go/issues/25192
-	// https://github.com/golang/go/issues/50034
-	qp, err := url.ParseQuery(strings.ReplaceAll(after, ";", "%3B"))
-	if err != nil {
-		return "", err
-	}
-	return before + "?" + qp.Encode(), nil
+	return exported.EncodeQueryParams(u, nil)
 }
 
 // JoinPaths concatenates multiple URL path segments into one path,

--- a/sdk/azcore/runtime/request_test.go
+++ b/sdk/azcore/runtime/request_test.go
@@ -477,10 +477,10 @@ func TestEncodeQueryParams(t *testing.T) {
 	const testURL = "https://contoso.com/"
 	nextLink, err := EncodeQueryParams(testURL + "query?$skip=5&$filter='foo eq bar'")
 	require.NoError(t, err)
-	require.EqualValues(t, testURL+"query?%24filter=%27foo+eq+bar%27&%24skip=5", nextLink)
+	require.EqualValues(t, testURL+"query?%24filter=%27foo%20eq%20bar%27&%24skip=5", nextLink)
 	nextLink, err = EncodeQueryParams(testURL + "query?%24filter=%27foo+eq+bar%27&%24skip=5")
 	require.NoError(t, err)
-	require.EqualValues(t, testURL+"query?%24filter=%27foo+eq+bar%27&%24skip=5", nextLink)
+	require.EqualValues(t, testURL+"query?%24filter=%27foo%20eq%20bar%27&%24skip=5", nextLink)
 	nextLink, err = EncodeQueryParams(testURL + "query?foo=bar&one=two")
 	require.NoError(t, err)
 	require.EqualValues(t, testURL+"query?foo=bar&one=two", nextLink)
@@ -490,6 +490,14 @@ func TestEncodeQueryParams(t *testing.T) {
 	nextLink, err = EncodeQueryParams(testURL + "query?compound=thing1;thing2;thing3")
 	require.NoError(t, err)
 	require.EqualValues(t, testURL+"query?compound=thing1%3Bthing2%3Bthing3", nextLink)
+	// a literal '+' encoded as %2B is preserved (i.e. round-trips as %2B, not a space)
+	nextLink, err = EncodeQueryParams(testURL + "query?a=1%2B2")
+	require.NoError(t, err)
+	require.EqualValues(t, testURL+"query?a=1%2B2", nextLink)
+	// a bare '+' is interpreted as a space and emitted as %20
+	nextLink, err = EncodeQueryParams(testURL + "query?a=1+2")
+	require.NoError(t, err)
+	require.EqualValues(t, testURL+"query?a=1%202", nextLink)
 }
 
 func TestNewUUID(t *testing.T) {


### PR DESCRIPTION
Added Parameters field to FetcherForNextLinkOptions which is used for query parameter reinjection into the nextLink URL.
Don't preprocess the nextLink when calling the NextReq handler as it's expected to create the fully formed URL.
Simplify resolveNextLink to check for a scheme in the URL instead of fully parsing it just to check if it has a scheme. EncodeQueryParams replaces + with %20 after calling url.Values.Encode.

