### PR TITLE
[Service Bus] Clarify and sample session listing

### DIFF
--- a/sdk/messaging/azservicebus/client.go
+++ b/sdk/messaging/azservicebus/client.go
@@ -438,8 +438,9 @@ func (client *Client) NewListSessionsForSubscriptionPager(topicName string, subs
 }
 
 func (client *Client) newListSessionsPager(e entity, updatedAfter *time.Time) *runtime.Pager[ListSessionsResponse] {
-	// The service switches between "active messages" mode and "updated since" mode by checking
-	// lastUpdatedTime != DateTime.MaxValue (exact equality). The .NET AMQP library encodes
+	// The service switches between default listing mode (active messages or stored session state)
+	// and updated-since mode by checking lastUpdatedTime != DateTime.MaxValue (exact equality).
+	// The .NET AMQP library encodes
 	// DateTime.MaxValue as 253402300800000 ms (10000-01-01T00:00:00Z) due to double→long rounding
 	// in TimeSpan.TotalMilliseconds, and its decoder clamps values beyond DateTime.MaxValue.Ticks
 	// back to DateTime.MaxValue. This matches Track 1 Java's SessionBrowser.MAXDATE =

--- a/sdk/messaging/azservicebus/client_list_sessions_live_test.go
+++ b/sdk/messaging/azservicebus/client_list_sessions_live_test.go
@@ -17,9 +17,10 @@ import (
 )
 
 // TestClient_ListSessionsForQueue_Live exercises the get-message-sessions operation
-// end-to-end against a live namespace. It is live-only: active-messages mode relies on
-// the service clamping the far-future sentinel timestamp to DateTime.MaxValue, which
-// cannot be reproduced with recorded responses.
+// end-to-end against a live namespace. It is live-only: default listing mode returns
+// sessions with active messages or stored session state and relies on the service clamping
+// the far-future sentinel timestamp to DateTime.MaxValue, which cannot be reproduced with
+// recorded responses.
 func TestClient_ListSessionsForQueue_Live(t *testing.T) {
 	if recording.GetRecordMode() == recording.PlaybackMode {
 		t.Skip("live-only: session listing exercises service-side sentinel clamping and cannot be recorded")
@@ -53,9 +54,9 @@ func TestClient_ListSessionsForQueue_Live(t *testing.T) {
 	}
 	require.NoError(t, sender.Close(ctx))
 
-	// A session that has session state set but no active message. Active-messages mode must
-	// still list it: the default lists sessions with active messages as well as sessions that
-	// have session state set but no active messages. Without this session the ElementsMatch
+	// A session that has session state set but no active message. Default listing mode must
+	// still list it: the default lists sessions with active messages as well as sessions with
+	// stored session state. Without this session the ElementsMatch
 	// below would pass whether or not state-only sessions are included.
 	const stateOnlySession = "state-only-000"
 	stateReceiver, err := client.AcceptSessionForQueue(ctx, queue, stateOnlySession, nil)
@@ -64,8 +65,8 @@ func TestClient_ListSessionsForQueue_Live(t *testing.T) {
 	require.NoError(t, stateReceiver.Close(ctx))
 	want = append(want, stateOnlySession)
 
-	// Active-messages mode (nil options => far-future sentinel): the service must return the
-	// sessions that have active messages plus the state-only session, across all pages.
+	// Default listing mode (nil options => far-future sentinel): the service must return
+	// sessions with active messages and sessions with stored session state, across all pages.
 	var got []string
 	pager := client.NewListSessionsForQueuePager(queue, nil)
 	for pager.More() {
@@ -79,11 +80,12 @@ func TestClient_ListSessionsForQueue_Live(t *testing.T) {
 
 // TestClient_ListSessionsForQueue_SessionStateUpdatedAfter_Live exercises the
 // SessionStateUpdatedAfter filter (the second listing mode) end-to-end against a live
-// namespace. Unlike active-messages mode, this mode passes a real last-updated-time to the
-// service, so it can only be validated live. Listing with a cutoff on either side of the
-// state update must return opposite sets: a past cutoff lists the state sessions, a future
-// cutoff excludes them. That difference proves the service applies the real last-updated-time
-// rather than ignoring the filter.
+// namespace. Unlike default listing mode, which returns sessions with active messages or
+// stored session state, this mode passes a real last-updated-time to the service, so it can
+// only be validated live. Listing with a cutoff on either side of the state update must
+// return opposite sets: a past cutoff lists the state sessions, a future cutoff excludes
+// them. That difference proves the service applies the real last-updated-time rather than
+// ignoring the filter.
 func TestClient_ListSessionsForQueue_SessionStateUpdatedAfter_Live(t *testing.T) {
 	if recording.GetRecordMode() == recording.PlaybackMode {
 		t.Skip("live-only: session-state-updated-time filtering is a service-side behavior and cannot be recorded")

--- a/sdk/messaging/azservicebus/client_list_sessions_unit_test.go
+++ b/sdk/messaging/azservicebus/client_list_sessions_unit_test.go
@@ -223,10 +223,10 @@ func TestClient_ListSessionsForQueue_StopsOnEmptyFirstPage(t *testing.T) {
 	require.Len(t, link.calls, 1)
 }
 
-func TestClient_ListSessionsForQueue_ActiveModeSendsSentinel(t *testing.T) {
-	// Active-messages mode (SessionStateUpdatedAfter nil) must send the 10000-01-01 sentinel
+func TestClient_ListSessionsForQueue_DefaultListingModeSendsSentinel(t *testing.T) {
+	// Default listing mode (SessionStateUpdatedAfter nil) must send the 10000-01-01 sentinel
 	// (253402300800000 ms on the AMQP wire) so the service's .NET AMQP decoder
-	// clamps it to DateTime.MaxValue, triggering active-messages mode.
+	// clamps it to DateTime.MaxValue, listing sessions with active messages or stored session state.
 	link := &scriptedRPCLink{
 		t: t,
 		responses: []*amqpwrap.RPCResponse{

--- a/sdk/messaging/azservicebus/example_client_test.go
+++ b/sdk/messaging/azservicebus/example_client_test.go
@@ -35,9 +35,9 @@ func ExampleNewClient() {
 }
 
 func ExampleClient_NewListSessionsForQueuePager() {
-	// List the IDs of sessions that currently have active messages in a
-	// session-enabled queue. The IDs are returned in pages; call NextPage until
-	// More returns false.
+	// List the IDs of sessions that have active messages or stored session state
+	// in a session-enabled queue. The IDs are returned in pages; call NextPage
+	// until More returns false.
 	pager := client.NewListSessionsForQueuePager("exampleSessionQueue", nil)
 
 	for pager.More() {
@@ -50,6 +50,48 @@ func ExampleClient_NewListSessionsForQueuePager() {
 
 		for _, sessionID := range page.Sessions {
 			fmt.Printf("Session ID: %s\n", sessionID)
+		}
+	}
+}
+
+func ExampleClient_NewListSessionsForSubscriptionPager() {
+	// List the IDs of sessions that have active messages or stored session state
+	// in a session-enabled subscription. The IDs are returned in pages; call
+	// NextPage until More returns false.
+	pager := client.NewListSessionsForSubscriptionPager("exampleTopic", "exampleSubscription", nil)
+
+	for pager.More() {
+		page, err := pager.NextPage(context.TODO())
+
+		if err != nil {
+			// TODO: Update the following line with your application specific error handling logic
+			log.Fatalf("ERROR: %s", err)
+		}
+
+		for _, sessionID := range page.Sessions {
+			fmt.Printf("Session ID: %s\n", sessionID)
+		}
+	}
+}
+
+func ExampleClient_NewListSessionsForQueuePager_filteringBySessionStateUpdateTime() {
+	// List only sessions whose stored session state was set or updated in the
+	// last seven days.
+	stateUpdatedAfter := time.Now().UTC().Add(-7 * 24 * time.Hour)
+	pager := client.NewListSessionsForQueuePager("exampleSessionQueue", &azservicebus.ListSessionsOptions{
+		SessionStateUpdatedAfter: &stateUpdatedAfter,
+	})
+
+	for pager.More() {
+		page, err := pager.NextPage(context.TODO())
+
+		if err != nil {
+			// TODO: Update the following line with your application specific error handling logic
+			log.Fatalf("ERROR: %s", err)
+		}
+
+		for _, sessionID := range page.Sessions {
+			fmt.Printf("Recently updated session ID: %s\n", sessionID)
 		}
 	}
 }

--- a/sdk/messaging/azservicebus/internal/mgmt.go
+++ b/sdk/messaging/azservicebus/internal/mgmt.go
@@ -605,7 +605,7 @@ func addAssociatedLinkName(linkName string, msg *amqp.Message) {
 //   - Pass time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC) to list sessions with active
 //     messages, as well as sessions that have session state set but no active messages.
 //     This encodes to 253402300800000 ms on the AMQP wire, which the service's
-//     .NET AMQP decoder clamps to DateTime.MaxValue, triggering active-messages mode.
+//     .NET AMQP decoder clamps to DateTime.MaxValue, triggering default listing mode.
 //   - Pass a real timestamp to list sessions whose session state was updated after that time.
 //
 // No associated link name is needed (entity-level operation).

--- a/sdk/messaging/azservicebus/internal/mgmt_get_sessions_test.go
+++ b/sdk/messaging/azservicebus/internal/mgmt_get_sessions_test.go
@@ -58,13 +58,14 @@ func TestGetMessageSessions_SessionStateUpdatedAfterMode(t *testing.T) {
 	require.Equal(t, []string{"session-a", "session-b", "session-c"}, result)
 }
 
-func TestGetMessageSessions_ActiveSessionsMode(t *testing.T) {
+func TestGetMessageSessions_DefaultListingMode(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	// The sentinel for "active messages" mode: 10000-01-01T00:00:00Z.
+	// The sentinel for default listing mode: 10000-01-01T00:00:00Z.
 	// On the AMQP wire this becomes 253402300800000 ms, which the service's .NET
-	// AMQP decoder clamps to DateTime.MaxValue, triggering active-messages mode.
+	// AMQP decoder clamps to DateTime.MaxValue. This mode lists sessions with active
+	// messages or stored session state.
 	sentinel := time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	rpcLink := mock.NewMockRPCLink(ctrl)


### PR DESCRIPTION
## Summary

Clarifies list-session terminology and adds examples for both modes of the existing API:

- Default listing returns sessions with active messages or stored session state.
- `SessionStateUpdatedAfter` filters to sessions whose stored state was set or updated after a cutoff.

No runtime behavior or public API changes. The PR is limited to list-session source comments, tests, and examples.

## Testing

- `go test ./...`
- `git diff --check`

Related implementation: Azure/azure-sdk-for-go#26688

- [x] The purpose of this PR is explained in this description.
- [x] The PR does not update generated files.
- [x] Tests are included and/or updated for code changes.
- [x] Updates to module CHANGELOG.md are included, or not required because this is documentation-only.
- [x] MIT license headers are included in each new file (no new files in this PR).

[Azure/autorest.go]: https://github.com/Azure/autorest.go
