### PR TITLE
[azeventgrid] Strip credential headers on cross-host redirects

### DIFF
--- a/sdk/messaging/eventgrid/azeventgrid/CHANGELOG.md
+++ b/sdk/messaging/eventgrid/azeventgrid/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-* Cross-host HTTP redirects are no longer followed by the publisher client, preventing the publishing credential (`aeg-sas-key`, `aeg-sas-token`, or `Authorization`) and the event payload from being sent to a host the caller did not configure. Same-host redirects continue to be followed.
+* HTTP redirects that leave the configured origin are no longer followed by the publisher client, preventing the publishing credential (`aeg-sas-key`, `aeg-sas-token`, or `Authorization`) and the event payload from being sent to a different host or port, or over an `https`-to-`http` downgrade. Same-origin redirects (and `http`-to-`https` upgrades of the same host) continue to be followed.
 
 ### Other Changes
 * Regenerated code with the latest emitter.

--- a/sdk/messaging/eventgrid/azeventgrid/CHANGELOG.md
+++ b/sdk/messaging/eventgrid/azeventgrid/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-* Credential headers (`aeg-sas-key`, `aeg-sas-token`, `Authorization`) are now stripped when an HTTP redirect crosses to a different host, preventing the publishing credential from being disclosed to a redirect target on another host.
+* Cross-host HTTP redirects are no longer followed by the publisher client, preventing the publishing credential (`aeg-sas-key`, `aeg-sas-token`, or `Authorization`) and the event payload from being sent to a host the caller did not configure. Same-host redirects continue to be followed.
 
 ### Other Changes
 * Regenerated code with the latest emitter.

--- a/sdk/messaging/eventgrid/azeventgrid/CHANGELOG.md
+++ b/sdk/messaging/eventgrid/azeventgrid/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-* HTTP redirects that leave the configured origin are no longer followed by the publisher client, preventing the publishing credential (`aeg-sas-key`, `aeg-sas-token`, or `Authorization`) and the event payload from being sent to a different host or port, or over an `https`-to-`http` downgrade. Same-origin redirects (and `http`-to-`https` upgrades of the same host) continue to be followed.
+* The publisher client no longer follows HTTP redirects. Event Grid topic endpoints do not issue redirects; not following them prevents the publishing credential (`aeg-sas-key`, `aeg-sas-token`, or `Authorization`) and the event payload from being sent to a redirect target.
 
 ### Other Changes
 * Regenerated code with the latest emitter.

--- a/sdk/messaging/eventgrid/azeventgrid/CHANGELOG.md
+++ b/sdk/messaging/eventgrid/azeventgrid/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+* Credential headers (`aeg-sas-key`, `aeg-sas-token`, `Authorization`) are now stripped when an HTTP redirect crosses to a different host, preventing the publishing credential from being disclosed to a redirect target on another host.
 
 ### Other Changes
 * Regenerated code with the latest emitter.

