### PR TITLE
docs: Add Service Bus unit testing guidance

### DIFF
--- a/sdk/messaging/azservicebus/CHANGELOG.md
+++ b/sdk/messaging/azservicebus/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Other Changes
 
+- Added unit-testing guidance and a compile-checked example for code that uses
+  `Receiver` through a consumer-defined interface.
 - Every administration operation now runs against service api-version `2024-05`, where it previously ran against `2021-05`. Responses follow the 2024-05 contract, which adds fields to some entity descriptions, and the topic filter counts above require this version. Set `APIVersion` on the `azcore.ClientOptions` embedded in the client's `ClientOptions` to pin a different version. (PR#27323)
 - Cleaned up accumulated `golangci-lint` findings in `azservicebus` (deprecated
   `runtime.WithHTTPHeader` calls switched to `policy.WithHTTPHeader`, duplicate

--- a/sdk/messaging/azservicebus/README.md
+++ b/sdk/messaging/azservicebus/README.md
@@ -101,6 +101,7 @@ The following examples cover common tasks using Azure Service Bus:
 
 - [Send messages](#send-messages)
 - [Receive messages](#receive-messages)
+- [Unit test code that uses receivers](#unit-test-code-that-uses-receivers)
 - [Dead lettering and subqueues](#dead-letter-queue)
 
 ### Send messages
@@ -244,6 +245,24 @@ for _, message := range messages {
 }
 ```
 
+### Unit test code that uses receivers
+
+Define an interface containing only the receiver operations that your
+application uses. Pass an `*azservicebus.Receiver` to the application in
+production and use a test implementation of the interface in unit tests.
+
+If the application creates receivers through an `azservicebus.Client`, inject
+a function that wraps `Client.NewReceiverForQueue` or
+`Client.NewReceiverForSubscription`. This keeps the application independent of
+the concrete receiver while preserving the SDK's client construction path.
+
+The public fields on `ReceivedMessage` let unit tests create messages with the
+values needed for each scenario. See the
+[unit-testing example][unit_testing_example] for a complete pattern.
+
+Use an integration test when the code under test needs the SDK to create other
+concrete values, such as `MessageBatch`.
+
 ### Dead letter queue
 
 The dead letter queue is a **sub-queue**. Each queue or subscription has its own dead letter queue. Dead letter queues store
@@ -334,3 +353,4 @@ If you'd like to contribute to this library, please read the [contributing guide
 [godoc_newreceiver_queue]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/#Client.NewReceiverForQueue
 [godoc_newreceiver_subscription]: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/#Client.NewReceiverForSubscription
 [servicebus_troubleshooting]: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/messaging/azservicebus/TROUBLESHOOTING.md
+[unit_testing_example]: https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/messaging/azservicebus/example_mocking_test.go

--- a/sdk/messaging/azservicebus/example_mocking_test.go
+++ b/sdk/messaging/azservicebus/example_mocking_test.go
@@ -17,6 +17,7 @@ import (
 type messageReceiver interface {
 	ReceiveMessages(context.Context, int, *azservicebus.ReceiveMessagesOptions) ([]*azservicebus.ReceivedMessage, error)
 	CompleteMessage(context.Context, *azservicebus.ReceivedMessage, *azservicebus.CompleteMessageOptions) error
+	Close(context.Context) error
 }
 
 type newReceiver func(string, *azservicebus.ReceiverOptions) (messageReceiver, error)
@@ -26,6 +27,7 @@ func processMessage(ctx context.Context, createReceiver newReceiver) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = receiver.Close(ctx) }()
 
 	messages, err := receiver.ReceiveMessages(ctx, 1, nil)
 	if err != nil {
@@ -44,6 +46,7 @@ func processMessage(ctx context.Context, createReceiver newReceiver) error {
 type fakeReceiver struct {
 	messages  []*azservicebus.ReceivedMessage
 	completed int
+	closed    bool
 }
 
 func (f *fakeReceiver) ReceiveMessages(context.Context, int, *azservicebus.ReceiveMessagesOptions) ([]*azservicebus.ReceivedMessage, error) {
@@ -52,6 +55,11 @@ func (f *fakeReceiver) ReceiveMessages(context.Context, int, *azservicebus.Recei
 
 func (f *fakeReceiver) CompleteMessage(context.Context, *azservicebus.ReceivedMessage, *azservicebus.CompleteMessageOptions) error {
 	f.completed++
+	return nil
+}
+
+func (f *fakeReceiver) Close(context.Context) error {
+	f.closed = true
 	return nil
 }
 
@@ -93,4 +101,5 @@ func TestUnitTestingReceiver(t *testing.T) {
 	err := processMessage(context.TODO(), createReceiver)
 	require.NoError(t, err)
 	require.Equal(t, 1, fake.completed)
+	require.True(t, fake.closed)
 }

--- a/sdk/messaging/azservicebus/example_mocking_test.go
+++ b/sdk/messaging/azservicebus/example_mocking_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azservicebus_test
+
+import (
+	"context"
+	"log"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
+	"github.com/stretchr/testify/require"
+)
+
+// messageReceiver contains only the receiver operations used by the
+// application. The SDK's Receiver satisfies this interface implicitly.
+type messageReceiver interface {
+	ReceiveMessages(context.Context, int, *azservicebus.ReceiveMessagesOptions) ([]*azservicebus.ReceivedMessage, error)
+	CompleteMessage(context.Context, *azservicebus.ReceivedMessage, *azservicebus.CompleteMessageOptions) error
+}
+
+type newReceiver func(string, *azservicebus.ReceiverOptions) (messageReceiver, error)
+
+func processMessage(ctx context.Context, createReceiver newReceiver) error {
+	receiver, err := createReceiver("orders", nil)
+	if err != nil {
+		return err
+	}
+
+	messages, err := receiver.ReceiveMessages(ctx, 1, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, message := range messages {
+		if err := receiver.CompleteMessage(ctx, message, nil); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type fakeReceiver struct {
+	messages  []*azservicebus.ReceivedMessage
+	completed int
+}
+
+func (f *fakeReceiver) ReceiveMessages(context.Context, int, *azservicebus.ReceiveMessagesOptions) ([]*azservicebus.ReceivedMessage, error) {
+	return f.messages, nil
+}
+
+func (f *fakeReceiver) CompleteMessage(context.Context, *azservicebus.ReceivedMessage, *azservicebus.CompleteMessageOptions) error {
+	f.completed++
+	return nil
+}
+
+var _ messageReceiver = (*azservicebus.Receiver)(nil)
+var _ messageReceiver = (*fakeReceiver)(nil)
+
+func Example_unitTesting() {
+	fake := &fakeReceiver{
+		messages: []*azservicebus.ReceivedMessage{
+			{
+				Body:      []byte("example"),
+				MessageID: "message-id",
+			},
+		},
+	}
+
+	createReceiver := func(string, *azservicebus.ReceiverOptions) (messageReceiver, error) {
+		return fake, nil
+	}
+
+	err := processMessage(context.TODO(), createReceiver)
+	if err != nil {
+		// TODO: Update the following line with your application specific error handling logic
+		log.Fatalf("ERROR: %s", err)
+	}
+}
+
+func TestUnitTestingReceiver(t *testing.T) {
+	fake := &fakeReceiver{
+		messages: []*azservicebus.ReceivedMessage{
+			{MessageID: "message-id"},
+		},
+	}
+
+	createReceiver := func(string, *azservicebus.ReceiverOptions) (messageReceiver, error) {
+		return fake, nil
+	}
+
+	err := processMessage(context.TODO(), createReceiver)
+	require.NoError(t, err)
+	require.Equal(t, 1, fake.completed)
+}


### PR DESCRIPTION
Closes #27395

Adds guidance for Go applications that unit test code using
`azservicebus.Receiver`. The documentation shows how to depend on a
consumer-defined interface, use the SDK receiver in production, and inject a
test implementation without connecting to Service Bus.

### Content covered

1. Defines a receiver interface containing only application-used operations.
2. Demonstrates receiver creation through an injected function.
3. Shows how tests can construct `ReceivedMessage` values and use a fake
   receiver.
4. Ensures the receiver created by the example is closed after use.
5. Clarifies that SDK-created concrete values such as `MessageBatch` require
   integration testing.

### Files changed

- `sdk/messaging/azservicebus/CHANGELOG.md`
- `sdk/messaging/azservicebus/README.md`
- `sdk/messaging/azservicebus/example_mocking_test.go`

### Review notes

- Keeps the interface application-owned rather than adding public SDK surface.
- Uses `context.TODO()` and the repository's example error-handling pattern.
- Includes compile-time interface assertions for the SDK and test receiver.
- Includes receiver cleanup in the application-owned interface and verifies it
   in the unit test.

### Testing

- `go test ./...` from `sdk/messaging/azservicebus`
- `gofmt -d sdk/messaging/azservicebus/example_mocking_test.go`
- `git diff --check`

### Checklist

- [x] The purpose of this PR is explained in this description and #27395.
- [x] The PR does not update generated files.
- [x] Tests are included for the added example.
- [x] The module CHANGELOG is updated.
- [x] The new Go file includes the MIT license header.

### PR review history

| Round | Reviewer | Comment | Action | Commit |
|-------|----------|---------|--------|--------|
| 1 | @copilot-pull-request-reviewer | Close receivers created by the injected factory. | Added `Close` to the application interface, deferred cleanup after creation, and verified fake cleanup. | `bab6418` |
| 2 | @copilot-pull-request-reviewer | No new comments. | No change. | `bab6418` |

