### PR TITLE
[Storage] Fix azblob structured message CRC64 download validation

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -15,8 +15,12 @@
 * Fixed the Structured Message encoder emitting a valid, complete message when the source returned a non-EOF error exactly on a segment boundary; such errors are now propagated.
 * Structured Message decoding now rejects a payload that declares fewer segments and appends unvalidated trailing bytes (`SMDecode` requires the parsed message to consume the entire input, and the streaming decoder validates the consumed byte count against the declared message length).
 * Fixed the Structured Message encoder returning `io.EOF` when the source ends before the declared content length; a premature EOF is now surfaced as `io.ErrUnexpectedEOF` so callers do not accept a truncated message.
+* Fixed Structured Message decoder discarding errors (including `net.Error` and `io.EOF`) when the returned bytes exactly complete a segment; such errors are now propagated so `RetryReader` can retry transient failures at segment boundaries.
+* Premature EOF during Structured Message framing reads (header, segment footer, or message trailer) now wraps `io.ErrUnexpectedEOF` so `RetryReader` classifies truncated framing as retryable.
 
 ### Other Changes
+
+* **Known limitation:** after a mid-segment connection failure, `RetryReader` resumes from a byte offset past already-emitted data whose segment CRC has not yet been validated. Only the suffix of that segment is CRC-checked on the retried response. A follow-up to buffer full segments or checkpoint at validated boundaries is tracked in [#27362](https://github.com/Azure/azure-sdk-for-go/issues/27362).
 
 ## 1.8.1-beta.1 (2026-07-24)
 

--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -9,6 +9,10 @@
 ### Bugs Fixed
 
 * Fixed WASM compilation by using heap-allocated buffers on JS targets.
+* Fixed Structured Message CRC64 download validation being skipped when the final payload byte exactly fills the caller's read buffer; the trailing segment footer and message trailer CRC64 are now drained and validated in the same `Read`.
+* Fixed transient `net.Error`/`io.ErrUnexpectedEOF` failures during a Structured Message download not being retried: the decoder now preserves the error chain with `%w` and the retry reader classifies retryable errors with `errors.Is`/`errors.As`.
+* Structured Message download now rejects a response missing the negotiated CRC64 flag instead of silently skipping validation.
+* Fixed the Structured Message encoder emitting a valid, complete message when the source returned a non-EOF error exactly on a segment boundary; such errors are now propagated.
 
 ### Other Changes
 

--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -17,7 +17,6 @@
 * Fixed the Structured Message encoder returning `io.EOF` when the source ends before the declared content length; a premature EOF is now surfaced as `io.ErrUnexpectedEOF` so callers do not accept a truncated message.
 * Fixed Structured Message decoder discarding errors (including `net.Error` and `io.EOF`) when the returned bytes exactly complete a segment; such errors are now propagated so `RetryReader` can retry transient failures at segment boundaries.
 * Premature EOF during Structured Message framing reads (header, segment footer, or message trailer) now wraps `io.ErrUnexpectedEOF` so `RetryReader` classifies truncated framing as retryable.
-* **Known limitation:** after a mid-segment connection failure, `RetryReader` resumes from a byte offset past already-emitted data whose segment CRC has not yet been validated. Only the suffix of that segment is CRC-checked on the retried response. A follow-up to buffer full segments or checkpoint at validated boundaries is tracked in [#27362](https://github.com/Azure/azure-sdk-for-go/issues/27362).
 
 ### Other Changes
 

--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -13,6 +13,8 @@
 * Fixed transient `net.Error`/`io.ErrUnexpectedEOF` failures during a Structured Message download not being retried: the decoder now preserves the error chain with `%w` and the retry reader classifies retryable errors with `errors.Is`/`errors.As`.
 * Structured Message download now rejects a response missing the negotiated CRC64 flag instead of silently skipping validation.
 * Fixed the Structured Message encoder emitting a valid, complete message when the source returned a non-EOF error exactly on a segment boundary; such errors are now propagated.
+* Structured Message decoding now rejects a payload that declares fewer segments and appends unvalidated trailing bytes (`SMDecode` requires the parsed message to consume the entire input, and the streaming decoder validates the consumed byte count against the declared message length).
+* Fixed the Structured Message encoder returning `io.EOF` when the source ends before the declared content length; a premature EOF is now surfaced as `io.ErrUnexpectedEOF` so callers do not accept a truncated message.
 
 ### Other Changes
 

--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -17,10 +17,9 @@
 * Fixed the Structured Message encoder returning `io.EOF` when the source ends before the declared content length; a premature EOF is now surfaced as `io.ErrUnexpectedEOF` so callers do not accept a truncated message.
 * Fixed Structured Message decoder discarding errors (including `net.Error` and `io.EOF`) when the returned bytes exactly complete a segment; such errors are now propagated so `RetryReader` can retry transient failures at segment boundaries.
 * Premature EOF during Structured Message framing reads (header, segment footer, or message trailer) now wraps `io.ErrUnexpectedEOF` so `RetryReader` classifies truncated framing as retryable.
+* **Known limitation:** after a mid-segment connection failure, `RetryReader` resumes from a byte offset past already-emitted data whose segment CRC has not yet been validated. Only the suffix of that segment is CRC-checked on the retried response. A follow-up to buffer full segments or checkpoint at validated boundaries is tracked in [#27362](https://github.com/Azure/azure-sdk-for-go/issues/27362).
 
 ### Other Changes
-
-* **Known limitation:** after a mid-segment connection failure, `RetryReader` resumes from a byte offset past already-emitted data whose segment CRC has not yet been validated. Only the suffix of that segment is CRC-checked on the retried response. A follow-up to buffer full segments or checkpoint at validated boundaries is tracked in [#27362](https://github.com/Azure/azure-sdk-for-go/issues/27362).
 
 ## 1.8.1-beta.1 (2026-07-24)
 

--- a/sdk/storage/azblob/blob/retry_reader.go
+++ b/sdk/storage/azblob/blob/retry_reader.go
@@ -5,6 +5,7 @@ package blob
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"strings"
@@ -127,7 +128,7 @@ func (s *RetryReader) Read(p []byte) (n int, err error) {
 		}
 
 		// We successfully read data or end EOF.
-		if err == nil || err == io.EOF {
+		if err == nil || errors.Is(err, io.EOF) {
 			s.info.Range.Offset += int64(n) // Increments the start offset in case we need to make a new HTTP request in the future
 			if s.info.Range.Count != CountToEnd {
 				s.info.Range.Count -= int64(n) // Decrement the count in case we need to make a new HTTP request in the future
@@ -140,8 +141,11 @@ func (s *RetryReader) Read(p []byte) (n int, err error) {
 
 		// Check the retry count and error code, and decide whether to retry.
 		retriesExhausted := try >= s.retryReaderOptions.MaxRetries
-		_, isNetError := err.(net.Error)
-		isUnexpectedEOF := err == io.ErrUnexpectedEOF
+		// Use errors.As so that a net.Error wrapped further down the chain (e.g. by the structured
+		// message decoder via fmt.Errorf("...: %w", err)) is still recognized as retryable.
+		var netErr net.Error
+		isNetError := errors.As(err, &netErr)
+		isUnexpectedEOF := errors.Is(err, io.ErrUnexpectedEOF)
 		willRetry := (isNetError || isUnexpectedEOF || s.wasRetryableEarlyClose(err)) && !retriesExhausted
 
 		// Notify, for logging purposes, of any failures

--- a/sdk/storage/azblob/blob/retry_reader_test.go
+++ b/sdk/storage/azblob/blob/retry_reader_test.go
@@ -428,3 +428,45 @@ func TestRetryReaderReadWithForcedRetry(t *testing.T) {
 		}
 	}
 }
+
+// TestRetryReaderWithRetryWrappedNetError verifies that a net.Error wrapped in an error chain via
+// fmt.Errorf("...: %w", err) — as the structured message decoder does for segment-read failures —
+// is still classified as retryable. The previous direct type assertion err.(net.Error) did not
+// unwrap the chain and so would not retry these transient failures.
+func TestRetryReaderWithRetryWrappedNetError(t *testing.T) {
+	byteCount := 1
+	body := newPerByteReader(byteCount)
+	body.doInjectError = true
+	body.doInjectErrorByteIndex = 0
+	body.doInjectTimes = 1
+	// A net.Error wrapped in an error chain, mirroring SMDecoder's fmt.Errorf("segment %d: %w", ...).
+	body.injectedError = fmt.Errorf("segment 1: %w", &net.DNSError{IsTemporary: true})
+
+	getter := func(ctx context.Context, info httpGetterInfo) (io.ReadCloser, error) {
+		r := http.Response{}
+		body.currentByteIndex = int(info.Range.Offset)
+		r.Body = body
+		return r.Body, nil
+	}
+
+	httpGetterInfo := httpGetterInfo{
+		Range: HTTPRange{
+			Count: int64(byteCount),
+		},
+	}
+	initResponse, err := getter(context.Background(), httpGetterInfo)
+	require.NoError(t, err)
+
+	retryReader := newRetryReader(context.Background(), initResponse, httpGetterInfo, getter, RetryReaderOptions{MaxRetries: 1})
+
+	// The wrapped net.Error should be recognized as retryable, and the retry should succeed.
+	can := make([]byte, 1)
+	n, err := retryReader.Read(can)
+	require.Equal(t, 1, n)
+	require.NoError(t, err)
+
+	// Subsequent read returns EOF.
+	n, err = retryReader.Read(can)
+	require.Equal(t, 0, n)
+	require.Equal(t, io.EOF, err)
+}

--- a/sdk/storage/azblob/internal/shared/structured_message.go
+++ b/sdk/storage/azblob/internal/shared/structured_message.go
@@ -6,6 +6,7 @@ package shared
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/crc64"
 	"io"
@@ -191,6 +192,12 @@ func SMDecode(smData []byte) (SMDecodeResult, error) {
 
 	flags := binary.LittleEndian.Uint16(smData[9:11])
 	numSegments := binary.LittleEndian.Uint16(smData[11:13])
+	// The structured message body is negotiated with properties=crc64, so the CRC64 flag
+	// must be present. Rejecting its absence prevents silently skipping validation. Only the
+	// CRC64 bit is required; other flag bits are ignored to preserve forward compatibility.
+	if flags&SMFlagCRC64 == 0 {
+		return SMDecodeResult{}, fmt.Errorf("structured message is missing the required CRC64 flag (flags=0x%04x)", flags)
+	}
 	hasCRC := flags&SMFlagCRC64 != 0
 
 	offset := SMHeaderSize
@@ -396,8 +403,11 @@ func (e *SMEncoder) Read(p []byte) (int, error) {
 				e.pendingOff = 0
 				e.state = encStateSegFooter
 			}
-			if err != nil && e.segRemain > 0 {
-				return totalRead, err
+			if err != nil {
+				finalContentBoundary := e.segRemain == 0 && e.segIndex == e.numSegments
+				if !errors.Is(err, io.EOF) || !finalContentBoundary {
+					return totalRead, err
+				}
 			}
 
 		case encStateSegFooter:
@@ -565,7 +575,13 @@ func (d *SMDecoder) Read(p []byte) (int, error) {
 	}
 
 	totalOut := 0
-	for totalOut < len(p) {
+	// NOTE: framing states (header, segment header/footer, trailer) are processed even once the
+	// caller's buffer is full, because that framing is consumed from the source into an internal
+	// buffer rather than into p. Only segment *data* requires space in p. This guarantees the final
+	// segment footer and message trailer CRC64 are drained and validated within the same Read call
+	// that emits the last payload byte, so a bounded reader (e.g. RetryReader) cannot report EOF and
+	// skip validation when the payload happens to fill the buffer exactly.
+	for {
 		switch d.state {
 		case decStateHeader:
 			done, err := d.fillFrame()
@@ -596,33 +612,41 @@ func (d *SMDecoder) Read(p []byte) (int, error) {
 			}
 
 		case decStateSegData:
-			// Read segment data from source, pass through to caller
-			toRead := int64(len(p) - totalOut)
-			if toRead > d.segRemain {
-				toRead = d.segRemain
-			}
-			n, err := d.source.Read(p[totalOut : totalOut+int(toRead)])
-			if n > 0 {
-				d.bytesRead += int64(n)
-				if d.hasCRC {
-					_, _ = d.segCRC.Write(p[totalOut : totalOut+n])
-					_, _ = d.msgCRC.Write(p[totalOut : totalOut+n])
+			if d.segRemain > 0 {
+				if totalOut >= len(p) {
+					// Caller's buffer is full and more segment data is pending;
+					// the remainder will be produced on the next Read.
+					return totalOut, nil
 				}
-				totalOut += n
-				d.segRemain -= int64(n)
+				// Read segment data from source, pass through to caller
+				toRead := int64(len(p) - totalOut)
+				if toRead > d.segRemain {
+					toRead = d.segRemain
+				}
+				n, err := d.source.Read(p[totalOut : totalOut+int(toRead)])
+				if n > 0 {
+					d.bytesRead += int64(n)
+					if d.hasCRC {
+						_, _ = d.segCRC.Write(p[totalOut : totalOut+n])
+						_, _ = d.msgCRC.Write(p[totalOut : totalOut+n])
+					}
+					totalOut += n
+					d.segRemain -= int64(n)
+				}
+				if err != nil && d.segRemain > 0 {
+					d.setError(fmt.Errorf("segment %d: %w", d.segIndex, err))
+					return totalOut, d.err
+				}
 			}
 			if d.segRemain == 0 {
-				// Segment data done
+				// Segment data is fully consumed. Advance to the footer/next segment even when the
+				// caller's buffer is full so trailing framing is drained and validated before EOF.
 				if d.hasCRC {
 					d.prepareFrame(SMSegmentFooterSize)
 					d.state = decStateSegFooter
 				} else {
 					d.advanceAfterSegment()
 				}
-			}
-			if err != nil && d.segRemain > 0 {
-				d.setError(fmt.Errorf("segment %d: %s", d.segIndex, err))
-				return totalOut, d.err
 			}
 
 		case decStateSegFooter:
@@ -663,7 +687,6 @@ func (d *SMDecoder) Read(p []byte) (int, error) {
 			return totalOut, d.err
 		}
 	}
-	return totalOut, nil
 }
 
 func (d *SMDecoder) parseHeader() error {
@@ -676,6 +699,12 @@ func (d *SMDecoder) parseHeader() error {
 	d.msgLen = binary.LittleEndian.Uint64(buf[1:9])
 	d.flags = binary.LittleEndian.Uint16(buf[9:11])
 	d.numSegments = binary.LittleEndian.Uint16(buf[11:13])
+	// The structured message body is negotiated with properties=crc64, so the CRC64 flag
+	// must be present. Rejecting its absence prevents silently skipping validation. Only the
+	// CRC64 bit is required; other flag bits are ignored to preserve forward compatibility.
+	if d.flags&SMFlagCRC64 == 0 {
+		return fmt.Errorf("structured message is missing the required CRC64 flag (flags=0x%04x)", d.flags)
+	}
 	d.hasCRC = d.flags&SMFlagCRC64 != 0
 
 	if d.hasCRC {
@@ -756,7 +785,7 @@ func (d *SMDecoder) fillFrame() (bool, error) {
 			return true, nil
 		}
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return false, fmt.Errorf("unexpected EOF reading structured message framing (have %d of %d bytes)", d.frameHave, d.frameNeed)
 			}
 			return false, err

--- a/sdk/storage/azblob/internal/shared/structured_message.go
+++ b/sdk/storage/azblob/internal/shared/structured_message.go
@@ -238,6 +238,14 @@ func SMDecode(smData []byte) (SMDecodeResult, error) {
 		if expectedMsgCRC != actualMsgCRC {
 			return SMDecodeResult{}, fmt.Errorf("message trailer CRC64 mismatch (expected 0x%016x, got 0x%016x)", expectedMsgCRC, actualMsgCRC)
 		}
+		offset += SMMessageTrailerSize
+	}
+
+	// The parsed message must consume the entire input. Declaring fewer segments and appending
+	// arbitrary trailing bytes would otherwise pass the header length check yet leave those bytes
+	// unvalidated, so reject any leftover data.
+	if offset != len(smData) {
+		return SMDecodeResult{}, fmt.Errorf("structured message has %d unexpected trailing bytes after offset %d", len(smData)-offset, offset)
 	}
 
 	return SMDecodeResult{
@@ -405,7 +413,15 @@ func (e *SMEncoder) Read(p []byte) (int, error) {
 			}
 			if err != nil {
 				finalContentBoundary := e.segRemain == 0 && e.segIndex == e.numSegments
-				if !errors.Is(err, io.EOF) || !finalContentBoundary {
+				if errors.Is(err, io.EOF) {
+					// EOF is only valid exactly at the final declared content boundary. A premature EOF
+					// means the source produced fewer bytes than the declared content length; surface it
+					// as io.ErrUnexpectedEOF so callers (e.g. io.ReadAll) don't accept a truncated message.
+					if !finalContentBoundary {
+						return totalRead, io.ErrUnexpectedEOF
+					}
+				} else {
+					// Any non-EOF error is propagated so a failed read is never encoded as a valid message.
 					return totalRead, err
 				}
 			}
@@ -769,6 +785,11 @@ func (d *SMDecoder) validateTrailerCRC() error {
 	actual := d.msgCRC.Sum64()
 	if expected != actual {
 		return fmt.Errorf("message trailer CRC64 mismatch (expected 0x%016x, got 0x%016x)", expected, actual)
+	}
+	// The consumed byte count must match the declared message length, so a stream that declares
+	// fewer segments (leaving trailing bytes unvalidated) is rejected rather than silently accepted.
+	if d.msgLen > 0 && d.bytesRead != int64(d.msgLen) {
+		return fmt.Errorf("structured message length mismatch: header says %d, consumed %d bytes", d.msgLen, d.bytesRead)
 	}
 	d.state = decStateDone
 	return nil

--- a/sdk/storage/azblob/internal/shared/structured_message.go
+++ b/sdk/storage/azblob/internal/shared/structured_message.go
@@ -653,6 +653,16 @@ func (d *SMDecoder) Read(p []byte) (int, error) {
 					d.setError(fmt.Errorf("segment %d: %w", d.segIndex, err))
 					return totalOut, d.err
 				}
+				if err != nil && d.segRemain == 0 {
+					// The source returned bytes that exactly completed the segment together with
+					// an error. Footer/trailer framing must still follow, so even io.EOF is
+					// premature here; convert it to io.ErrUnexpectedEOF so RetryReader can retry.
+					if errors.Is(err, io.EOF) {
+						err = io.ErrUnexpectedEOF
+					}
+					d.setError(fmt.Errorf("segment %d: %w", d.segIndex, err))
+					return totalOut, d.err
+				}
 			}
 			if d.segRemain == 0 {
 				// Segment data is fully consumed. Advance to the footer/next segment even when the
@@ -807,7 +817,7 @@ func (d *SMDecoder) fillFrame() (bool, error) {
 		}
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return false, fmt.Errorf("unexpected EOF reading structured message framing (have %d of %d bytes)", d.frameHave, d.frameNeed)
+				return false, fmt.Errorf("reading structured message framing (have %d of %d bytes): %w", d.frameHave, d.frameNeed, io.ErrUnexpectedEOF)
 			}
 			return false, err
 		}

--- a/sdk/storage/azblob/internal/shared/structured_message_test.go
+++ b/sdk/storage/azblob/internal/shared/structured_message_test.go
@@ -9,6 +9,7 @@ package shared
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/crc64"
 	"io"
@@ -983,4 +984,138 @@ func TestSMEncoderSegmentSizeJustOverLimit(t *testing.T) {
 	decodedData, err := io.ReadAll(dec)
 	require.NoError(t, err)
 	require.Equal(t, content, decodedData)
+}
+
+// segBoundaryReader is a test io.ReadSeeker whose Read returns err exactly when its data is
+// exhausted, allowing simulation of a source that returns bytes together with an error at a
+// segment boundary.
+type segBoundaryReader struct {
+	data []byte
+	err  error
+	off  int
+}
+
+func (r *segBoundaryReader) Read(p []byte) (int, error) {
+	if r.off >= len(r.data) {
+		return 0, r.err
+	}
+	n := copy(p, r.data[r.off:])
+	r.off += n
+	if r.off >= len(r.data) {
+		return n, r.err
+	}
+	return n, nil
+}
+
+func (r *segBoundaryReader) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+		r.off = int(offset)
+	case io.SeekCurrent:
+		r.off += int(offset)
+	case io.SeekEnd:
+		r.off = len(r.data) + int(offset)
+	}
+	return int64(r.off), nil
+}
+
+// TestStreamingDecoderValidatesTrailerOnExactBufferFill guards against a decoder that returns the
+// final payload byte without draining and validating the trailing segment footer/message trailer in
+// the same Read. A bounded reader (e.g. RetryReader) could otherwise report EOF and skip validation
+// when the payload exactly fills the caller's buffer.
+func TestStreamingDecoderValidatesTrailerOnExactBufferFill(t *testing.T) {
+	data := make([]byte, 2048)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+
+	// Corrupt only the message trailer CRC (last 8 bytes); the segment data and footer remain valid.
+	corrupted := makeCorruptedSM(data, func(d []byte) { d[len(d)-1] ^= 0xFF })
+
+	dec := NewSMDecoder(io.NopCloser(bytes.NewReader(corrupted)))
+
+	// Buffer sized exactly to the payload length so the last payload byte fills it exactly.
+	buf := make([]byte, len(data))
+	n, err := dec.Read(buf)
+	require.Equal(t, len(data), n)
+	// The trailing framing must have been drained and validated in this same call.
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "trailer CRC64 mismatch")
+}
+
+// TestStreamingDecoderExactBufferFillValid verifies the happy path for the same exact-fill boundary:
+// a valid message returns all payload bytes plus a nil error on the fill read, and a subsequent read
+// reports io.EOF with no extra bytes.
+func TestStreamingDecoderExactBufferFillValid(t *testing.T) {
+	data := make([]byte, 2048)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+
+	valid := SMEncode(data, 0).EncodedData
+	dec := NewSMDecoder(io.NopCloser(bytes.NewReader(valid)))
+
+	buf := make([]byte, len(data))
+	n, err := dec.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, len(data), n)
+	require.Equal(t, data, buf)
+
+	n, err = dec.Read(make([]byte, 8))
+	require.Equal(t, 0, n)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+// TestEncoderPropagatesNonEOFErrorAtSegmentBoundary verifies that when the inner reader returns data
+// together with a non-EOF error and those bytes exactly complete a segment, the encoder propagates
+// the error instead of silently emitting a valid trailer.
+func TestEncoderPropagatesNonEOFErrorAtSegmentBoundary(t *testing.T) {
+	data := []byte("ABCD") // exactly one 4-byte segment
+	sentinel := errors.New("read failure at segment boundary")
+
+	enc := NewSMEncoder(&segBoundaryReader{data: data, err: sentinel}, int64(len(data)), len(data))
+	_, err := io.ReadAll(enc)
+	require.Error(t, err)
+	require.ErrorIs(t, err, sentinel)
+}
+
+// TestEncoderAcceptsDataWithEOFAtFinalBoundary verifies that a source returning its final bytes
+// together with io.EOF (valid io.Reader behavior) still produces a correctly encoded message rather
+// than a spurious error.
+func TestEncoderAcceptsDataWithEOFAtFinalBoundary(t *testing.T) {
+	data := []byte("ABCDEFGHIJ") // 10 bytes across two 5-byte segments
+	segSize := 5
+
+	enc := NewSMEncoder(&segBoundaryReader{data: data, err: io.EOF}, int64(len(data)), segSize)
+	encoded, err := io.ReadAll(enc)
+	require.NoError(t, err)
+
+	decoded, err := SMDecode(encoded)
+	require.NoError(t, err)
+	require.Equal(t, data, decoded.Data)
+}
+
+// TestDecoderRejectsMissingCRC64Flag verifies that a structured message whose CRC64 flag is not set
+// is rejected. The body is negotiated with properties=crc64, so a missing flag (which would cause the
+// decoder to skip all footer/trailer validation) must be treated as an error by both the streaming
+// decoder and the one-shot SMDecode.
+func TestDecoderRejectsMissingCRC64Flag(t *testing.T) {
+	data := []byte("structured message body that should be validated")
+
+	// Clear the CRC64 flag bits (flags occupy bytes [9:11]) while leaving msgLen and framing intact.
+	noFlag := makeCorruptedSM(data, func(d []byte) {
+		d[9] = 0
+		d[10] = 0
+	})
+
+	// Streaming decoder must reject it.
+	dec := NewSMDecoder(io.NopCloser(bytes.NewReader(noFlag)))
+	_, err := io.ReadAll(dec)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing the required CRC64 flag")
+
+	// One-shot decode must reject it too.
+	_, err = SMDecode(noFlag)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing the required CRC64 flag")
 }

--- a/sdk/storage/azblob/internal/shared/structured_message_test.go
+++ b/sdk/storage/azblob/internal/shared/structured_message_test.go
@@ -1185,10 +1185,10 @@ func TestDecoderPropagatesNetErrorAtExactSegmentCompletion(t *testing.T) {
 // segDataNetErrorReader serves an encoded SM stream but injects a net.Error exactly when the
 // segment data bytes are exhausted (bytes + error at segment completion boundary).
 type segDataNetErrorReader struct {
-	encoded []byte
-	segSize int
-	netErr  net.Error
-	off     int
+	encoded  []byte
+	segSize  int
+	netErr   net.Error
+	off      int
 	injected bool
 }
 

--- a/sdk/storage/azblob/internal/shared/structured_message_test.go
+++ b/sdk/storage/azblob/internal/shared/structured_message_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"hash/crc64"
 	"io"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -1150,6 +1151,182 @@ func TestEncoderPrematureEOFIsUnexpected(t *testing.T) {
 	enc := NewSMEncoder(&segBoundaryReader{data: data, err: io.EOF}, 10, 0)
 
 	_, err := io.ReadAll(enc)
+	require.Error(t, err)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+// TestDecoderPropagatesNetErrorAtExactSegmentCompletion verifies that when the source returns bytes
+// together with a net.Error and those bytes exactly complete a segment, the decoder propagates the
+// error (wrapped with %w) instead of silently advancing to the footer state.
+func TestDecoderPropagatesNetErrorAtExactSegmentCompletion(t *testing.T) {
+	data := []byte("ABCD") // 4 bytes, one segment
+	segSize := len(data)
+
+	// Encode a valid structured message to get the framing.
+	encoded := SMEncode(data, segSize).EncodedData
+
+	// Build a reader that returns the full encoded bytes but injects a net.Error exactly when the
+	// segment data is exhausted. The segBoundaryReader returns (n, err) when its data runs out.
+	netErr := &net.DNSError{IsTemporary: true}
+
+	// We need a reader that returns SM framing normally but injects the error at the segment data boundary.
+	src := &segDataNetErrorReader{
+		encoded: encoded,
+		segSize: segSize,
+		netErr:  netErr,
+	}
+
+	dec := NewSMDecoder(io.NopCloser(src))
+	_, err := io.ReadAll(dec)
+	require.Error(t, err)
+	require.ErrorIs(t, err, netErr)
+}
+
+// segDataNetErrorReader serves an encoded SM stream but injects a net.Error exactly when the
+// segment data bytes are exhausted (bytes + error at segment completion boundary).
+type segDataNetErrorReader struct {
+	encoded []byte
+	segSize int
+	netErr  net.Error
+	off     int
+	injected bool
+}
+
+func (r *segDataNetErrorReader) Read(p []byte) (int, error) {
+	if r.off >= len(r.encoded) {
+		return 0, io.EOF
+	}
+	// Calculate the end of the first segment's data within the encoded stream.
+	// Header (13 bytes) + segment header (6 bytes) + segment data (segSize bytes).
+	segDataEnd := SMHeaderSize + SMSegmentHeaderSize + r.segSize
+	if !r.injected && r.off < segDataEnd {
+		// Serve up to the end of segment data, then inject the error.
+		avail := segDataEnd - r.off
+		n := copy(p, r.encoded[r.off:r.off+avail])
+		r.off += n
+		if r.off >= segDataEnd {
+			r.injected = true
+			return n, r.netErr
+		}
+		return n, nil
+	}
+	n := copy(p, r.encoded[r.off:])
+	r.off += n
+	if r.off >= len(r.encoded) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+// TestDecoderPrematureEOFDuringSegmentData verifies that when the source returns io.EOF while
+// segment data bytes are still expected, the decoder converts it to io.ErrUnexpectedEOF so the
+// error is retryable by RetryReader.
+func TestDecoderPrematureEOFDuringSegmentData(t *testing.T) {
+	data := []byte("ABCDEFGH") // 8 bytes
+	segSize := len(data)
+
+	encoded := SMEncode(data, segSize).EncodedData
+
+	// Truncate the encoded stream partway through the segment data (cut after header + seg header + 4 bytes).
+	truncateAt := SMHeaderSize + SMSegmentHeaderSize + 4
+	truncated := encoded[:truncateAt]
+
+	dec := NewSMDecoder(io.NopCloser(bytes.NewReader(truncated)))
+	_, err := io.ReadAll(dec)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "segment")
+}
+
+// TestDecoderEOFExactlyCompletingSegmentIsUnexpected verifies that a source returning (n, io.EOF)
+// where n exactly completes the segment is treated as an error (footer/trailer must still follow).
+func TestDecoderEOFExactlyCompletingSegmentIsUnexpected(t *testing.T) {
+	data := []byte("ABCD")
+	segSize := len(data)
+
+	encoded := SMEncode(data, segSize).EncodedData
+
+	// Build a reader that returns (n, io.EOF) exactly when segment data is exhausted,
+	// before footer/trailer can be read.
+	segDataEnd := SMHeaderSize + SMSegmentHeaderSize + segSize
+	src := &segBoundaryEOFReader{
+		encoded:    encoded,
+		segDataEnd: segDataEnd,
+	}
+
+	dec := NewSMDecoder(io.NopCloser(src))
+	_, err := io.ReadAll(dec)
+	require.Error(t, err)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+// segBoundaryEOFReader returns (n, io.EOF) exactly when the segment data is exhausted, simulating
+// a source that ends at the segment data boundary before footer/trailer framing.
+type segBoundaryEOFReader struct {
+	encoded    []byte
+	segDataEnd int
+	off        int
+}
+
+func (r *segBoundaryEOFReader) Read(p []byte) (int, error) {
+	if r.off >= len(r.encoded) {
+		return 0, io.EOF
+	}
+	if r.off < r.segDataEnd {
+		end := r.segDataEnd
+		if end > r.off+len(p) {
+			end = r.off + len(p)
+		}
+		n := copy(p, r.encoded[r.off:end])
+		r.off += n
+		if r.off >= r.segDataEnd {
+			return n, io.EOF
+		}
+		return n, nil
+	}
+	n := copy(p, r.encoded[r.off:])
+	r.off += n
+	if r.off >= len(r.encoded) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+// TestFillFrameTruncatedFooterIsRetryable verifies that a premature EOF during footer/trailer
+// framing reads wraps io.ErrUnexpectedEOF so RetryReader can classify it as retryable.
+func TestFillFrameTruncatedFooterIsRetryable(t *testing.T) {
+	data := []byte("ABCDEFGH")
+	segSize := len(data)
+
+	encoded := SMEncode(data, segSize).EncodedData
+
+	// Truncate after segment data, partway through the segment footer.
+	// Header (13) + seg header (6) + seg data (8) + partial footer (4 of 8).
+	truncateAt := SMHeaderSize + SMSegmentHeaderSize + segSize + 4
+	require.Less(t, truncateAt, len(encoded))
+	truncated := encoded[:truncateAt]
+
+	dec := NewSMDecoder(io.NopCloser(bytes.NewReader(truncated)))
+	_, err := io.ReadAll(dec)
+	require.Error(t, err)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+// TestFillFrameTruncatedTrailerIsRetryable verifies that a premature EOF during message trailer
+// reads wraps io.ErrUnexpectedEOF.
+func TestFillFrameTruncatedTrailerIsRetryable(t *testing.T) {
+	data := []byte("ABCDEFGH")
+	segSize := len(data)
+
+	encoded := SMEncode(data, segSize).EncodedData
+
+	// Truncate after segment footer, partway through the message trailer.
+	// Header (13) + seg header (6) + seg data (8) + seg footer (8) + partial trailer (4 of 8).
+	truncateAt := SMHeaderSize + SMSegmentHeaderSize + segSize + SMSegmentFooterSize + 4
+	require.Less(t, truncateAt, len(encoded))
+	truncated := encoded[:truncateAt]
+
+	dec := NewSMDecoder(io.NopCloser(bytes.NewReader(truncated)))
+	_, err := io.ReadAll(dec)
 	require.Error(t, err)
 	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 }

--- a/sdk/storage/azblob/internal/shared/structured_message_test.go
+++ b/sdk/storage/azblob/internal/shared/structured_message_test.go
@@ -1119,3 +1119,37 @@ func TestDecoderRejectsMissingCRC64Flag(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing the required CRC64 flag")
 }
+
+// TestDecodeRejectsTrailingBytes verifies that SMDecode rejects a payload whose declared length
+// matches the input but whose parsed segments/trailer end before the end of the buffer, leaving
+// unexamined trailing bytes. This guards against declaring fewer segments, placing a valid message
+// CRC at the resulting trailer offset, and appending arbitrary bytes.
+func TestDecodeRejectsTrailingBytes(t *testing.T) {
+	data := []byte("payload that will be followed by junk")
+	encoded := SMEncode(data, 0).EncodedData
+
+	// Append arbitrary trailing bytes and bump the header's declared message length to match, so the
+	// initial length check passes but the parsed message ends before len(smData).
+	junk := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	tampered := make([]byte, 0, len(encoded)+len(junk))
+	tampered = append(tampered, encoded...)
+	tampered = append(tampered, junk...)
+	binary.LittleEndian.PutUint64(tampered[1:9], uint64(len(tampered)))
+
+	_, err := SMDecode(tampered)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected trailing bytes")
+}
+
+// TestEncoderPrematureEOFIsUnexpected verifies that when the source ends before the declared content
+// length, the encoder surfaces io.ErrUnexpectedEOF rather than a plain io.EOF, so callers such as
+// io.ReadAll do not accept a truncated structured message as success.
+func TestEncoderPrematureEOFIsUnexpected(t *testing.T) {
+	// Declare 10 bytes of content but only supply 4 before EOF.
+	data := []byte("ABCD")
+	enc := NewSMEncoder(&segBoundaryReader{data: data, err: io.EOF}, 10, 0)
+
+	_, err := io.ReadAll(enc)
+	require.Error(t, err)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}


### PR DESCRIPTION
## Summary

Ports the structured message (XSM/1.0) CRC64 integrity fixes from the merged azfile change (#27261) to **azblob**, whose decoder and retry reader still had the pre-fix behavior. These same code paths are used by **azdatalake** (#27263), which delegates structured message download decoding to azblob — so these fixes are required for azdatalake's download validation to be correct as well.

Found during review of #27263.

## Fixes

- **Download validation skipped on exact buffer fill** — `SMDecoder.Read` now drains and validates the trailing segment footer and message trailer CRC64 in the same `Read` that emits the final payload byte. Previously, when the last payload byte exactly filled the caller's buffer (common for full 4 MiB chunks with `io.Copy`), a bounded reader (`RetryReader`) could report EOF before the footer/trailer were consumed, skipping validation entirely.
- **Transient failures not retried** — the decoder now preserves the source error chain with `%w`, and `RetryReader` classifies retryable errors with `errors.Is`/`errors.As`. Previously the decoder wrapped segment-read failures with `%s` (erasing `net.Error`/`io.ErrUnexpectedEOF`) and the retry reader used direct type assertions/equality, so transient failures during structured segment data terminated the download instead of retrying.
- **Missing CRC64 flag accepted** — the decoder (both streaming `SMDecoder` and one-shot `SMDecode`) now rejects a structured message that lacks the negotiated `SMFlagCRC64` bit instead of silently skipping all validation. Only the CRC64 bit is required; other flag bits are ignored for forward compatibility.
- **Encoder could emit a valid message over a failed read** — `SMEncoder.Read` now propagates a non-EOF source error that lands exactly on a segment boundary, instead of ignoring it and emitting a valid, complete message.

## Test plan

- [x] Added regression tests to `internal/shared/structured_message_test.go`: exact-buffer-fill validation (corrupt + valid), encoder non-EOF error propagation, encoder EOF-at-final-boundary acceptance, and missing-CRC64-flag rejection.
- [x] Added `TestRetryReaderWithRetryWrappedNetError` proving a `%w`-wrapped `net.Error` is retried (fails under the old type assertion, passes with `errors.As`).
- [x] `go build ./...`, `go test ./internal/shared/`, and `go test ./blob/ -run RetryReader` all pass.

## Related

- #27261 (azfile — the original fixes, merged)
- #27263 (azdatalake — depends on this via the azblob dependency; will bump azblob after this releases)
