### PR TITLE
[commvaultcontentstore] Set planned release date for armcommvaultcontentstore v0.1.0

### DIFF
--- a/sdk/resourcemanager/commvaultcontentstore/armcommvaultcontentstore/CHANGELOG.md
+++ b/sdk/resourcemanager/commvaultcontentstore/armcommvaultcontentstore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.1.0 (2026-06-24)
+## 0.1.0 (2026-08-20)
 ### Other Changes
 
 The package of `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/commvaultcontentstore/armcommvaultcontentstore` is using our [next generation design principles](https://azure.github.io/azure-sdk/general_introduction.html).

--- a/sdk/resourcemanager/commvaultcontentstore/armcommvaultcontentstore/CHANGELOG.md
+++ b/sdk/resourcemanager/commvaultcontentstore/armcommvaultcontentstore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.1.0 (2026-08-20)
+## 0.1.0 (2026-06-24)
 ### Other Changes
 
 The package of `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/commvaultcontentstore/armcommvaultcontentstore` is using our [next generation design principles](https://azure.github.io/azure-sdk/general_introduction.html).


### PR DESCRIPTION
Updates CHANGELOG.md with a planned release date (2026-08-18) so the release pipeline readiness check passes for release plan 2101.