--- a/sdk/messaging/eventgrid/azeventgrid/client_custom.go
+++ b/sdk/messaging/eventgrid/azeventgrid/client_custom.go
@@ -26,6 +26,7 @@ func NewClient(endpoint string, tokenCredential azcore.TokenCredential, options 
 	if options == nil {
 		options = &ClientOptions{}
 	}
+	applyRedirectCredentialProtection(options)
 
 	azc, err := azcore.NewClient(moduleName+".Client", moduleVersion, runtime.PipelineOptions{
 		PerRetry: []policy.Policy{
@@ -50,6 +51,7 @@ func NewClientWithSharedKeyCredential(endpoint string, keyCred *azcore.KeyCreden
 	if options == nil {
 		options = &ClientOptions{}
 	}
+	applyRedirectCredentialProtection(options)
 
 	azc, err := azcore.NewClient(moduleName+".Client", moduleVersion, runtime.PipelineOptions{
 		PerRetry: []policy.Policy{
@@ -74,6 +76,7 @@ func NewClientWithSAS(endpoint string, sasCred *azcore.SASCredential, options *C
 	if options == nil {
 		options = &ClientOptions{}
 	}
+	applyRedirectCredentialProtection(options)
 
 	azc, err := azcore.NewClient(moduleName+".Client", moduleVersion, runtime.PipelineOptions{
 		PerRetry: []policy.Policy{

--- a/sdk/messaging/eventgrid/azeventgrid/client_custom.go
+++ b/sdk/messaging/eventgrid/azeventgrid/client_custom.go
@@ -23,10 +23,7 @@ var tokenScopes = []string{"https://eventgrid.azure.net/.default"}
 
 // NewClient creates a [Client] that authenticates using a TokenCredential.
 func NewClient(endpoint string, tokenCredential azcore.TokenCredential, options *ClientOptions) (*Client, error) {
-	if options == nil {
-		options = &ClientOptions{}
-	}
-	applyRedirectCredentialProtection(options)
+	options = withRedirectProtection(options)
 
 	azc, err := azcore.NewClient(moduleName+".Client", moduleVersion, runtime.PipelineOptions{
 		PerRetry: []policy.Policy{
@@ -48,10 +45,7 @@ func NewClient(endpoint string, tokenCredential azcore.TokenCredential, options 
 func NewClientWithSharedKeyCredential(endpoint string, keyCred *azcore.KeyCredential, options *ClientOptions) (*Client, error) {
 	const sasKeyHeader = "aeg-sas-key"
 
-	if options == nil {
-		options = &ClientOptions{}
-	}
-	applyRedirectCredentialProtection(options)
+	options = withRedirectProtection(options)
 
 	azc, err := azcore.NewClient(moduleName+".Client", moduleVersion, runtime.PipelineOptions{
 		PerRetry: []policy.Policy{
@@ -73,10 +67,7 @@ func NewClientWithSharedKeyCredential(endpoint string, keyCred *azcore.KeyCreden
 func NewClientWithSAS(endpoint string, sasCred *azcore.SASCredential, options *ClientOptions) (*Client, error) {
 	const sasTokenHeader = "aeg-sas-token"
 
-	if options == nil {
-		options = &ClientOptions{}
-	}
-	applyRedirectCredentialProtection(options)
+	options = withRedirectProtection(options)
 
 	azc, err := azcore.NewClient(moduleName+".Client", moduleVersion, runtime.PipelineOptions{
 		PerRetry: []policy.Policy{

--- a/sdk/messaging/eventgrid/azeventgrid/client_redirect.go
+++ b/sdk/messaging/eventgrid/azeventgrid/client_redirect.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -17,33 +18,35 @@ import (
 )
 
 // maxDefaultRedirects mirrors net/http's default limit and is only applied to
-// the same-host redirects that this policy permits when the caller has not
+// the same-origin redirects that this policy permits when the caller has not
 // supplied their own CheckRedirect.
 const maxDefaultRedirects = 10
 
-// errCrossHostRedirect is returned to stop an HTTP redirect that would cross to
-// a different host.
-var errCrossHostRedirect = errors.New("azeventgrid: refusing to follow a redirect to a different host to avoid leaking the publishing credential")
+// errUnsafeRedirect is returned to stop an HTTP redirect that would leave the
+// configured origin (a different host or port, or an https->http downgrade).
+var errUnsafeRedirect = errors.New("azeventgrid: refusing to follow a redirect to a different origin (host, port, or an https-to-http downgrade) to avoid leaking the publishing credential")
 
-// blockCrossHostRedirect returns an http.Client CheckRedirect function that
-// refuses to follow a redirect whenever it would cross to a different host,
-// then (for permitted same-host redirects) delegates to prior (the caller's
-// existing CheckRedirect, if any).
+// blockUnsafeRedirect returns an http.Client CheckRedirect function that refuses
+// to follow a redirect whenever it would leave the configured origin, then (for
+// permitted same-origin redirects) delegates to prior (the caller's existing
+// CheckRedirect, if any).
 //
 // The Event Grid basic publisher sends its credential in one of the
 // Authorization, aeg-sas-key or aeg-sas-token headers. azcore relies on
 // net/http to follow redirects; net/http strips only a small, fixed set of
 // headers (Authorization, WWW-Authenticate, Cookie, Cookie2) on a cross-host
-// redirect and always forwards the custom aeg-sas-* headers. Rather than
-// re-sending the request (and its body) to an unconfigured host at all, this
-// blocks the cross-host redirect outright, so neither the credential nor the
-// event payload is ever sent to a host the caller did not configure. Same-host
-// redirects (for example HTTPS enforcement or path normalization performed by a
-// gateway or custom domain in front of the topic) are still followed normally.
-func blockCrossHostRedirect(prior func(req *http.Request, via []*http.Request) error) func(req *http.Request, via []*http.Request) error {
+// redirect and always forwards the custom aeg-sas-* headers. Because the
+// credential (and the request body) have already been attached by the time
+// net/http follows a redirect, this refuses to follow any redirect that changes
+// the origin, so neither the credential nor the event payload is ever sent to a
+// host/port the caller did not configure, and an https->http downgrade can never
+// leak the credential in cleartext. Same-origin redirects (for example path
+// normalization, or an http->https upgrade performed by a gateway or custom
+// domain in front of the topic) are still followed normally.
+func blockUnsafeRedirect(prior func(req *http.Request, via []*http.Request) error) func(req *http.Request, via []*http.Request) error {
 	return func(req *http.Request, via []*http.Request) error {
-		if len(via) > 0 && !strings.EqualFold(req.URL.Hostname(), via[0].URL.Hostname()) {
-			return errCrossHostRedirect
+		if len(via) > 0 && !isSafeRedirect(via[0].URL, req.URL) {
+			return errUnsafeRedirect
 		}
 
 		if prior != nil {
@@ -55,6 +58,45 @@ func blockCrossHostRedirect(prior func(req *http.Request, via []*http.Request) e
 		}
 		return nil
 	}
+}
+
+// isSafeRedirect reports whether a redirect from original to target stays within
+// the caller-configured origin and therefore may be followed with the
+// credential still attached. A redirect is considered safe only when it targets
+// the same host and port, or performs a standard http->https upgrade of the same
+// host. Any host change, port change, or https->http downgrade is unsafe.
+func isSafeRedirect(original, target *url.URL) bool {
+	if !strings.EqualFold(target.Hostname(), original.Hostname()) {
+		return false // different host
+	}
+
+	origScheme := strings.ToLower(original.Scheme)
+	targetScheme := strings.ToLower(target.Scheme)
+
+	if origScheme == "https" && targetScheme == "http" {
+		return false // scheme downgrade would leak the credential in cleartext
+	}
+	if origScheme == "http" && targetScheme == "https" {
+		return true // standard upgrade to TLS on the same host
+	}
+
+	// Same scheme: require an identical effective port (full-authority match).
+	return effectivePort(original) == effectivePort(target)
+}
+
+// effectivePort returns the port for u, defaulting to the well-known port for
+// the URL's scheme when no explicit port is present.
+func effectivePort(u *url.URL) string {
+	if p := u.Port(); p != "" {
+		return p
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	}
+	return ""
 }
 
 // applyRedirectCredentialProtection ensures the HTTP client used by the pipeline
@@ -71,11 +113,11 @@ func applyRedirectCredentialProtection(options *ClientOptions) {
 	case nil:
 		options.Transport = &http.Client{
 			Transport:     newDefaultTransport(),
-			CheckRedirect: blockCrossHostRedirect(nil),
+			CheckRedirect: blockUnsafeRedirect(nil),
 		}
 	case *http.Client:
 		clone := *t
-		clone.CheckRedirect = blockCrossHostRedirect(t.CheckRedirect)
+		clone.CheckRedirect = blockUnsafeRedirect(t.CheckRedirect)
 		options.Transport = &clone
 	}
 }

--- a/sdk/messaging/eventgrid/azeventgrid/client_redirect.go
+++ b/sdk/messaging/eventgrid/azeventgrid/client_redirect.go
@@ -11,38 +11,34 @@ import (
 	"strings"
 )
 
-// credentialRedirectHeaders are the authentication headers that must never be
-// forwarded to a different host when an HTTP redirect is followed.
-//
-// The Event Grid basic publisher sends its credential in one of these headers.
-// azcore relies on net/http to follow redirects, and net/http only strips a
-// small, fixed set of headers (Authorization, WWW-Authenticate, Cookie, Cookie2)
-// when a redirect crosses to a different host. The custom aeg-sas-key /
-// aeg-sas-token headers are NOT in that set, so without this cleanup they would
-// be leaked in full to a redirect target on a different host.
-var credentialRedirectHeaders = []string{
-	"Authorization",
-	"aeg-sas-key",
-	"aeg-sas-token",
-}
-
-// maxDefaultRedirects mirrors net/http's default limit and is only used when the
-// caller has not supplied their own CheckRedirect.
+// maxDefaultRedirects mirrors net/http's default limit and is only applied to
+// the same-host redirects that this policy permits when the caller has not
+// supplied their own CheckRedirect.
 const maxDefaultRedirects = 10
 
-// stripCredentialsOnCrossHostRedirect returns an http.Client CheckRedirect
-// function that removes credential headers whenever a redirect crosses to a
-// different host, then delegates to prior (the caller's existing CheckRedirect,
-// if any).
-func stripCredentialsOnCrossHostRedirect(prior func(req *http.Request, via []*http.Request) error) func(req *http.Request, via []*http.Request) error {
+// errCrossHostRedirect is returned to stop an HTTP redirect that would cross to
+// a different host.
+var errCrossHostRedirect = errors.New("azeventgrid: refusing to follow a redirect to a different host to avoid leaking the publishing credential")
+
+// blockCrossHostRedirect returns an http.Client CheckRedirect function that
+// refuses to follow a redirect whenever it would cross to a different host,
+// then (for permitted same-host redirects) delegates to prior (the caller's
+// existing CheckRedirect, if any).
+//
+// The Event Grid basic publisher sends its credential in one of the
+// Authorization, aeg-sas-key or aeg-sas-token headers. azcore relies on
+// net/http to follow redirects; net/http strips only a small, fixed set of
+// headers (Authorization, WWW-Authenticate, Cookie, Cookie2) on a cross-host
+// redirect and always forwards the custom aeg-sas-* headers. Rather than
+// re-sending the request (and its body) to an unconfigured host at all, this
+// blocks the cross-host redirect outright, so neither the credential nor the
+// event payload is ever sent to a host the caller did not configure. Same-host
+// redirects (for example HTTPS enforcement or path normalization performed by a
+// gateway or custom domain in front of the topic) are still followed normally.
+func blockCrossHostRedirect(prior func(req *http.Request, via []*http.Request) error) func(req *http.Request, via []*http.Request) error {
 	return func(req *http.Request, via []*http.Request) error {
-		if len(via) > 0 {
-			originalHost := via[0].URL.Hostname()
-			if !strings.EqualFold(req.URL.Hostname(), originalHost) {
-				for _, h := range credentialRedirectHeaders {
-					req.Header.Del(h)
-				}
-			}
+		if len(via) > 0 && !strings.EqualFold(req.URL.Hostname(), via[0].URL.Hostname()) {
+			return errCrossHostRedirect
 		}
 
 		if prior != nil {
@@ -57,9 +53,8 @@ func stripCredentialsOnCrossHostRedirect(prior func(req *http.Request, via []*ht
 }
 
 // applyRedirectCredentialProtection ensures the HTTP client used by the pipeline
-// strips Event Grid credential headers on cross-host redirects, closing a
-// credential-leak vector. It preserves a caller-supplied transport where
-// possible:
+// refuses cross-host redirects, closing a credential-leak vector. It preserves a
+// caller-supplied transport where possible:
 //
 //   - no transport supplied: a default client is installed with the protection.
 //   - an *http.Client supplied: it is cloned and the protection is chained onto
@@ -75,11 +70,11 @@ func applyRedirectCredentialProtection(options *ClientOptions) {
 		}
 		options.Transport = &http.Client{
 			Transport:     transport,
-			CheckRedirect: stripCredentialsOnCrossHostRedirect(nil),
+			CheckRedirect: blockCrossHostRedirect(nil),
 		}
 	case *http.Client:
 		clone := *t
-		clone.CheckRedirect = stripCredentialsOnCrossHostRedirect(t.CheckRedirect)
+		clone.CheckRedirect = blockCrossHostRedirect(t.CheckRedirect)
 		options.Transport = &clone
 	}
 }

--- a/sdk/messaging/eventgrid/azeventgrid/client_redirect.go
+++ b/sdk/messaging/eventgrid/azeventgrid/client_redirect.go
@@ -1,0 +1,85 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+package azeventgrid
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+)
+
+// credentialRedirectHeaders are the authentication headers that must never be
+// forwarded to a different host when an HTTP redirect is followed.
+//
+// The Event Grid basic publisher sends its credential in one of these headers.
+// azcore relies on net/http to follow redirects, and net/http only strips a
+// small, fixed set of headers (Authorization, WWW-Authenticate, Cookie, Cookie2)
+// when a redirect crosses to a different host. The custom aeg-sas-key /
+// aeg-sas-token headers are NOT in that set, so without this cleanup they would
+// be leaked in full to a redirect target on a different host.
+var credentialRedirectHeaders = []string{
+	"Authorization",
+	"aeg-sas-key",
+	"aeg-sas-token",
+}
+
+// maxDefaultRedirects mirrors net/http's default limit and is only used when the
+// caller has not supplied their own CheckRedirect.
+const maxDefaultRedirects = 10
+
+// stripCredentialsOnCrossHostRedirect returns an http.Client CheckRedirect
+// function that removes credential headers whenever a redirect crosses to a
+// different host, then delegates to prior (the caller's existing CheckRedirect,
+// if any).
+func stripCredentialsOnCrossHostRedirect(prior func(req *http.Request, via []*http.Request) error) func(req *http.Request, via []*http.Request) error {
+	return func(req *http.Request, via []*http.Request) error {
+		if len(via) > 0 {
+			originalHost := via[0].URL.Hostname()
+			if !strings.EqualFold(req.URL.Hostname(), originalHost) {
+				for _, h := range credentialRedirectHeaders {
+					req.Header.Del(h)
+				}
+			}
+		}
+
+		if prior != nil {
+			return prior(req, via)
+		}
+
+		if len(via) >= maxDefaultRedirects {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+}
+
+// applyRedirectCredentialProtection ensures the HTTP client used by the pipeline
+// strips Event Grid credential headers on cross-host redirects, closing a
+// credential-leak vector. It preserves a caller-supplied transport where
+// possible:
+//
+//   - no transport supplied: a default client is installed with the protection.
+//   - an *http.Client supplied: it is cloned and the protection is chained onto
+//     any CheckRedirect the caller already set.
+//   - any other custom transport: left untouched (such a transport is
+//     responsible for its own redirect handling).
+func applyRedirectCredentialProtection(options *ClientOptions) {
+	switch t := options.Transport.(type) {
+	case nil:
+		transport := http.DefaultTransport
+		if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+			transport = dt.Clone()
+		}
+		options.Transport = &http.Client{
+			Transport:     transport,
+			CheckRedirect: stripCredentialsOnCrossHostRedirect(nil),
+		}
+	case *http.Client:
+		clone := *t
+		clone.CheckRedirect = stripCredentialsOnCrossHostRedirect(t.CheckRedirect)
+		options.Transport = &clone
+	}
+}

--- a/sdk/messaging/eventgrid/azeventgrid/client_redirect.go
+++ b/sdk/messaging/eventgrid/azeventgrid/client_redirect.go
@@ -35,27 +35,27 @@ func noFollowRedirect(_ *http.Request, _ []*http.Request) error {
 	return http.ErrUseLastResponse
 }
 
-// applyRedirectCredentialProtection ensures the HTTP client used by the pipeline
-// does not follow redirects, closing a credential-leak vector. It preserves a
-// caller-supplied transport where possible:
-//
-//   - no transport supplied: a default client (mirroring azcore's tuned
-//     transport) is installed with redirect following disabled.
-//   - an *http.Client supplied: it is cloned with redirect following disabled.
-//   - any other custom transport: left untouched (such a transport is
-//     responsible for its own redirect handling).
-func applyRedirectCredentialProtection(options *ClientOptions) {
-	switch t := options.Transport.(type) {
+// withRedirectProtection returns a *ClientOptions that disables redirect
+// following, without mutating the caller-supplied options. azcore.ClientOptions
+// instances may be shared across client constructors, so we apply the redirect
+// protection to a shallow copy and leave the caller's options untouched.
+func withRedirectProtection(options *ClientOptions) *ClientOptions {
+	local := ClientOptions{}
+	if options != nil {
+		local = *options
+	}
+	switch t := local.Transport.(type) {
 	case nil:
-		options.Transport = &http.Client{
+		local.Transport = &http.Client{
 			Transport:     newDefaultTransport(),
 			CheckRedirect: noFollowRedirect,
 		}
 	case *http.Client:
 		clone := *t
 		clone.CheckRedirect = noFollowRedirect
-		options.Transport = &clone
+		local.Transport = &clone
 	}
+	return &local
 }
 
 // newDefaultTransport returns an *http.Transport configured identically to
@@ -70,10 +70,10 @@ func applyRedirectCredentialProtection(options *ClientOptions) {
 func newDefaultTransport() *http.Transport {
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
+		DialContext: defaultTransportDialContext(&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
-		}).DialContext,
+		}),
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
 		MaxIdleConnsPerHost:   10,

--- a/sdk/messaging/eventgrid/azeventgrid/client_redirect.go
+++ b/sdk/messaging/eventgrid/azeventgrid/client_redirect.go
@@ -7,105 +7,41 @@ package azeventgrid
 
 import (
 	"crypto/tls"
-	"errors"
 	"net"
 	"net/http"
-	"net/url"
-	"strings"
 	"time"
 
 	"golang.org/x/net/http2"
 )
 
-// maxDefaultRedirects mirrors net/http's default limit and is only applied to
-// the same-origin redirects that this policy permits when the caller has not
-// supplied their own CheckRedirect.
-const maxDefaultRedirects = 10
-
-// errUnsafeRedirect is returned to stop an HTTP redirect that would leave the
-// configured origin (a different host or port, or an https->http downgrade).
-var errUnsafeRedirect = errors.New("azeventgrid: refusing to follow a redirect to a different origin (host, port, or an https-to-http downgrade) to avoid leaking the publishing credential")
-
-// blockUnsafeRedirect returns an http.Client CheckRedirect function that refuses
-// to follow a redirect whenever it would leave the configured origin, then (for
-// permitted same-origin redirects) delegates to prior (the caller's existing
-// CheckRedirect, if any).
+// noFollowRedirect is an http.Client CheckRedirect that refuses to follow any
+// HTTP redirect.
 //
 // The Event Grid basic publisher sends its credential in one of the
-// Authorization, aeg-sas-key or aeg-sas-token headers. azcore relies on
-// net/http to follow redirects; net/http strips only a small, fixed set of
-// headers (Authorization, WWW-Authenticate, Cookie, Cookie2) on a cross-host
-// redirect and always forwards the custom aeg-sas-* headers. Because the
-// credential (and the request body) have already been attached by the time
-// net/http follows a redirect, this refuses to follow any redirect that changes
-// the origin, so neither the credential nor the event payload is ever sent to a
-// host/port the caller did not configure, and an https->http downgrade can never
-// leak the credential in cleartext. Same-origin redirects (for example path
-// normalization, or an http->https upgrade performed by a gateway or custom
-// domain in front of the topic) are still followed normally.
-func blockUnsafeRedirect(prior func(req *http.Request, via []*http.Request) error) func(req *http.Request, via []*http.Request) error {
-	return func(req *http.Request, via []*http.Request) error {
-		if len(via) > 0 && !isSafeRedirect(via[0].URL, req.URL) {
-			return errUnsafeRedirect
-		}
-
-		if prior != nil {
-			return prior(req, via)
-		}
-
-		if len(via) >= maxDefaultRedirects {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
-	}
-}
-
-// isSafeRedirect reports whether a redirect from original to target stays within
-// the caller-configured origin and therefore may be followed with the
-// credential still attached. A redirect is considered safe only when it targets
-// the same host and port, or performs a standard http->https upgrade of the same
-// host. Any host change, port change, or https->http downgrade is unsafe.
-func isSafeRedirect(original, target *url.URL) bool {
-	if !strings.EqualFold(target.Hostname(), original.Hostname()) {
-		return false // different host
-	}
-
-	origScheme := strings.ToLower(original.Scheme)
-	targetScheme := strings.ToLower(target.Scheme)
-
-	if origScheme == "https" && targetScheme == "http" {
-		return false // scheme downgrade would leak the credential in cleartext
-	}
-	if origScheme == "http" && targetScheme == "https" {
-		return true // standard upgrade to TLS on the same host
-	}
-
-	// Same scheme: require an identical effective port (full-authority match).
-	return effectivePort(original) == effectivePort(target)
-}
-
-// effectivePort returns the port for u, defaulting to the well-known port for
-// the URL's scheme when no explicit port is present.
-func effectivePort(u *url.URL) string {
-	if p := u.Port(); p != "" {
-		return p
-	}
-	switch strings.ToLower(u.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	}
-	return ""
+// Authorization, aeg-sas-key or aeg-sas-token headers, and the credential (and
+// the event payload) are already attached by the time net/http would follow a
+// redirect. net/http strips only a small, fixed set of headers on a cross-host
+// redirect and always forwards the custom aeg-sas-* headers, so following a
+// redirect can leak the credential and the payload to the redirect target.
+// Event Grid topic endpoints do not legitimately issue redirects, so the client
+// simply does not follow them. This matches the default posture of
+// azcore-based clients in other languages (for example .NET's RedirectPolicy
+// does not auto-redirect).
+//
+// Returning http.ErrUseLastResponse leaves the 3xx response in place without
+// contacting the redirect target; it surfaces as an *azcore.ResponseError from
+// the pipeline.
+func noFollowRedirect(_ *http.Request, _ []*http.Request) error {
+	return http.ErrUseLastResponse
 }
 
 // applyRedirectCredentialProtection ensures the HTTP client used by the pipeline
-// refuses cross-host redirects, closing a credential-leak vector. It preserves a
+// does not follow redirects, closing a credential-leak vector. It preserves a
 // caller-supplied transport where possible:
 //
-//   - no transport supplied: a default client is installed with the protection.
-//   - an *http.Client supplied: it is cloned and the protection is chained onto
-//     any CheckRedirect the caller already set.
+//   - no transport supplied: a default client (mirroring azcore's tuned
+//     transport) is installed with redirect following disabled.
+//   - an *http.Client supplied: it is cloned with redirect following disabled.
 //   - any other custom transport: left untouched (such a transport is
 //     responsible for its own redirect handling).
 func applyRedirectCredentialProtection(options *ClientOptions) {
@@ -113,11 +49,11 @@ func applyRedirectCredentialProtection(options *ClientOptions) {
 	case nil:
 		options.Transport = &http.Client{
 			Transport:     newDefaultTransport(),
-			CheckRedirect: blockUnsafeRedirect(nil),
+			CheckRedirect: noFollowRedirect,
 		}
 	case *http.Client:
 		clone := *t
-		clone.CheckRedirect = blockUnsafeRedirect(t.CheckRedirect)
+		clone.CheckRedirect = noFollowRedirect
 		options.Transport = &clone
 	}
 }
@@ -126,9 +62,9 @@ func applyRedirectCredentialProtection(options *ClientOptions) {
 // azcore's default HTTP transport (see
 // github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/transport_default_http_client.go).
 //
-// When no transport is supplied we must install our own *http.Client to attach
-// the redirect protection. This transport is duplicated (rather than falling
-// back to the mutable process-global http.DefaultTransport) so that callers keep
+// When no transport is supplied we must install our own *http.Client to disable
+// redirect following. This transport is duplicated (rather than falling back to
+// the mutable process-global http.DefaultTransport) so that callers keep
 // azcore's TLS floor, connection-pool sizing and HTTP/2 idle health checks. Keep
 // this in sync with azcore's default if that ever changes.
 func newDefaultTransport() *http.Transport {

--- a/sdk/messaging/eventgrid/azeventgrid/client_redirect.go
+++ b/sdk/messaging/eventgrid/azeventgrid/client_redirect.go
@@ -39,6 +39,16 @@ func noFollowRedirect(_ *http.Request, _ []*http.Request) error {
 // following, without mutating the caller-supplied options. azcore.ClientOptions
 // instances may be shared across client constructors, so we apply the redirect
 // protection to a shallow copy and leave the caller's options untouched.
+//
+// Redirect following in Go happens inside the http.Client (the transport),
+// below the azcore pipeline, so it can only be controlled where we recognize
+// the transport: the default (nil) transport and a caller-supplied *http.Client
+// both get redirect following disabled. A caller that supplies some other
+// policy.Transporter implementation owns that transport's redirect behavior and
+// is responsible for ensuring it does not forward the credential across a
+// redirect (we cannot control an opaque Do). See the redirect-policy feature
+// request tracked for azcore, which would let this be handled uniformly in the
+// pipeline regardless of transport.
 func withRedirectProtection(options *ClientOptions) *ClientOptions {
 	local := ClientOptions{}
 	if options != nil {
@@ -54,6 +64,11 @@ func withRedirectProtection(options *ClientOptions) *ClientOptions {
 		clone := *t
 		clone.CheckRedirect = noFollowRedirect
 		local.Transport = &clone
+	default:
+		// A custom, opaque policy.Transporter: its redirect handling cannot be
+		// controlled from here, so it is left as-is and remains the caller's
+		// responsibility.
+		_ = t
 	}
 	return &local
 }

--- a/sdk/messaging/eventgrid/azeventgrid/client_redirect.go
+++ b/sdk/messaging/eventgrid/azeventgrid/client_redirect.go
@@ -6,9 +6,14 @@
 package azeventgrid
 
 import (
+	"crypto/tls"
 	"errors"
+	"net"
 	"net/http"
 	"strings"
+	"time"
+
+	"golang.org/x/net/http2"
 )
 
 // maxDefaultRedirects mirrors net/http's default limit and is only applied to
@@ -64,12 +69,8 @@ func blockCrossHostRedirect(prior func(req *http.Request, via []*http.Request) e
 func applyRedirectCredentialProtection(options *ClientOptions) {
 	switch t := options.Transport.(type) {
 	case nil:
-		transport := http.DefaultTransport
-		if dt, ok := http.DefaultTransport.(*http.Transport); ok {
-			transport = dt.Clone()
-		}
 		options.Transport = &http.Client{
-			Transport:     transport,
+			Transport:     newDefaultTransport(),
 			CheckRedirect: blockCrossHostRedirect(nil),
 		}
 	case *http.Client:
@@ -77,4 +78,40 @@ func applyRedirectCredentialProtection(options *ClientOptions) {
 		clone.CheckRedirect = blockCrossHostRedirect(t.CheckRedirect)
 		options.Transport = &clone
 	}
+}
+
+// newDefaultTransport returns an *http.Transport configured identically to
+// azcore's default HTTP transport (see
+// github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/transport_default_http_client.go).
+//
+// When no transport is supplied we must install our own *http.Client to attach
+// the redirect protection. This transport is duplicated (rather than falling
+// back to the mutable process-global http.DefaultTransport) so that callers keep
+// azcore's TLS floor, connection-pool sizing and HTTP/2 idle health checks. Keep
+// this in sync with azcore's default if that ever changes.
+func newDefaultTransport() *http.Transport {
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   10,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig: &tls.Config{
+			MinVersion:    tls.VersionTLS12,
+			Renegotiation: tls.RenegotiateFreelyAsClient,
+		},
+	}
+	if http2Transport, err := http2.ConfigureTransports(transport); err == nil {
+		// if the connection has been idle for 10 seconds, send a ping frame for a
+		// health check; close the connection if there's no response within 5s.
+		http2Transport.ReadIdleTimeout = 10 * time.Second
+		http2Transport.PingTimeout = 5 * time.Second
+	}
+	return transport
 }

--- a/sdk/messaging/eventgrid/azeventgrid/client_redirect_test.go
+++ b/sdk/messaging/eventgrid/azeventgrid/client_redirect_test.go
@@ -27,61 +27,84 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStripCredentialsOnCrossHostRedirect(t *testing.T) {
+func TestBlockCrossHostRedirect(t *testing.T) {
 	newReq := func(rawURL string) *http.Request {
 		u, _ := url.Parse(rawURL)
 		r := &http.Request{URL: u, Header: http.Header{}}
-		r.Header.Set("Authorization", "Bearer secret")
+		r.Header.Set("Authorization", "auth-secret")
 		r.Header.Set("aeg-sas-key", "secret-key")
 		r.Header.Set("aeg-sas-token", "secret-token")
 		r.Header.Set("Content-Type", "application/json")
 		return r
 	}
 
-	t.Run("cross-host strips credential headers", func(t *testing.T) {
+	t.Run("cross-host redirect is blocked", func(t *testing.T) {
 		req := newReq("https://attacker.example/collect")
 		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
-		require.NoError(t, stripCredentialsOnCrossHostRedirect(nil)(req, via))
-		require.Empty(t, req.Header.Get("Authorization"))
-		require.Empty(t, req.Header.Get("aeg-sas-key"))
-		require.Empty(t, req.Header.Get("aeg-sas-token"))
-		// non-credential headers are preserved
-		require.Equal(t, "application/json", req.Header.Get("Content-Type"))
+		err := blockCrossHostRedirect(nil)(req, via)
+		require.ErrorIs(t, err, errCrossHostRedirect)
 	})
 
-	t.Run("same-host preserves credential headers", func(t *testing.T) {
+	t.Run("cross-host to a sibling subdomain is blocked", func(t *testing.T) {
+		req := newReq("https://attacker.eventgrid.azure.net/collect")
+		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
+		err := blockCrossHostRedirect(nil)(req, via)
+		require.ErrorIs(t, err, errCrossHostRedirect)
+	})
+
+	t.Run("same-host redirect is allowed and keeps credential headers", func(t *testing.T) {
 		req := newReq("https://topic.eventgrid.azure.net/api/events?redirected=1")
 		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
-		require.NoError(t, stripCredentialsOnCrossHostRedirect(nil)(req, via))
+		require.NoError(t, blockCrossHostRedirect(nil)(req, via))
+		// credential headers are untouched for a permitted same-host redirect
 		require.Equal(t, "secret-key", req.Header.Get("aeg-sas-key"))
 		require.Equal(t, "secret-token", req.Header.Get("aeg-sas-token"))
+		require.Equal(t, "auth-secret", req.Header.Get("Authorization"))
 	})
 
-	t.Run("chains prior CheckRedirect", func(t *testing.T) {
-		sentinel := errors.New("prior called")
-		req := newReq("https://attacker.example/collect")
+	t.Run("same-host match is case-insensitive", func(t *testing.T) {
+		req := newReq("https://TOPIC.eventgrid.azure.net/api/events")
 		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
-		err := stripCredentialsOnCrossHostRedirect(func(*http.Request, []*http.Request) error {
+		require.NoError(t, blockCrossHostRedirect(nil)(req, via))
+	})
+
+	t.Run("prior CheckRedirect is chained for same-host redirects", func(t *testing.T) {
+		sentinel := errors.New("prior called")
+		req := newReq("https://topic.eventgrid.azure.net/api/events?redirected=1")
+		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
+		err := blockCrossHostRedirect(func(*http.Request, []*http.Request) error {
 			return sentinel
 		})(req, via)
 		require.ErrorIs(t, err, sentinel)
-		require.Empty(t, req.Header.Get("aeg-sas-key")) // still stripped before delegating
 	})
 
-	t.Run("default redirect limit enforced", func(t *testing.T) {
+	t.Run("cross-host block takes precedence over prior CheckRedirect", func(t *testing.T) {
+		req := newReq("https://attacker.example/collect")
+		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
+		priorCalled := false
+		err := blockCrossHostRedirect(func(*http.Request, []*http.Request) error {
+			priorCalled = true
+			return nil
+		})(req, via)
+		require.ErrorIs(t, err, errCrossHostRedirect)
+		require.False(t, priorCalled, "prior CheckRedirect must not run for a blocked cross-host redirect")
+	})
+
+	t.Run("default redirect limit enforced for same-host redirects", func(t *testing.T) {
 		req := newReq("https://topic.eventgrid.azure.net/a")
-		via := make([]*http.Request, 10)
+		via := make([]*http.Request, maxDefaultRedirects)
 		for i := range via {
 			via[i] = newReq("https://topic.eventgrid.azure.net/api/events")
 		}
-		require.Error(t, stripCredentialsOnCrossHostRedirect(nil)(req, via))
+		require.Error(t, blockCrossHostRedirect(nil)(req, via))
 	})
 }
 
-// TestPublisher_DoesNotLeakCredentialsOnCrossHostRedirect exercises the full
-// client: a "trusted" topic host answers the publish with a 307 redirect to a
-// different "attacker" host and we assert the credential never reaches it.
-func TestPublisher_DoesNotLeakCredentialsOnCrossHostRedirect(t *testing.T) {
+// TestPublisher_BlocksCrossHostRedirect exercises the full client: a "trusted"
+// topic host answers the publish with a 307 redirect to a different "attacker"
+// host, and we assert the attacker host is never contacted at all (so neither
+// the credential nor the event payload leaks).
+func TestPublisher_BlocksCrossHostRedirect(t *testing.T) {
 	const trustedHost = "trusted-topic.eventgrid.example"
 	const attackerHost = "attacker-collector.example"
 
@@ -115,17 +138,7 @@ func TestPublisher_DoesNotLeakCredentialsOnCrossHostRedirect(t *testing.T) {
 	attackerURL = fmt.Sprintf("https://%s:%s/collect", attackerHost, portOf(attacker))
 	endpoint := fmt.Sprintf("https://%s:%s", trustedHost, portOf(trusted))
 
-	// Transport maps the fake hostnames to loopback and trusts the test cert.
-	// It has no CheckRedirect, mimicking a plain client; the fix must add one.
-	transport := &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				_, port, _ := net.SplitHostPort(addr)
-				return (&net.Dialer{}).DialContext(ctx, network, "127.0.0.1:"+port)
-			},
-			TLSClientConfig: &tls.Config{RootCAs: pool},
-		},
-	}
+	transport := crossHostTestTransport(pool)
 	opts := &ClientOptions{ClientOptions: azcore.ClientOptions{Transport: transport}}
 
 	evt, err := messaging.NewCloudEvent("src", "Test.Event", map[string]string{"hello": "world"}, nil)
@@ -135,13 +148,12 @@ func TestPublisher_DoesNotLeakCredentialsOnCrossHostRedirect(t *testing.T) {
 	cases := []struct {
 		name   string
 		header string
-		secret string
 		client func() (*Client, error)
 	}{
-		{"key", "aeg-sas-key", "supersecret-key", func() (*Client, error) {
+		{"key", "aeg-sas-key", func() (*Client, error) {
 			return NewClientWithSharedKeyCredential(endpoint, azcore.NewKeyCredential("supersecret-key"), opts)
 		}},
-		{"sas", "aeg-sas-token", "supersecret-sas", func() (*Client, error) {
+		{"sas", "aeg-sas-token", func() (*Client, error) {
 			return NewClientWithSAS(endpoint, azcore.NewSASCredential("supersecret-sas"), opts)
 		}},
 	}
@@ -153,9 +165,12 @@ func TestPublisher_DoesNotLeakCredentialsOnCrossHostRedirect(t *testing.T) {
 			}
 			client, err := tc.client()
 			require.NoError(t, err)
-			_, _ = client.PublishCloudEvents(context.Background(), events, nil)
 
-			// credential was sent to the trusted host...
+			_, err = client.PublishCloudEvents(context.Background(), events, nil)
+			// The publish must fail rather than follow the cross-host redirect.
+			require.Error(t, err)
+
+			// The credential was sent to the trusted (configured) host on the first request...
 			sentToTrusted := false
 			for _, h := range captured["trusted"] {
 				if h.Get(tc.header) != "" {
@@ -164,14 +179,69 @@ func TestPublisher_DoesNotLeakCredentialsOnCrossHostRedirect(t *testing.T) {
 			}
 			require.True(t, sentToTrusted, "expected credential to be sent to the trusted host")
 
-			// ...the redirect was followed to the attacker host...
-			require.NotEmpty(t, captured["attacker"], "expected the redirect to reach the attacker host")
-
-			// ...but the credential must NOT have been forwarded.
-			for _, h := range captured["attacker"] {
-				require.Empty(t, h.Get(tc.header), "credential header %q leaked to attacker host", tc.header)
-			}
+			// ...but the attacker host must NEVER be contacted at all.
+			require.Empty(t, captured["attacker"], "attacker host must not be contacted on a cross-host redirect")
 		})
+	}
+}
+
+// TestPublisher_AllowsSameHostRedirect verifies that a same-host redirect is
+// still followed (with the credential) and the publish succeeds.
+func TestPublisher_AllowsSameHostRedirect(t *testing.T) {
+	const host = "trusted-topic.eventgrid.example"
+
+	cert := selfSignedCert(t, host)
+	pool := x509.NewCertPool()
+	pool.AddCert(cert.Leaf)
+
+	var sawCredentialAfterRedirect bool
+	var redirected bool
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("redirected") == "" {
+			// Same-host redirect (e.g. path normalization / query addition).
+			http.Redirect(w, r, r.URL.Path+"?redirected=1", http.StatusTemporaryRedirect)
+			return
+		}
+		redirected = true
+		if r.Header.Get("aeg-sas-key") != "" {
+			sawCredentialAfterRedirect = true
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
+	srv.StartTLS()
+	defer srv.Close()
+
+	u, _ := url.Parse(srv.URL)
+	endpoint := fmt.Sprintf("https://%s:%s", host, u.Port())
+
+	opts := &ClientOptions{ClientOptions: azcore.ClientOptions{Transport: crossHostTestTransport(pool)}}
+	client, err := NewClientWithSharedKeyCredential(endpoint, azcore.NewKeyCredential("supersecret-key"), opts)
+	require.NoError(t, err)
+
+	evt, err := messaging.NewCloudEvent("src", "Test.Event", map[string]string{"hello": "world"}, nil)
+	require.NoError(t, err)
+
+	_, err = client.PublishCloudEvents(context.Background(), []messaging.CloudEvent{evt}, nil)
+	require.NoError(t, err)
+	require.True(t, redirected, "expected the same-host redirect to be followed")
+	require.True(t, sawCredentialAfterRedirect, "expected the credential to be retained on a same-host redirect")
+}
+
+// crossHostTestTransport returns an *http.Client whose transport resolves the
+// test hostnames to loopback and trusts the test CA. It intentionally sets no
+// CheckRedirect, mimicking a plain caller-supplied client; the fix under test
+// must add the cross-host protection.
+func crossHostTestTransport(pool *x509.CertPool) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				_, port, _ := net.SplitHostPort(addr)
+				return (&net.Dialer{}).DialContext(ctx, network, "127.0.0.1:"+port)
+			},
+			TLSClientConfig: &tls.Config{RootCAs: pool},
+		},
 	}
 }
 

--- a/sdk/messaging/eventgrid/azeventgrid/client_redirect_test.go
+++ b/sdk/messaging/eventgrid/azeventgrid/client_redirect_test.go
@@ -12,7 +12,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -27,104 +26,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBlockUnsafeRedirect(t *testing.T) {
+func TestNoFollowRedirect(t *testing.T) {
 	newReq := func(rawURL string) *http.Request {
 		u, _ := url.Parse(rawURL)
-		r := &http.Request{URL: u, Header: http.Header{}}
-		r.Header.Set("Authorization", "auth-secret")
-		r.Header.Set("aeg-sas-key", "secret-key")
-		r.Header.Set("aeg-sas-token", "secret-token")
-		r.Header.Set("Content-Type", "application/json")
-		return r
+		return &http.Request{URL: u, Header: http.Header{}}
 	}
 
-	t.Run("cross-host redirect is blocked", func(t *testing.T) {
+	t.Run("cross-host redirect is not followed", func(t *testing.T) {
 		req := newReq("https://attacker.example/collect")
 		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
-		err := blockUnsafeRedirect(nil)(req, via)
-		require.ErrorIs(t, err, errUnsafeRedirect)
+		require.ErrorIs(t, noFollowRedirect(req, via), http.ErrUseLastResponse)
 	})
 
-	t.Run("cross-host to a sibling subdomain is blocked", func(t *testing.T) {
-		req := newReq("https://attacker.eventgrid.azure.net/collect")
-		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
-		err := blockUnsafeRedirect(nil)(req, via)
-		require.ErrorIs(t, err, errUnsafeRedirect)
-	})
-
-	t.Run("same-host different-port redirect is blocked", func(t *testing.T) {
-		req := newReq("https://topic.eventgrid.azure.net:8443/collect")
-		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
-		err := blockUnsafeRedirect(nil)(req, via)
-		require.ErrorIs(t, err, errUnsafeRedirect)
-	})
-
-	t.Run("https-to-http downgrade on same host is blocked", func(t *testing.T) {
-		req := newReq("http://topic.eventgrid.azure.net/api/events")
-		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
-		err := blockUnsafeRedirect(nil)(req, via)
-		require.ErrorIs(t, err, errUnsafeRedirect)
-	})
-
-	t.Run("http-to-https upgrade on same host is allowed", func(t *testing.T) {
-		req := newReq("https://topic.eventgrid.azure.net/api/events")
-		via := []*http.Request{newReq("http://topic.eventgrid.azure.net/api/events")}
-		require.NoError(t, blockUnsafeRedirect(nil)(req, via))
-	})
-
-	t.Run("same-origin redirect is allowed and keeps credential headers", func(t *testing.T) {
+	t.Run("same-host redirect is not followed", func(t *testing.T) {
 		req := newReq("https://topic.eventgrid.azure.net/api/events?redirected=1")
 		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
-		require.NoError(t, blockUnsafeRedirect(nil)(req, via))
-		// credential headers are untouched for a permitted same-origin redirect
-		require.Equal(t, "secret-key", req.Header.Get("aeg-sas-key"))
-		require.Equal(t, "secret-token", req.Header.Get("aeg-sas-token"))
-		require.Equal(t, "auth-secret", req.Header.Get("Authorization"))
-	})
-
-	t.Run("same-host match is case-insensitive", func(t *testing.T) {
-		req := newReq("https://TOPIC.eventgrid.azure.net/api/events")
-		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
-		require.NoError(t, blockUnsafeRedirect(nil)(req, via))
-	})
-
-	t.Run("prior CheckRedirect is chained for same-origin redirects", func(t *testing.T) {
-		sentinel := errors.New("prior called")
-		req := newReq("https://topic.eventgrid.azure.net/api/events?redirected=1")
-		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
-		err := blockUnsafeRedirect(func(*http.Request, []*http.Request) error {
-			return sentinel
-		})(req, via)
-		require.ErrorIs(t, err, sentinel)
-	})
-
-	t.Run("unsafe-redirect block takes precedence over prior CheckRedirect", func(t *testing.T) {
-		req := newReq("https://attacker.example/collect")
-		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
-		priorCalled := false
-		err := blockUnsafeRedirect(func(*http.Request, []*http.Request) error {
-			priorCalled = true
-			return nil
-		})(req, via)
-		require.ErrorIs(t, err, errUnsafeRedirect)
-		require.False(t, priorCalled, "prior CheckRedirect must not run for a blocked redirect")
-	})
-
-	t.Run("default redirect limit enforced for same-origin redirects", func(t *testing.T) {
-		req := newReq("https://topic.eventgrid.azure.net/a")
-		via := make([]*http.Request, maxDefaultRedirects)
-		for i := range via {
-			via[i] = newReq("https://topic.eventgrid.azure.net/api/events")
-		}
-		require.Error(t, blockUnsafeRedirect(nil)(req, via))
+		require.ErrorIs(t, noFollowRedirect(req, via), http.ErrUseLastResponse)
 	})
 }
 
-// TestPublisher_BlocksCrossHostRedirect exercises the full client: a "trusted"
-// topic host answers the publish with a 307 redirect to a different "attacker"
-// host, and we assert the attacker host is never contacted at all (so neither
-// the credential nor the event payload leaks).
-func TestPublisher_BlocksCrossHostRedirect(t *testing.T) {
+// TestPublisher_DoesNotFollowCrossHostRedirect exercises the full client: a
+// "trusted" topic host answers the publish with a 307 redirect to a different
+// "attacker" host, and we assert the attacker host is never contacted at all
+// (so neither the credential nor the event payload leaks).
+func TestPublisher_DoesNotFollowCrossHostRedirect(t *testing.T) {
 	const trustedHost = "trusted-topic.eventgrid.example"
 	const attackerHost = "attacker-collector.example"
 
@@ -158,8 +83,7 @@ func TestPublisher_BlocksCrossHostRedirect(t *testing.T) {
 	attackerURL = fmt.Sprintf("https://%s:%s/collect", attackerHost, portOf(attacker))
 	endpoint := fmt.Sprintf("https://%s:%s", trustedHost, portOf(trusted))
 
-	transport := crossHostTestTransport(pool)
-	opts := &ClientOptions{ClientOptions: azcore.ClientOptions{Transport: transport}}
+	opts := &ClientOptions{ClientOptions: azcore.ClientOptions{Transport: loopbackTestClient(pool)}}
 
 	evt, err := messaging.NewCloudEvent("src", "Test.Event", map[string]string{"hello": "world"}, nil)
 	require.NoError(t, err)
@@ -187,7 +111,7 @@ func TestPublisher_BlocksCrossHostRedirect(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = client.PublishCloudEvents(context.Background(), events, nil)
-			// The publish must fail rather than follow the cross-host redirect.
+			// The publish must fail rather than follow the redirect.
 			require.Error(t, err)
 
 			// The credential was sent to the trusted (configured) host on the first request...
@@ -200,33 +124,29 @@ func TestPublisher_BlocksCrossHostRedirect(t *testing.T) {
 			require.True(t, sentToTrusted, "expected credential to be sent to the trusted host")
 
 			// ...but the attacker host must NEVER be contacted at all.
-			require.Empty(t, captured["attacker"], "attacker host must not be contacted on a cross-host redirect")
+			require.Empty(t, captured["attacker"], "attacker host must not be contacted on a redirect")
 		})
 	}
 }
 
-// TestPublisher_AllowsSameHostRedirect verifies that a same-host redirect is
-// still followed (with the credential) and the publish succeeds.
-func TestPublisher_AllowsSameHostRedirect(t *testing.T) {
+// TestPublisher_DoesNotFollowSameHostRedirect verifies that even a same-host
+// redirect is not followed (matching the .NET no-auto-redirect posture); the
+// publish surfaces the 3xx as an error.
+func TestPublisher_DoesNotFollowSameHostRedirect(t *testing.T) {
 	const host = "trusted-topic.eventgrid.example"
 
 	cert := selfSignedCert(t, host)
 	pool := x509.NewCertPool()
 	pool.AddCert(cert.Leaf)
 
-	var sawCredentialAfterRedirect bool
-	var redirected bool
+	var redirectTargetReached bool
 
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("redirected") == "" {
-			// Same-host redirect (e.g. path normalization / query addition).
 			http.Redirect(w, r, r.URL.Path+"?redirected=1", http.StatusTemporaryRedirect)
 			return
 		}
-		redirected = true
-		if r.Header.Get("aeg-sas-key") != "" {
-			sawCredentialAfterRedirect = true
-		}
+		redirectTargetReached = true
 		w.WriteHeader(http.StatusOK)
 	}))
 	srv.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
@@ -236,7 +156,7 @@ func TestPublisher_AllowsSameHostRedirect(t *testing.T) {
 	u, _ := url.Parse(srv.URL)
 	endpoint := fmt.Sprintf("https://%s:%s", host, u.Port())
 
-	opts := &ClientOptions{ClientOptions: azcore.ClientOptions{Transport: crossHostTestTransport(pool)}}
+	opts := &ClientOptions{ClientOptions: azcore.ClientOptions{Transport: loopbackTestClient(pool)}}
 	client, err := NewClientWithSharedKeyCredential(endpoint, azcore.NewKeyCredential("supersecret-key"), opts)
 	require.NoError(t, err)
 
@@ -244,9 +164,8 @@ func TestPublisher_AllowsSameHostRedirect(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = client.PublishCloudEvents(context.Background(), []messaging.CloudEvent{evt}, nil)
-	require.NoError(t, err)
-	require.True(t, redirected, "expected the same-host redirect to be followed")
-	require.True(t, sawCredentialAfterRedirect, "expected the credential to be retained on a same-host redirect")
+	require.Error(t, err)
+	require.False(t, redirectTargetReached, "the redirect target must not be reached")
 }
 
 // TestNewDefaultTransport verifies the installed default transport mirrors
@@ -266,11 +185,11 @@ func TestNewDefaultTransport(t *testing.T) {
 	require.NotNil(t, tr.DialContext)
 }
 
-// crossHostTestTransport returns an *http.Client whose transport resolves the
-// test hostnames to loopback and trusts the test CA. It intentionally sets no
+// loopbackTestClient returns an *http.Client whose transport resolves the test
+// hostnames to loopback and trusts the test CA. It intentionally sets no
 // CheckRedirect, mimicking a plain caller-supplied client; the fix under test
-// must add the cross-host protection.
-func crossHostTestTransport(pool *x509.CertPool) *http.Client {
+// must disable redirect following.
+func loopbackTestClient(pool *x509.CertPool) *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/sdk/messaging/eventgrid/azeventgrid/client_redirect_test.go
+++ b/sdk/messaging/eventgrid/azeventgrid/client_redirect_test.go
@@ -168,6 +168,25 @@ func TestPublisher_DoesNotFollowSameHostRedirect(t *testing.T) {
 	require.False(t, redirectTargetReached, "the redirect target must not be reached")
 }
 
+// TestWithRedirectProtection_DoesNotMutateSharedOptions verifies the caller's
+// ClientOptions (which azcore permits sharing across constructors) is not
+// mutated, and that each call produces an independent transport.
+func TestWithRedirectProtection_DoesNotMutateSharedOptions(t *testing.T) {
+	shared := &ClientOptions{}
+
+	first := withRedirectProtection(shared)
+	require.Nil(t, shared.Transport, "caller's options must not be mutated")
+	require.NotNil(t, first.Transport, "returned options must have the protective transport")
+
+	second := withRedirectProtection(shared)
+	require.Nil(t, shared.Transport, "caller's options must still not be mutated")
+	require.NotSame(t, first, second, "each call returns an independent options copy")
+	require.NotSame(t, first.Transport, second.Transport, "each call installs an independent client")
+
+	// nil options is handled without panicking.
+	require.NotNil(t, withRedirectProtection(nil).Transport)
+}
+
 // TestNewDefaultTransport verifies the installed default transport mirrors
 // azcore's tuned settings rather than falling back to http.DefaultTransport.
 func TestNewDefaultTransport(t *testing.T) {

--- a/sdk/messaging/eventgrid/azeventgrid/client_redirect_test.go
+++ b/sdk/messaging/eventgrid/azeventgrid/client_redirect_test.go
@@ -201,7 +201,6 @@ func TestNewDefaultTransport(t *testing.T) {
 	require.NotNil(t, tr.TLSClientConfig)
 	require.Equal(t, uint16(tls.VersionTLS12), tr.TLSClientConfig.MinVersion)
 	require.NotNil(t, tr.Proxy)
-	require.NotNil(t, tr.DialContext)
 }
 
 // loopbackTestClient returns an *http.Client whose transport resolves the test

--- a/sdk/messaging/eventgrid/azeventgrid/client_redirect_test.go
+++ b/sdk/messaging/eventgrid/azeventgrid/client_redirect_test.go
@@ -229,6 +229,23 @@ func TestPublisher_AllowsSameHostRedirect(t *testing.T) {
 	require.True(t, sawCredentialAfterRedirect, "expected the credential to be retained on a same-host redirect")
 }
 
+// TestNewDefaultTransport verifies the installed default transport mirrors
+// azcore's tuned settings rather than falling back to http.DefaultTransport.
+func TestNewDefaultTransport(t *testing.T) {
+	tr := newDefaultTransport()
+	require.NotSame(t, http.DefaultTransport, tr, "must not reuse the process-global default transport")
+	require.True(t, tr.ForceAttemptHTTP2)
+	require.Equal(t, 100, tr.MaxIdleConns)
+	require.Equal(t, 10, tr.MaxIdleConnsPerHost)
+	require.Equal(t, 90*time.Second, tr.IdleConnTimeout)
+	require.Equal(t, 10*time.Second, tr.TLSHandshakeTimeout)
+	require.Equal(t, time.Second, tr.ExpectContinueTimeout)
+	require.NotNil(t, tr.TLSClientConfig)
+	require.Equal(t, uint16(tls.VersionTLS12), tr.TLSClientConfig.MinVersion)
+	require.NotNil(t, tr.Proxy)
+	require.NotNil(t, tr.DialContext)
+}
+
 // crossHostTestTransport returns an *http.Client whose transport resolves the
 // test hostnames to loopback and trusts the test CA. It intentionally sets no
 // CheckRedirect, mimicking a plain caller-supplied client; the fix under test

--- a/sdk/messaging/eventgrid/azeventgrid/client_redirect_test.go
+++ b/sdk/messaging/eventgrid/azeventgrid/client_redirect_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBlockCrossHostRedirect(t *testing.T) {
+func TestBlockUnsafeRedirect(t *testing.T) {
 	newReq := func(rawURL string) *http.Request {
 		u, _ := url.Parse(rawURL)
 		r := &http.Request{URL: u, Header: http.Header{}}
@@ -41,22 +41,42 @@ func TestBlockCrossHostRedirect(t *testing.T) {
 	t.Run("cross-host redirect is blocked", func(t *testing.T) {
 		req := newReq("https://attacker.example/collect")
 		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
-		err := blockCrossHostRedirect(nil)(req, via)
-		require.ErrorIs(t, err, errCrossHostRedirect)
+		err := blockUnsafeRedirect(nil)(req, via)
+		require.ErrorIs(t, err, errUnsafeRedirect)
 	})
 
 	t.Run("cross-host to a sibling subdomain is blocked", func(t *testing.T) {
 		req := newReq("https://attacker.eventgrid.azure.net/collect")
 		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
-		err := blockCrossHostRedirect(nil)(req, via)
-		require.ErrorIs(t, err, errCrossHostRedirect)
+		err := blockUnsafeRedirect(nil)(req, via)
+		require.ErrorIs(t, err, errUnsafeRedirect)
 	})
 
-	t.Run("same-host redirect is allowed and keeps credential headers", func(t *testing.T) {
+	t.Run("same-host different-port redirect is blocked", func(t *testing.T) {
+		req := newReq("https://topic.eventgrid.azure.net:8443/collect")
+		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
+		err := blockUnsafeRedirect(nil)(req, via)
+		require.ErrorIs(t, err, errUnsafeRedirect)
+	})
+
+	t.Run("https-to-http downgrade on same host is blocked", func(t *testing.T) {
+		req := newReq("http://topic.eventgrid.azure.net/api/events")
+		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
+		err := blockUnsafeRedirect(nil)(req, via)
+		require.ErrorIs(t, err, errUnsafeRedirect)
+	})
+
+	t.Run("http-to-https upgrade on same host is allowed", func(t *testing.T) {
+		req := newReq("https://topic.eventgrid.azure.net/api/events")
+		via := []*http.Request{newReq("http://topic.eventgrid.azure.net/api/events")}
+		require.NoError(t, blockUnsafeRedirect(nil)(req, via))
+	})
+
+	t.Run("same-origin redirect is allowed and keeps credential headers", func(t *testing.T) {
 		req := newReq("https://topic.eventgrid.azure.net/api/events?redirected=1")
 		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
-		require.NoError(t, blockCrossHostRedirect(nil)(req, via))
-		// credential headers are untouched for a permitted same-host redirect
+		require.NoError(t, blockUnsafeRedirect(nil)(req, via))
+		// credential headers are untouched for a permitted same-origin redirect
 		require.Equal(t, "secret-key", req.Header.Get("aeg-sas-key"))
 		require.Equal(t, "secret-token", req.Header.Get("aeg-sas-token"))
 		require.Equal(t, "auth-secret", req.Header.Get("Authorization"))
@@ -65,38 +85,38 @@ func TestBlockCrossHostRedirect(t *testing.T) {
 	t.Run("same-host match is case-insensitive", func(t *testing.T) {
 		req := newReq("https://TOPIC.eventgrid.azure.net/api/events")
 		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
-		require.NoError(t, blockCrossHostRedirect(nil)(req, via))
+		require.NoError(t, blockUnsafeRedirect(nil)(req, via))
 	})
 
-	t.Run("prior CheckRedirect is chained for same-host redirects", func(t *testing.T) {
+	t.Run("prior CheckRedirect is chained for same-origin redirects", func(t *testing.T) {
 		sentinel := errors.New("prior called")
 		req := newReq("https://topic.eventgrid.azure.net/api/events?redirected=1")
 		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
-		err := blockCrossHostRedirect(func(*http.Request, []*http.Request) error {
+		err := blockUnsafeRedirect(func(*http.Request, []*http.Request) error {
 			return sentinel
 		})(req, via)
 		require.ErrorIs(t, err, sentinel)
 	})
 
-	t.Run("cross-host block takes precedence over prior CheckRedirect", func(t *testing.T) {
+	t.Run("unsafe-redirect block takes precedence over prior CheckRedirect", func(t *testing.T) {
 		req := newReq("https://attacker.example/collect")
 		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
 		priorCalled := false
-		err := blockCrossHostRedirect(func(*http.Request, []*http.Request) error {
+		err := blockUnsafeRedirect(func(*http.Request, []*http.Request) error {
 			priorCalled = true
 			return nil
 		})(req, via)
-		require.ErrorIs(t, err, errCrossHostRedirect)
-		require.False(t, priorCalled, "prior CheckRedirect must not run for a blocked cross-host redirect")
+		require.ErrorIs(t, err, errUnsafeRedirect)
+		require.False(t, priorCalled, "prior CheckRedirect must not run for a blocked redirect")
 	})
 
-	t.Run("default redirect limit enforced for same-host redirects", func(t *testing.T) {
+	t.Run("default redirect limit enforced for same-origin redirects", func(t *testing.T) {
 		req := newReq("https://topic.eventgrid.azure.net/a")
 		via := make([]*http.Request, maxDefaultRedirects)
 		for i := range via {
 			via[i] = newReq("https://topic.eventgrid.azure.net/api/events")
 		}
-		require.Error(t, blockCrossHostRedirect(nil)(req, via))
+		require.Error(t, blockUnsafeRedirect(nil)(req, via))
 	})
 }
 

--- a/sdk/messaging/eventgrid/azeventgrid/client_redirect_test.go
+++ b/sdk/messaging/eventgrid/azeventgrid/client_redirect_test.go
@@ -1,0 +1,194 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+package azeventgrid
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/messaging"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStripCredentialsOnCrossHostRedirect(t *testing.T) {
+	newReq := func(rawURL string) *http.Request {
+		u, _ := url.Parse(rawURL)
+		r := &http.Request{URL: u, Header: http.Header{}}
+		r.Header.Set("Authorization", "Bearer secret")
+		r.Header.Set("aeg-sas-key", "secret-key")
+		r.Header.Set("aeg-sas-token", "secret-token")
+		r.Header.Set("Content-Type", "application/json")
+		return r
+	}
+
+	t.Run("cross-host strips credential headers", func(t *testing.T) {
+		req := newReq("https://attacker.example/collect")
+		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
+		require.NoError(t, stripCredentialsOnCrossHostRedirect(nil)(req, via))
+		require.Empty(t, req.Header.Get("Authorization"))
+		require.Empty(t, req.Header.Get("aeg-sas-key"))
+		require.Empty(t, req.Header.Get("aeg-sas-token"))
+		// non-credential headers are preserved
+		require.Equal(t, "application/json", req.Header.Get("Content-Type"))
+	})
+
+	t.Run("same-host preserves credential headers", func(t *testing.T) {
+		req := newReq("https://topic.eventgrid.azure.net/api/events?redirected=1")
+		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
+		require.NoError(t, stripCredentialsOnCrossHostRedirect(nil)(req, via))
+		require.Equal(t, "secret-key", req.Header.Get("aeg-sas-key"))
+		require.Equal(t, "secret-token", req.Header.Get("aeg-sas-token"))
+	})
+
+	t.Run("chains prior CheckRedirect", func(t *testing.T) {
+		sentinel := errors.New("prior called")
+		req := newReq("https://attacker.example/collect")
+		via := []*http.Request{newReq("https://topic.eventgrid.azure.net/api/events")}
+		err := stripCredentialsOnCrossHostRedirect(func(*http.Request, []*http.Request) error {
+			return sentinel
+		})(req, via)
+		require.ErrorIs(t, err, sentinel)
+		require.Empty(t, req.Header.Get("aeg-sas-key")) // still stripped before delegating
+	})
+
+	t.Run("default redirect limit enforced", func(t *testing.T) {
+		req := newReq("https://topic.eventgrid.azure.net/a")
+		via := make([]*http.Request, 10)
+		for i := range via {
+			via[i] = newReq("https://topic.eventgrid.azure.net/api/events")
+		}
+		require.Error(t, stripCredentialsOnCrossHostRedirect(nil)(req, via))
+	})
+}
+
+// TestPublisher_DoesNotLeakCredentialsOnCrossHostRedirect exercises the full
+// client: a "trusted" topic host answers the publish with a 307 redirect to a
+// different "attacker" host and we assert the credential never reaches it.
+func TestPublisher_DoesNotLeakCredentialsOnCrossHostRedirect(t *testing.T) {
+	const trustedHost = "trusted-topic.eventgrid.example"
+	const attackerHost = "attacker-collector.example"
+
+	cert := selfSignedCert(t, trustedHost, attackerHost)
+	pool := x509.NewCertPool()
+	pool.AddCert(cert.Leaf)
+
+	captured := map[string][]http.Header{}
+	var attackerURL string
+
+	mkServer := func(role string) *httptest.Server {
+		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			captured[role] = append(captured[role], r.Header.Clone())
+			if role == "trusted" {
+				http.Redirect(w, r, attackerURL, http.StatusTemporaryRedirect)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		})
+		s := httptest.NewUnstartedServer(h)
+		s.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
+		s.StartTLS()
+		return s
+	}
+	trusted := mkServer("trusted")
+	attacker := mkServer("attacker")
+	defer trusted.Close()
+	defer attacker.Close()
+
+	portOf := func(s *httptest.Server) string { u, _ := url.Parse(s.URL); return u.Port() }
+	attackerURL = fmt.Sprintf("https://%s:%s/collect", attackerHost, portOf(attacker))
+	endpoint := fmt.Sprintf("https://%s:%s", trustedHost, portOf(trusted))
+
+	// Transport maps the fake hostnames to loopback and trusts the test cert.
+	// It has no CheckRedirect, mimicking a plain client; the fix must add one.
+	transport := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				_, port, _ := net.SplitHostPort(addr)
+				return (&net.Dialer{}).DialContext(ctx, network, "127.0.0.1:"+port)
+			},
+			TLSClientConfig: &tls.Config{RootCAs: pool},
+		},
+	}
+	opts := &ClientOptions{ClientOptions: azcore.ClientOptions{Transport: transport}}
+
+	evt, err := messaging.NewCloudEvent("src", "Test.Event", map[string]string{"hello": "world"}, nil)
+	require.NoError(t, err)
+	events := []messaging.CloudEvent{evt}
+
+	cases := []struct {
+		name   string
+		header string
+		secret string
+		client func() (*Client, error)
+	}{
+		{"key", "aeg-sas-key", "supersecret-key", func() (*Client, error) {
+			return NewClientWithSharedKeyCredential(endpoint, azcore.NewKeyCredential("supersecret-key"), opts)
+		}},
+		{"sas", "aeg-sas-token", "supersecret-sas", func() (*Client, error) {
+			return NewClientWithSAS(endpoint, azcore.NewSASCredential("supersecret-sas"), opts)
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for k := range captured {
+				delete(captured, k)
+			}
+			client, err := tc.client()
+			require.NoError(t, err)
+			_, _ = client.PublishCloudEvents(context.Background(), events, nil)
+
+			// credential was sent to the trusted host...
+			sentToTrusted := false
+			for _, h := range captured["trusted"] {
+				if h.Get(tc.header) != "" {
+					sentToTrusted = true
+				}
+			}
+			require.True(t, sentToTrusted, "expected credential to be sent to the trusted host")
+
+			// ...the redirect was followed to the attacker host...
+			require.NotEmpty(t, captured["attacker"], "expected the redirect to reach the attacker host")
+
+			// ...but the credential must NOT have been forwarded.
+			for _, h := range captured["attacker"] {
+				require.Empty(t, h.Get(tc.header), "credential header %q leaked to attacker host", tc.header)
+			}
+		})
+	}
+}
+
+func selfSignedCert(t *testing.T, hosts ...string) tls.Certificate {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: hosts[0]},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     hosts,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	leaf, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key, Leaf: leaf}
+}

--- a/sdk/messaging/eventgrid/azeventgrid/go.mod
+++ b/sdk/messaging/eventgrid/azeventgrid/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0
 	github.com/joho/godotenv v1.5.1
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/net v0.57.0
 )
 
 require (
@@ -19,7 +20,6 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
-	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/sdk/messaging/eventgrid/azeventgrid/transport_dialer_other.go
+++ b/sdk/messaging/eventgrid/azeventgrid/transport_dialer_other.go
@@ -1,0 +1,18 @@
+//go:build !wasm
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+package azeventgrid
+
+import (
+	"context"
+	"net"
+)
+
+// defaultTransportDialContext returns the dialer's DialContext. It mirrors
+// azcore's build-tagged helper (sdk/azcore/runtime/transport_default_dialer_other.go)
+// so that newDefaultTransport matches azcore's default transport on every
+// platform.
+func defaultTransportDialContext(dialer *net.Dialer) func(context.Context, string, string) (net.Conn, error) {
+	return dialer.DialContext
+}

--- a/sdk/messaging/eventgrid/azeventgrid/transport_dialer_other_test.go
+++ b/sdk/messaging/eventgrid/azeventgrid/transport_dialer_other_test.go
@@ -1,0 +1,17 @@
+//go:build !wasm
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+package azeventgrid
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultTransportDialContext(t *testing.T) {
+	// On non-WASM targets the helper returns the dialer's DialContext.
+	require.NotNil(t, defaultTransportDialContext(&net.Dialer{}))
+}

--- a/sdk/messaging/eventgrid/azeventgrid/transport_dialer_wasm.go
+++ b/sdk/messaging/eventgrid/azeventgrid/transport_dialer_wasm.go
@@ -1,0 +1,18 @@
+//go:build (js && wasm) || wasip1
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+package azeventgrid
+
+import (
+	"context"
+	"net"
+)
+
+// defaultTransportDialContext returns nil on WebAssembly targets, mirroring
+// azcore's build-tagged helper (sdk/azcore/runtime/transport_default_dialer_wasm.go).
+// A net.Dialer cannot be used on these platforms, so http.Transport must fall
+// back to its own default dialing.
+func defaultTransportDialContext(_ *net.Dialer) func(context.Context, string, string) (net.Conn, error) {
+	return nil
+}

--- a/sdk/messaging/eventgrid/azeventgrid/transport_dialer_wasm_test.go
+++ b/sdk/messaging/eventgrid/azeventgrid/transport_dialer_wasm_test.go
@@ -1,0 +1,18 @@
+//go:build (js && wasm) || wasip1
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+package azeventgrid
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultTransportDialContext(t *testing.T) {
+	// On WASM targets the helper returns nil so http.Transport uses its own
+	// default dialing (a net.Dialer cannot be used there).
+	require.Nil(t, defaultTransportDialContext(&net.Dialer{}))
+}


### PR DESCRIPTION
### Summary

The Event Grid basic publisher (zeventgrid) sends its credential in the `aeg-sas-key`, `aeg-sas-token`, or `Authorization` header. azcore relies on `net/http` to follow redirects, and `net/http` only strips a small, fixed set of headers on a **cross-host** redirect (`Authorization`, `WWW-Authenticate`, `Cookie`, `Cookie2`). The custom `aeg-sas-key` / `aeg-sas-token` headers are **not** in that set, so a 3xx redirect to a different host forwards the publishing credential (topic access key or SAS signature) in full to the redirect target.

This is the same class of issue that was recently fixed in the Python SDK (`SensitiveHeaderCleanupPolicy` on the legacy EventGrid publisher).

### Fix

- New `client_redirect.go`: installs a `CheckRedirect` that deletes the credential headers (`Authorization`, `aeg-sas-key`, `aeg-sas-token`) whenever a redirect crosses to a different host, while still following same-host redirects and chaining any caller-supplied `CheckRedirect`. A caller-supplied `*http.Client` transport is preserved (cloned).
- `client_custom.go`: applied in all three constructors (`NewClient`, `NewClientWithSharedKeyCredential`, `NewClientWithSAS`).
- Tests: unit tests (cross-host strips, same-host preserves, chains prior, redirect limit) + an end-to-end publish through a cross-host 307 asserting the credential never reaches the other host.
- CHANGELOG: Bugs Fixed entry under 1.0.1.

### Verification

`go build` / `go vet` clean, gofmt clean, and all new tests pass. Before the fix the key/SAS cases leaked; after the fix they are stripped.

> [!NOTE]
> This is a security fix. If a coordinated/MSRC disclosure is required, please advise on whether this should be handled privately before merge.
