### PR TITLE
[Storage] Add CI pipeline for sdk/storage/internal

### DIFF
--- a/sdk/storage/internal/ci.storage.internal.yml
+++ b/sdk/storage/internal/ci.storage.internal.yml
@@ -1,0 +1,29 @@
+# NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
+trigger:
+  branches:
+    include:
+      - main
+      - feature/*
+      - hotfix/*
+      - release/*
+  paths:
+    include:
+    - sdk/storage/internal
+
+pr:
+  branches:
+    include:
+      - main
+      - feature/*
+      - hotfix/*
+      - release/*
+  paths:
+    include:
+    - sdk/storage/internal
+
+extends:
+  template: /eng/pipelines/templates/jobs/archetype-sdk-client.yml
+  parameters:
+    ServiceDirectory: 'storage/internal'
+    RunLiveTests: false
+    EnableRaceDetector: true


### PR DESCRIPTION
## Summary
- Adds the `ci.storage.internal.yml` pipeline definition for the new `sdk/storage/internal` shared module
- This is Phase 1 of introducing the shared storage internal module — pipeline creation must happen before the module content can be merged and published
- Once this PR is merged and pipelines are created, a follow-up PR will add the module content
