### PR TITLE
[Service Bus] Prepare azservicebus 1.11.0-beta.1 release

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -1,13 +1,11 @@
 # Release History
 
-## 1.11.0-beta.1 (Unreleased)
+## 1.11.0-beta.1 (2026-08-21)
 
 ### Features Added
 
 - Added `Client.NewListSessionsForQueuePager()` and `Client.NewListSessionsForSubscriptionPager()` to list the IDs of sessions in session-enabled queues and subscriptions. By default they list sessions that have active messages, as well as sessions that have session state set but no active messages; set `SessionStateUpdatedAfter` to instead list sessions whose session state was updated after a given time. (PR#26688)
 - Added `SQLFilterCount` and `CorrelationFilterCount` to `TopicRuntimeProperties`, exposing the total number of SQL filters and correlation filters across all of a topic's subscriptions, including the default rule each subscription is created with. The service reports these at api-version 2024-05 or later. (PR#27323)
-
-### Breaking Changes
 
 ### Bugs Fixed
 


### PR DESCRIPTION
## Summary

Prepares `sdk/messaging/azservicebus` `1.11.0-beta.1` for the planned
August 21, 2026 release.

## Changes

- `sdk/messaging/azservicebus/CHANGELOG.md`

No additional package changes.

## Cross-SDK release set

| SDK | Package | Version | PR |
|-----|---------|---------|----|
| .NET | `Azure.Messaging.ServiceBus` | `7.21.0-beta.1` | [#62282](https://github.com/Azure/azure-sdk-for-net/pull/62282) |
| Java | `azure-messaging-servicebus` | `7.18.0-beta.3` | [#50198](https://github.com/Azure/azure-sdk-for-java/pull/50198) |
| JavaScript | `@azure/service-bus` | `7.10.0-beta.5` | [#39672](https://github.com/Azure/azure-sdk-for-js/pull/39672) |
| Go | `sdk/messaging/azservicebus` | `1.11.0-beta.1` | [#27420](https://github.com/Azure/azure-sdk-for-go/pull/27420) |
| Python | `azure-servicebus` | `7.15.0b2` | [#48649](https://github.com/Azure/azure-sdk-for-python/pull/48649) |

## Validation

- `./eng/common/scripts/Prepare-Release.ps1 -PackageName 'sdk/messaging/azservicebus' -ServiceDirectory 'messaging/azservicebus' -ReleaseDate '08/21/2026'`
- `git diff --check`
- Metadata-only change; no product tests required.

## Release controls

- Release tracking: [35850 - Go - Service Bus - 1.11](https://dev.azure.com/azure-sdk/Release/_workitems/edit/35850/)
- Release pipeline: Not queued by this PR.
