### PR TITLE
[DO NOT MERGE] Dummy azcosmos change to validate feature/azcosmos/v2 branch protections

### DIFF
--- a/sdk/data/azcosmos/cosmos_client.go
+++ b/sdk/data/azcosmos/cosmos_client.go
@@ -29,6 +29,7 @@ const (
 )
 
 // Client is used to interact with the Azure Cosmos DB database service.
+// DUMMY TEST CHANGE - branch protection validation, do not merge.
 type Client struct {
 	endpoint    string
 	internal    *azcore.Client


### PR DESCRIPTION
## Do not merge — test PR

Opened to observe what actually gets enforced on `feature/azcosmos/v2` today, ahead of asking for a repo ruleset targeting this branch.

**Change:** one comment line in `sdk/data/azcosmos/cosmos_client.go`.

**What we're checking:**
- Which rulesets apply (expectation: none — all three current rulesets target `~DEFAULT_BRANCH` only)
- Whether `@Azure/azure-cosmos-go-sdk` is auto-requested via CODEOWNERS
- Which status checks run (`license/cla`, `go - pullrequest`)
- Whether merge is blocked without approval

Will be closed once we've captured the results.