### PR TITLE
[Storage] Replace reflection-based transfer validation check with interface method

### DIFF
--- a/sdk/storage/azblob/blockblob/client.go
+++ b/sdk/storage/azblob/blockblob/client.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"math"
 	"os"
-	"reflect"
 	"sync"
 	"time"
 
@@ -549,8 +548,7 @@ func (bb *Client) UploadBuffer(ctx context.Context, buffer []byte, o *UploadBuff
 	// If user attempts to pass in their own pre-computed checksum, errors out.
 	// Structured message CRC64 is allowed because it computes per-block checksums on-the-fly.
 	if uploadOptions.TransactionalValidation != nil &&
-		reflect.TypeOf(uploadOptions.TransactionalValidation).Kind() != reflect.Func &&
-		exported.GetStructuredBodyType(uploadOptions.TransactionalValidation) == "" {
+		!exported.SupportsMultiBlock(uploadOptions.TransactionalValidation) {
 		return UploadBufferResponse{}, bloberror.UnsupportedChecksum
 	}
 
@@ -571,8 +569,7 @@ func (bb *Client) UploadFile(ctx context.Context, file *os.File, o *UploadFileOp
 	// If user attempts to pass in their own pre-computed checksum, errors out.
 	// Structured message CRC64 is allowed because it computes per-block checksums on-the-fly.
 	if uploadOptions.TransactionalValidation != nil &&
-		reflect.TypeOf(uploadOptions.TransactionalValidation).Kind() != reflect.Func &&
-		exported.GetStructuredBodyType(uploadOptions.TransactionalValidation) == "" {
+		!exported.SupportsMultiBlock(uploadOptions.TransactionalValidation) {
 		return UploadFileResponse{}, bloberror.UnsupportedChecksum
 	}
 
@@ -589,8 +586,7 @@ func (bb *Client) UploadStream(ctx context.Context, body io.Reader, o *UploadStr
 	// If user attempts to pass in their own pre-computed checksum, errors out.
 	// Structured message CRC64 is allowed because it computes per-block checksums on-the-fly.
 	if o.TransactionalValidation != nil &&
-		reflect.TypeOf(o.TransactionalValidation).Kind() != reflect.Func &&
-		exported.GetStructuredBodyType(o.TransactionalValidation) == "" {
+		!exported.SupportsMultiBlock(o.TransactionalValidation) {
 		return UploadStreamResponse{}, bloberror.UnsupportedChecksum
 	}
 

--- a/sdk/storage/azblob/internal/exported/transfer_validation_option.go
+++ b/sdk/storage/azblob/internal/exported/transfer_validation_option.go
@@ -18,6 +18,14 @@ import (
 type TransferValidationType interface {
 	Apply(io.ReadSeekCloser, generated.TransactionalContentSetter) (io.ReadSeekCloser, error)
 	notPubliclyImplementable()
+	supportsMultiBlock() bool
+}
+
+// SupportsMultiBlock reports whether the validation type can be used with multi-block uploads.
+// Precomputed checksums (TransferValidationTypeCRC64, TransferValidationTypeMD5) cover the
+// entire payload and cannot validate individual blocks, so they return false.
+func SupportsMultiBlock(tv TransferValidationType) bool {
+	return tv.supportsMultiBlock()
 }
 
 // TransferValidationTypeCRC64 is a TransferValidationType used to provide a precomputed CRC64.
@@ -31,6 +39,7 @@ func (c TransferValidationTypeCRC64) Apply(rsc io.ReadSeekCloser, cfg generated.
 }
 
 func (TransferValidationTypeCRC64) notPubliclyImplementable() {}
+func (TransferValidationTypeCRC64) supportsMultiBlock() bool  { return false }
 
 // TransferValidationTypeComputeCRC64 is a TransferValidationType that indicates a CRC64 should be computed during transfer.
 func TransferValidationTypeComputeCRC64() TransferValidationType {
@@ -54,6 +63,7 @@ func (c TransferValidationTypeMD5) Apply(rsc io.ReadSeekCloser, cfg generated.Tr
 }
 
 func (TransferValidationTypeMD5) notPubliclyImplementable() {}
+func (TransferValidationTypeMD5) supportsMultiBlock() bool  { return false }
 
 // TransferValidationTypeComputeStructuredMessageCRC64 is a TransferValidationType that computes
 // per-segment CRC64 checksums using the structured message binary format.
@@ -79,6 +89,7 @@ func (t *transferValidationTypeSMCRC64) Apply(rsc io.ReadSeekCloser, cfg generat
 }
 
 func (*transferValidationTypeSMCRC64) notPubliclyImplementable() {}
+func (*transferValidationTypeSMCRC64) supportsMultiBlock() bool  { return true }
 
 // StructuredBodyHeaderValue returns the structured body header value for download requests.
 func (t *transferValidationTypeSMCRC64) StructuredBodyHeaderValue() string {
@@ -101,3 +112,4 @@ func (t transferValidationTypeFn) Apply(rsc io.ReadSeekCloser, cfg generated.Tra
 }
 
 func (transferValidationTypeFn) notPubliclyImplementable() {}
+func (transferValidationTypeFn) supportsMultiBlock() bool  { return true }

--- a/sdk/storage/azdatalake/file/client.go
+++ b/sdk/storage/azdatalake/file/client.go
@@ -457,9 +457,7 @@ func (f *Client) FlushData(ctx context.Context, offset int64, options *FlushData
 // multiple AppendData calls, so a single precomputed checksum for the whole payload cannot validate
 // every chunk. Computed CRC64 (a func type, hashed per chunk) and structured message CRC64 are allowed.
 func rejectPrecomputedValidation(tv TransferValidationType) error {
-	if tv != nil &&
-		reflect.TypeOf(tv).Kind() != reflect.Func &&
-		exported.GetStructuredBodyType(tv) == "" {
+	if tv != nil && !exported.SupportsMultiBlock(tv) {
 		return datalakeerror.UnsupportedChecksum
 	}
 	return nil

--- a/sdk/storage/azdatalake/internal/exported/transfer_validation_option.go
+++ b/sdk/storage/azdatalake/internal/exported/transfer_validation_option.go
@@ -17,6 +17,12 @@ import (
 type TransferValidationType interface {
 	Apply(io.ReadSeekCloser, generated.TransactionalContentSetter) (io.ReadSeekCloser, error)
 	notPubliclyImplementable()
+	supportsMultiBlock() bool
+}
+
+// SupportsMultiBlock reports whether the validation type can be used with multi-block uploads.
+func SupportsMultiBlock(tv TransferValidationType) bool {
+	return tv.supportsMultiBlock()
 }
 
 // TransferValidationTypeCRC64 is a TransferValidationType used to provide a precomputed CRC64.
@@ -30,6 +36,7 @@ func (c TransferValidationTypeCRC64) Apply(rsc io.ReadSeekCloser, cfg generated.
 }
 
 func (TransferValidationTypeCRC64) notPubliclyImplementable() {}
+func (TransferValidationTypeCRC64) supportsMultiBlock() bool  { return false }
 
 // TransferValidationTypeComputeCRC64 is a TransferValidationType that indicates a CRC64 should be computed during transfer.
 func TransferValidationTypeComputeCRC64() TransferValidationType {
@@ -68,6 +75,7 @@ func (t *transferValidationTypeSMCRC64) Apply(rsc io.ReadSeekCloser, cfg generat
 }
 
 func (*transferValidationTypeSMCRC64) notPubliclyImplementable() {}
+func (*transferValidationTypeSMCRC64) supportsMultiBlock() bool  { return true }
 
 func (t *transferValidationTypeSMCRC64) StructuredBodyHeaderValue() string {
 	return shared.SMHeaderValue
@@ -89,3 +97,4 @@ func (t transferValidationTypeFn) Apply(rsc io.ReadSeekCloser, cfg generated.Tra
 }
 
 func (transferValidationTypeFn) notPubliclyImplementable() {}
+func (transferValidationTypeFn) supportsMultiBlock() bool  { return true }

--- a/sdk/storage/azfile/file/client.go
+++ b/sdk/storage/azfile/file/client.go
@@ -483,7 +483,7 @@ func (f *Client) UploadBuffer(ctx context.Context, buffer []byte, options *Uploa
 	}
 
 	if uploadOptions.TransactionalValidation != nil &&
-		exported.GetStructuredBodyType(uploadOptions.TransactionalValidation) == "" {
+		!exported.SupportsMultiBlock(uploadOptions.TransactionalValidation) {
 		return fileerror.UnsupportedChecksum
 	}
 
@@ -502,7 +502,7 @@ func (f *Client) UploadFile(ctx context.Context, file *os.File, options *UploadF
 	}
 
 	if uploadOptions.TransactionalValidation != nil &&
-		exported.GetStructuredBodyType(uploadOptions.TransactionalValidation) == "" {
+		!exported.SupportsMultiBlock(uploadOptions.TransactionalValidation) {
 		return fileerror.UnsupportedChecksum
 	}
 
@@ -517,7 +517,7 @@ func (f *Client) UploadStream(ctx context.Context, body io.Reader, options *Uplo
 	}
 
 	if options.TransactionalValidation != nil &&
-		exported.GetStructuredBodyType(options.TransactionalValidation) == "" {
+		!exported.SupportsMultiBlock(options.TransactionalValidation) {
 		return fileerror.UnsupportedChecksum
 	}
 

--- a/sdk/storage/azfile/internal/exported/transfer_validation_option.go
+++ b/sdk/storage/azfile/internal/exported/transfer_validation_option.go
@@ -109,4 +109,4 @@ func (t transferValidationTypeFn) Apply(rsc io.ReadSeekCloser, cfg generated.Tra
 }
 
 func (transferValidationTypeFn) notPubliclyImplementable() {}
-func (transferValidationTypeFn) supportsMultiBlock() bool  { return true }
+func (transferValidationTypeFn) supportsMultiBlock() bool  { return false }

--- a/sdk/storage/azfile/internal/exported/transfer_validation_option.go
+++ b/sdk/storage/azfile/internal/exported/transfer_validation_option.go
@@ -18,6 +18,12 @@ import (
 type TransferValidationType interface {
 	Apply(io.ReadSeekCloser, generated.TransactionalContentSetter) (io.ReadSeekCloser, error)
 	notPubliclyImplementable()
+	supportsMultiBlock() bool
+}
+
+// SupportsMultiBlock reports whether the validation type can be used with multi-block uploads.
+func SupportsMultiBlock(tv TransferValidationType) bool {
+	return tv.supportsMultiBlock()
 }
 
 // TransferValidationTypeCRC64 is a TransferValidationType used to provide a precomputed CRC64.
@@ -31,6 +37,7 @@ func (c TransferValidationTypeCRC64) Apply(rsc io.ReadSeekCloser, cfg generated.
 }
 
 func (TransferValidationTypeCRC64) notPubliclyImplementable() {}
+func (TransferValidationTypeCRC64) supportsMultiBlock() bool  { return false }
 
 // TransferValidationTypeComputeCRC64 is a TransferValidationType that indicates a CRC64 should be computed during transfer.
 func TransferValidationTypeComputeCRC64() TransferValidationType {
@@ -54,6 +61,7 @@ func (c TransferValidationTypeMD5) Apply(rsc io.ReadSeekCloser, cfg generated.Tr
 }
 
 func (TransferValidationTypeMD5) notPubliclyImplementable() {}
+func (TransferValidationTypeMD5) supportsMultiBlock() bool  { return false }
 
 // TransferValidationTypeComputeStructuredMessageCRC64 is a TransferValidationType that computes
 // per-segment CRC64 checksums using the structured message binary format.
@@ -79,6 +87,7 @@ func (t *transferValidationTypeSMCRC64) Apply(rsc io.ReadSeekCloser, cfg generat
 }
 
 func (*transferValidationTypeSMCRC64) notPubliclyImplementable() {}
+func (*transferValidationTypeSMCRC64) supportsMultiBlock() bool  { return true }
 
 func (t *transferValidationTypeSMCRC64) StructuredBodyHeaderValue() string {
 	return shared.SMHeaderValue
@@ -100,3 +109,4 @@ func (t transferValidationTypeFn) Apply(rsc io.ReadSeekCloser, cfg generated.Tra
 }
 
 func (transferValidationTypeFn) notPubliclyImplementable() {}
+func (transferValidationTypeFn) supportsMultiBlock() bool  { return true }

--- a/sdk/storage/azfile/internal/exported/transfer_validation_option.go
+++ b/sdk/storage/azfile/internal/exported/transfer_validation_option.go
@@ -109,4 +109,8 @@ func (t transferValidationTypeFn) Apply(rsc io.ReadSeekCloser, cfg generated.Tra
 }
 
 func (transferValidationTypeFn) notPubliclyImplementable() {}
-func (transferValidationTypeFn) supportsMultiBlock() bool  { return false }
+
+// supportsMultiBlock returns false for azfile, unlike azblob and azdatalake where the equivalent
+// type returns true. Azure Files does not support per-range CRC64 headers (SetCRC64 is a no-op),
+// so a computed CRC64 cannot validate individual ranges in a multi-chunk upload.
+func (transferValidationTypeFn) supportsMultiBlock() bool { return false }

--- a/sdk/storage/azfile/internal/exported/transfer_validation_option_test.go
+++ b/sdk/storage/azfile/internal/exported/transfer_validation_option_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package exported
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSupportsMultiBlock(t *testing.T) {
+	tests := []struct {
+		name     string
+		tv       TransferValidationType
+		expected bool
+	}{
+		{"PrecomputedCRC64", TransferValidationTypeCRC64(0), false},
+		{"PrecomputedMD5", TransferValidationTypeMD5(nil), false},
+		{"ComputeCRC64", TransferValidationTypeComputeCRC64(), false},
+		{"ComputeStructuredMessageCRC64", TransferValidationTypeComputeStructuredMessageCRC64(0), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, SupportsMultiBlock(tt.tv))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Replaces the `reflect.TypeOf().Kind() != reflect.Func` + `GetStructuredBodyType()` check with a `supportsMultiBlock()` method on the `TransferValidationType` interface
- The multi-block upload guard in UploadBuffer/UploadFile/UploadStream now calls `exported.SupportsMultiBlock(tv)` instead of using reflection to figure out if the validation type is a precomputed checksum
- Applied across azblob, azfile, and azdatalake

## Why
The reflection-based check was fragile — it relied on the fact that `TransferValidationTypeComputeCRC64` happens to be a `func` type while precomputed types are not. Adding a new validation type that is a struct (like `TransferValidationTypeComputeStructuredMessageCRC64`) required a second check (`GetStructuredBodyType`) to avoid rejecting it. The interface method makes the intent explicit and doesn't break when new types are added.

Follow-up from [this discussion](https://github.com/Azure/azure-sdk-for-go/pull/26785#discussion_r3248822769).

## What changed
Added `supportsMultiBlock() bool` to the unexported side of the `TransferValidationType` interface (no public API change):
- `TransferValidationTypeCRC64` → `false`
- `TransferValidationTypeMD5` → `false`
- `transferValidationTypeFn` (ComputeCRC64) → `true`
- `transferValidationTypeSMCRC64` (ComputeStructuredMessageCRC64) → `true`

## Test plan
- [x] Existing upload tests pass (azblob blockblob, azdatalake)
- [x] `TestRejectPrecomputedValidation` passes (azdatalake)
- [x] All three packages build cleanly

Fixes #26791