### PR TITLE
Optimize small blob downloads by replacing GetProperties with initial GetBlob

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fixed WASM compilation by using heap-allocated buffers on JS targets.
 
 ### Other Changes
+* Optimized `DownloadBuffer` and `DownloadFile` to use an initial GET request instead of a HEAD (GetProperties) call for blob size discovery. For small blobs (<=4MB), the entire content is returned in a single request, reducing download latency by ~50%.
 
 ## 1.8.1-beta.1 (2026-07-24)
 

--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 ### Breaking Changes
-* `DownloadBuffer` and `DownloadFile` now use ETag locking to ensure consistency across parallel chunk requests. If a blob is modified during a multi-chunk download, subsequent requests will fail with `ConditionNotMet` instead of silently returning data from mixed blob versions.
+* `DownloadBuffer` and `DownloadFile` now use ETag locking to ensure consistency across parallel chunk requests when the blob size is not specified upfront (i.e., `Range.Count` is zero). If a blob is modified during a multi-chunk download, subsequent requests will fail with `ConditionNotMet` instead of silently returning data from mixed blob versions.
 
 ### Bugs Fixed
 

--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 ### Breaking Changes
+* `DownloadBuffer` and `DownloadFile` now use ETag locking to ensure consistency across parallel chunk requests. If a blob is modified during a multi-chunk download, subsequent requests will fail with `ConditionNotMet` instead of silently returning data from mixed blob versions.
 
 ### Bugs Fixed
 

--- a/sdk/storage/azblob/appendblob/client_test.go
+++ b/sdk/storage/azblob/appendblob/client_test.go
@@ -1086,7 +1086,9 @@ func (s *AppendBlobRecordedTestsSuite) TestAppendBlockFromURLCopySourceAuth() {
 
 	// Download data from destination
 	destBuffer := make([]byte, 4*1024)
-	_, err = destABClient.DownloadBuffer(context.Background(), destBuffer, nil)
+	_, err = destABClient.DownloadBuffer(context.Background(), destBuffer, &blob.DownloadBufferOptions{
+		Range: blob.HTTPRange{Count: int64(contentSize)},
+	})
 	_require.NoError(err)
 	_require.Equal(destBuffer, sourceData)
 }

--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_b6a5f7fb26"
+  "Tag": "go/storage/azblob_837ac36d9a"
 }

--- a/sdk/storage/azblob/assets.json
+++ b/sdk/storage/azblob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "go",
   "TagPrefix": "go/storage/azblob",
-  "Tag": "go/storage/azblob_acaf3dbead"
+  "Tag": "go/storage/azblob_b6a5f7fb26"
 }

--- a/sdk/storage/azblob/blob/client.go
+++ b/sdk/storage/azblob/blob/client.go
@@ -338,6 +338,11 @@ func (b *Client) GetSASURL(permissions sas.BlobPermissions, expiry time.Time, o 
 
 // Concurrent Download Functions -----------------------------------------------------------------------------------------
 
+type downloadProgress struct {
+	byteCount     int64
+	byteCountLock sync.Mutex
+}
+
 // downloadBuffer downloads an Azure blob to a WriterAt in parallel.
 // It uses an initial GetBlob (GET) request instead of GetProperties (HEAD) to determine the blob size,
 // eliminating an extra round trip for small blobs where the entire content is returned in the initial response.
@@ -351,8 +356,7 @@ func (b *Client) downloadBuffer(ctx context.Context, writer io.WriterAt, o downl
 		return b.parallelDownload(ctx, writer, o, count)
 	}
 
-	initialRange := HTTPRange{Offset: o.Range.Offset, Count: o.BlockSize}
-	dr, err := b.DownloadStream(ctx, o.getDownloadBlobOptions(initialRange, nil))
+	dr, err := b.DownloadStream(ctx, o.getDownloadBlobOptions(HTTPRange{Offset: o.Range.Offset, Count: o.BlockSize}, nil))
 	if err != nil {
 		if bloberror.HasCode(err, bloberror.InvalidRange) {
 			return 0, nil
@@ -407,15 +411,14 @@ func (b *Client) downloadBuffer(ctx context.Context, writer io.WriterAt, o downl
 		return 0, nil
 	}
 
-	progress := int64(0)
-	progressLock := &sync.Mutex{}
+	prog := &downloadProgress{}
 	var body io.ReadCloser = dr.NewRetryReader(ctx, &o.RetryReaderOptionsPerBlock)
 	if o.Progress != nil {
 		body = streaming.NewResponseProgress(body, func(bytesTransferred int64) {
-			progressLock.Lock()
-			progress = bytesTransferred
-			o.Progress(progress)
-			progressLock.Unlock()
+			prog.byteCountLock.Lock()
+			prog.byteCount = bytesTransferred
+			o.Progress(prog.byteCount)
+			prog.byteCountLock.Unlock()
 		})
 	}
 	_, err = io.Copy(shared.NewSectionWriter(writer, 0, initialChunkSize), body)
@@ -437,7 +440,7 @@ func (b *Client) downloadBuffer(ctx context.Context, writer io.WriterAt, o downl
 	}
 
 	remaining := count - initialChunkSize
-	remainingDownloaded, err := b.parallelDownloadFrom(ctx, writer, o, initialChunkSize, remaining, &progress, progressLock)
+	remainingDownloaded, err := b.parallelDownloadFrom(ctx, writer, o, initialChunkSize, remaining, prog)
 	if err != nil {
 		return 0, err
 	}
@@ -446,8 +449,7 @@ func (b *Client) downloadBuffer(ctx context.Context, writer io.WriterAt, o downl
 
 func (b *Client) parallelDownload(ctx context.Context, writer io.WriterAt, o downloadOptions, count int64) (int64, error) {
 	dataDownloaded := int64(0)
-	progress := int64(0)
-	progressLock := &sync.Mutex{}
+	prog := &downloadProgress{}
 
 	err := shared.DoBatchTransfer(ctx, &shared.BatchTransferOptions{
 		OperationName: "downloadBlobToWriterAt",
@@ -467,10 +469,10 @@ func (b *Client) parallelDownload(ctx context.Context, writer io.WriterAt, o dow
 				body = streaming.NewResponseProgress(body, func(bytesTransferred int64) {
 					diff := bytesTransferred - rangeProgress
 					rangeProgress = bytesTransferred
-					progressLock.Lock()
-					progress += diff
-					o.Progress(progress)
-					progressLock.Unlock()
+					prog.byteCountLock.Lock()
+					prog.byteCount += diff
+					o.Progress(prog.byteCount)
+					prog.byteCountLock.Unlock()
 				})
 			}
 			if _, err = io.Copy(shared.NewSectionWriter(writer, chunkStart, count), body); err != nil {
@@ -491,7 +493,7 @@ func (b *Client) parallelDownload(ctx context.Context, writer io.WriterAt, o dow
 	return dataDownloaded, nil
 }
 
-func (b *Client) parallelDownloadFrom(ctx context.Context, writer io.WriterAt, o downloadOptions, writerOffset int64, remaining int64, progress *int64, progressLock *sync.Mutex) (int64, error) {
+func (b *Client) parallelDownloadFrom(ctx context.Context, writer io.WriterAt, o downloadOptions, writerOffset int64, remaining int64, prog *downloadProgress) (int64, error) {
 	dataDownloaded := int64(0)
 
 	err := shared.DoBatchTransfer(ctx, &shared.BatchTransferOptions{
@@ -512,10 +514,10 @@ func (b *Client) parallelDownloadFrom(ctx context.Context, writer io.WriterAt, o
 				body = streaming.NewResponseProgress(body, func(bytesTransferred int64) {
 					diff := bytesTransferred - rangeProgress
 					rangeProgress = bytesTransferred
-					progressLock.Lock()
-					*progress += diff
-					o.Progress(*progress)
-					progressLock.Unlock()
+					prog.byteCountLock.Lock()
+					prog.byteCount += diff
+					o.Progress(prog.byteCount)
+					prog.byteCountLock.Unlock()
 				})
 			}
 			if _, err = io.Copy(shared.NewSectionWriter(writer, chunkStart+writerOffset, count), body); err != nil {

--- a/sdk/storage/azblob/blob/client.go
+++ b/sdk/storage/azblob/blob/client.go
@@ -364,19 +364,19 @@ func (b *Client) downloadBuffer(ctx context.Context, writer io.WriterAt, o downl
 	if dr.ContentRange != nil {
 		totalSize = parseContentRangeTotal(*dr.ContentRange)
 		if totalSize <= 0 {
-			dr.Body.Close()
+			_ = dr.Body.Close()
 			return 0, fmt.Errorf("unable to parse total size from Content-Range header: %s", *dr.ContentRange)
 		}
 	} else if dr.ContentLength != nil {
 		totalSize = *dr.ContentLength + o.Range.Offset
 	} else {
-		dr.Body.Close()
+		_ = dr.Body.Close()
 		return 0, fmt.Errorf("response missing both Content-Range and Content-Length headers")
 	}
 
 	count = totalSize - o.Range.Offset
 	if count <= 0 {
-		dr.Body.Close()
+		_ = dr.Body.Close()
 		return 0, nil
 	}
 
@@ -386,12 +386,15 @@ func (b *Client) downloadBuffer(ctx context.Context, writer io.WriterAt, o downl
 			clone := *o.AccessConditions
 			ac = &clone
 		}
-		if ac.ModifiedAccessConditions == nil {
-			ac.ModifiedAccessConditions = &ModifiedAccessConditions{}
+		mac := &ModifiedAccessConditions{}
+		if ac.ModifiedAccessConditions != nil {
+			macClone := *ac.ModifiedAccessConditions
+			mac = &macClone
 		}
-		if ac.ModifiedAccessConditions.IfMatch == nil {
-			ac.ModifiedAccessConditions.IfMatch = dr.ETag
+		if mac.IfMatch == nil {
+			mac.IfMatch = dr.ETag
 		}
+		ac.ModifiedAccessConditions = mac
 		o.AccessConditions = ac
 	}
 
@@ -402,7 +405,7 @@ func (b *Client) downloadBuffer(ctx context.Context, writer io.WriterAt, o downl
 		initialChunkSize = *dr.ContentLength
 	}
 	if initialChunkSize <= 0 {
-		dr.Body.Close()
+		_ = dr.Body.Close()
 		return 0, nil
 	}
 
@@ -419,7 +422,7 @@ func (b *Client) downloadBuffer(ctx context.Context, writer io.WriterAt, o downl
 	}
 	_, err = io.Copy(shared.NewSectionWriter(writer, 0, initialChunkSize), body)
 	if err != nil {
-		body.Close()
+		_ = body.Close()
 		return 0, err
 	}
 	if err = body.Close(); err != nil {
@@ -473,7 +476,7 @@ func (b *Client) parallelDownload(ctx context.Context, writer io.WriterAt, o dow
 				})
 			}
 			if _, err = io.Copy(shared.NewSectionWriter(writer, chunkStart, count), body); err != nil {
-				body.Close()
+				_ = body.Close()
 				return err
 			}
 			if dr.StructuredBodyType != nil && *dr.StructuredBodyType != "" && dr.ContentRange != nil {
@@ -518,7 +521,7 @@ func (b *Client) parallelDownloadFrom(ctx context.Context, writer io.WriterAt, o
 				})
 			}
 			if _, err = io.Copy(shared.NewSectionWriter(writer, chunkStart+writerOffset, count), body); err != nil {
-				body.Close()
+				_ = body.Close()
 				return err
 			}
 			if dr.StructuredBodyType != nil && *dr.StructuredBodyType != "" && dr.ContentRange != nil {

--- a/sdk/storage/azblob/blob/client.go
+++ b/sdk/storage/azblob/blob/client.go
@@ -364,6 +364,14 @@ func (b *Client) downloadBuffer(ctx context.Context, writer io.WriterAt, o downl
 		return 0, err
 	}
 
+	if dr.ContentRange == nil && dr.ContentLength == nil {
+		// A 304 Not Modified response (from If-None-Match / If-Modified-Since conditions)
+		// has no body or size headers. Close the body and surface as an error so callers
+		// see the same behavior as the prior GetProperties path.
+		_ = dr.Body.Close()
+		return 0, fmt.Errorf("response contained no content headers; this may indicate a 304 Not Modified due to access conditions")
+	}
+
 	var totalSize int64
 	if dr.ContentRange != nil {
 		totalSize = parseContentRangeTotal(*dr.ContentRange)
@@ -371,11 +379,8 @@ func (b *Client) downloadBuffer(ctx context.Context, writer io.WriterAt, o downl
 			_ = dr.Body.Close()
 			return 0, fmt.Errorf("unable to parse total size from Content-Range header: %s", *dr.ContentRange)
 		}
-	} else if dr.ContentLength != nil {
-		totalSize = *dr.ContentLength + o.Range.Offset
 	} else {
-		_ = dr.Body.Close()
-		return 0, fmt.Errorf("response missing both Content-Range and Content-Length headers")
+		totalSize = *dr.ContentLength + o.Range.Offset
 	}
 
 	count = totalSize - o.Range.Offset

--- a/sdk/storage/azblob/blob/client.go
+++ b/sdk/storage/azblob/blob/client.go
@@ -381,15 +381,18 @@ func (b *Client) downloadBuffer(ctx context.Context, writer io.WriterAt, o downl
 	}
 
 	if dr.ETag != nil {
-		if o.AccessConditions == nil {
-			o.AccessConditions = &AccessConditions{
-				ModifiedAccessConditions: &ModifiedAccessConditions{IfMatch: dr.ETag},
-			}
-		} else if o.AccessConditions.ModifiedAccessConditions == nil {
-			o.AccessConditions.ModifiedAccessConditions = &ModifiedAccessConditions{IfMatch: dr.ETag}
-		} else if o.AccessConditions.ModifiedAccessConditions.IfMatch == nil {
-			o.AccessConditions.ModifiedAccessConditions.IfMatch = dr.ETag
+		ac := &AccessConditions{}
+		if o.AccessConditions != nil {
+			clone := *o.AccessConditions
+			ac = &clone
 		}
+		if ac.ModifiedAccessConditions == nil {
+			ac.ModifiedAccessConditions = &ModifiedAccessConditions{}
+		}
+		if ac.ModifiedAccessConditions.IfMatch == nil {
+			ac.ModifiedAccessConditions.IfMatch = dr.ETag
+		}
+		o.AccessConditions = ac
 	}
 
 	var initialChunkSize int64
@@ -470,6 +473,7 @@ func (b *Client) parallelDownload(ctx context.Context, writer io.WriterAt, o dow
 				})
 			}
 			if _, err = io.Copy(shared.NewSectionWriter(writer, chunkStart, count), body); err != nil {
+				body.Close()
 				return err
 			}
 			if dr.StructuredBodyType != nil && *dr.StructuredBodyType != "" && dr.ContentRange != nil {
@@ -514,6 +518,7 @@ func (b *Client) parallelDownloadFrom(ctx context.Context, writer io.WriterAt, o
 				})
 			}
 			if _, err = io.Copy(shared.NewSectionWriter(writer, chunkStart+writerOffset, count), body); err != nil {
+				body.Close()
 				return err
 			}
 			if dr.StructuredBodyType != nil && *dr.StructuredBodyType != "" && dr.ContentRange != nil {
@@ -579,15 +584,13 @@ func (b *Client) DownloadFile(ctx context.Context, file *os.File, o *DownloadFil
 		return 0, err
 	}
 
-	if downloaded > 0 {
-		stat, err := file.Stat()
-		if err != nil {
+	stat, err := file.Stat()
+	if err != nil {
+		return downloaded, err
+	}
+	if stat.Size() != downloaded {
+		if err = file.Truncate(downloaded); err != nil {
 			return downloaded, err
-		}
-		if stat.Size() != downloaded {
-			if err = file.Truncate(downloaded); err != nil {
-				return downloaded, err
-			}
 		}
 	}
 

--- a/sdk/storage/azblob/blob/client.go
+++ b/sdk/storage/azblob/blob/client.go
@@ -391,9 +391,7 @@ func (b *Client) downloadBuffer(ctx context.Context, writer io.WriterAt, o downl
 			macClone := *ac.ModifiedAccessConditions
 			mac = &macClone
 		}
-		if mac.IfMatch == nil {
-			mac.IfMatch = dr.ETag
-		}
+		mac.IfMatch = dr.ETag
 		ac.ModifiedAccessConditions = mac
 		o.AccessConditions = ac
 	}

--- a/sdk/storage/azblob/blob/client.go
+++ b/sdk/storage/azblob/blob/client.go
@@ -339,30 +339,109 @@ func (b *Client) GetSASURL(permissions sas.BlobPermissions, expiry time.Time, o 
 // Concurrent Download Functions -----------------------------------------------------------------------------------------
 
 // downloadBuffer downloads an Azure blob to a WriterAt in parallel.
+// It uses an initial GetBlob (GET) request instead of GetProperties (HEAD) to determine the blob size,
+// eliminating an extra round trip for small blobs where the entire content is returned in the initial response.
 func (b *Client) downloadBuffer(ctx context.Context, writer io.WriterAt, o downloadOptions) (int64, error) {
 	if o.BlockSize == 0 {
 		o.BlockSize = DefaultDownloadBlockSize
 	}
-	dataDownloaded := int64(0)
-	computeReadLength := true
+
 	count := o.Range.Count
-	if count == CountToEnd { // If size not specified, calculate it
-		// If we don't have the length at all, get it
-		gr, err := b.GetProperties(ctx, o.getBlobPropertiesOptions())
-		if err != nil {
-			return 0, err
-		}
-		count = *gr.ContentLength - o.Range.Offset
-		dataDownloaded = count
-		computeReadLength = false
+	if count != CountToEnd {
+		return b.parallelDownload(ctx, writer, o, count)
 	}
 
+	initialRange := HTTPRange{Offset: o.Range.Offset, Count: o.BlockSize}
+	dr, err := b.DownloadStream(ctx, o.getDownloadBlobOptions(initialRange, nil))
+	if err != nil {
+		if bloberror.HasCode(err, bloberror.InvalidRange) {
+			return 0, nil
+		}
+		return 0, err
+	}
+
+	var totalSize int64
+	if dr.ContentRange != nil {
+		totalSize = parseContentRangeTotal(*dr.ContentRange)
+		if totalSize <= 0 {
+			dr.Body.Close()
+			return 0, fmt.Errorf("unable to parse total size from Content-Range header: %s", *dr.ContentRange)
+		}
+	} else if dr.ContentLength != nil {
+		totalSize = *dr.ContentLength + o.Range.Offset
+	} else {
+		dr.Body.Close()
+		return 0, fmt.Errorf("response missing both Content-Range and Content-Length headers")
+	}
+
+	count = totalSize - o.Range.Offset
 	if count <= 0 {
-		// The file is empty, there is nothing to download.
+		dr.Body.Close()
 		return 0, nil
 	}
 
-	// Prepare and do parallel download.
+	if dr.ETag != nil {
+		if o.AccessConditions == nil {
+			o.AccessConditions = &AccessConditions{
+				ModifiedAccessConditions: &ModifiedAccessConditions{IfMatch: dr.ETag},
+			}
+		} else if o.AccessConditions.ModifiedAccessConditions == nil {
+			o.AccessConditions.ModifiedAccessConditions = &ModifiedAccessConditions{IfMatch: dr.ETag}
+		} else if o.AccessConditions.ModifiedAccessConditions.IfMatch == nil {
+			o.AccessConditions.ModifiedAccessConditions.IfMatch = dr.ETag
+		}
+	}
+
+	var initialChunkSize int64
+	if dr.ContentRange != nil {
+		initialChunkSize = parseContentRangeLength(*dr.ContentRange)
+	} else if dr.ContentLength != nil {
+		initialChunkSize = *dr.ContentLength
+	}
+	if initialChunkSize <= 0 {
+		dr.Body.Close()
+		return 0, nil
+	}
+
+	progress := int64(0)
+	progressLock := &sync.Mutex{}
+	var body io.ReadCloser = dr.NewRetryReader(ctx, &o.RetryReaderOptionsPerBlock)
+	if o.Progress != nil {
+		body = streaming.NewResponseProgress(body, func(bytesTransferred int64) {
+			progressLock.Lock()
+			progress = bytesTransferred
+			o.Progress(progress)
+			progressLock.Unlock()
+		})
+	}
+	_, err = io.Copy(shared.NewSectionWriter(writer, 0, initialChunkSize), body)
+	if err != nil {
+		body.Close()
+		return 0, err
+	}
+	if err = body.Close(); err != nil {
+		return 0, err
+	}
+
+	initialDataLen := initialChunkSize
+	if dr.StructuredBodyType != nil && *dr.StructuredBodyType != "" && dr.ContentRange != nil {
+		initialDataLen = parseContentRangeLength(*dr.ContentRange)
+	}
+
+	if initialChunkSize >= count {
+		return initialDataLen, nil
+	}
+
+	remaining := count - initialChunkSize
+	remainingDownloaded, err := b.parallelDownloadFrom(ctx, writer, o, initialChunkSize, remaining, &progress, progressLock)
+	if err != nil {
+		return 0, err
+	}
+	return initialDataLen + remainingDownloaded, nil
+}
+
+func (b *Client) parallelDownload(ctx context.Context, writer io.WriterAt, o downloadOptions, count int64) (int64, error) {
+	dataDownloaded := int64(0)
 	progress := int64(0)
 	progressLock := &sync.Mutex{}
 
@@ -373,43 +452,76 @@ func (b *Client) downloadBuffer(ctx context.Context, writer io.WriterAt, o downl
 		NumChunks:     uint64(((count - 1) / o.BlockSize) + 1),
 		Concurrency:   o.Concurrency,
 		Operation: func(ctx context.Context, chunkStart int64, count int64) error {
-			downloadBlobOptions := o.getDownloadBlobOptions(HTTPRange{
-				Offset: chunkStart + o.Range.Offset,
-				Count:  count,
-			}, nil)
-			dr, err := b.DownloadStream(ctx, downloadBlobOptions)
+			dr, err := b.DownloadStream(ctx, o.getDownloadBlobOptions(HTTPRange{
+				Offset: chunkStart + o.Range.Offset, Count: count}, nil))
 			if err != nil {
 				return err
 			}
 			var body io.ReadCloser = dr.NewRetryReader(ctx, &o.RetryReaderOptionsPerBlock)
 			if o.Progress != nil {
 				rangeProgress := int64(0)
-				body = streaming.NewResponseProgress(
-					body,
-					func(bytesTransferred int64) {
-						diff := bytesTransferred - rangeProgress
-						rangeProgress = bytesTransferred
-						progressLock.Lock()
-						progress += diff
-						o.Progress(progress)
-						progressLock.Unlock()
-					})
+				body = streaming.NewResponseProgress(body, func(bytesTransferred int64) {
+					diff := bytesTransferred - rangeProgress
+					rangeProgress = bytesTransferred
+					progressLock.Lock()
+					progress += diff
+					o.Progress(progress)
+					progressLock.Unlock()
+				})
 			}
-			_, err = io.Copy(shared.NewSectionWriter(writer, chunkStart, count), body)
+			if _, err = io.Copy(shared.NewSectionWriter(writer, chunkStart, count), body); err != nil {
+				return err
+			}
+			if dr.StructuredBodyType != nil && *dr.StructuredBodyType != "" && dr.ContentRange != nil {
+				atomic.AddInt64(&dataDownloaded, parseContentRangeLength(*dr.ContentRange))
+			} else {
+				atomic.AddInt64(&dataDownloaded, *dr.ContentLength)
+			}
+			return body.Close()
+		},
+	})
+	if err != nil {
+		return 0, err
+	}
+	return dataDownloaded, nil
+}
+
+func (b *Client) parallelDownloadFrom(ctx context.Context, writer io.WriterAt, o downloadOptions, writerOffset int64, remaining int64, progress *int64, progressLock *sync.Mutex) (int64, error) {
+	dataDownloaded := int64(0)
+
+	err := shared.DoBatchTransfer(ctx, &shared.BatchTransferOptions{
+		OperationName: "downloadBlobToWriterAt",
+		TransferSize:  remaining,
+		ChunkSize:     o.BlockSize,
+		NumChunks:     uint64(((remaining - 1) / o.BlockSize) + 1),
+		Concurrency:   o.Concurrency,
+		Operation: func(ctx context.Context, chunkStart int64, count int64) error {
+			dr, err := b.DownloadStream(ctx, o.getDownloadBlobOptions(HTTPRange{
+				Offset: chunkStart + writerOffset + o.Range.Offset, Count: count}, nil))
 			if err != nil {
 				return err
 			}
-			if computeReadLength {
-				if dr.StructuredBodyType != nil && *dr.StructuredBodyType != "" && dr.ContentRange != nil {
-					// For structured message responses, ContentLength reflects the encoded size.
-					// Use ContentRange to get the original data length.
-					atomic.AddInt64(&dataDownloaded, parseContentRangeLength(*dr.ContentRange))
-				} else {
-					atomic.AddInt64(&dataDownloaded, *dr.ContentLength)
-				}
+			var body io.ReadCloser = dr.NewRetryReader(ctx, &o.RetryReaderOptionsPerBlock)
+			if o.Progress != nil {
+				rangeProgress := int64(0)
+				body = streaming.NewResponseProgress(body, func(bytesTransferred int64) {
+					diff := bytesTransferred - rangeProgress
+					rangeProgress = bytesTransferred
+					progressLock.Lock()
+					*progress += diff
+					o.Progress(*progress)
+					progressLock.Unlock()
+				})
 			}
-			err = body.Close()
-			return err
+			if _, err = io.Copy(shared.NewSectionWriter(writer, chunkStart+writerOffset, count), body); err != nil {
+				return err
+			}
+			if dr.StructuredBodyType != nil && *dr.StructuredBodyType != "" && dr.ContentRange != nil {
+				atomic.AddInt64(&dataDownloaded, parseContentRangeLength(*dr.ContentRange))
+			} else {
+				atomic.AddInt64(&dataDownloaded, *dr.ContentLength)
+			}
+			return body.Close()
 		},
 	})
 	if err != nil {
@@ -431,8 +543,6 @@ func (b *Client) DownloadStream(ctx context.Context, o *DownloadStreamOptions) (
 		return DownloadStreamResponse{}, err
 	}
 
-	// If the response contains a structured message body, wrap it with SMDecoder
-	// to validate CRC64 checksums and extract the raw data.
 	if dr.StructuredBodyType != nil && *dr.StructuredBodyType != "" {
 		dr.Body = shared.NewSMDecoder(dr.Body)
 	}
@@ -464,39 +574,24 @@ func (b *Client) DownloadFile(ctx context.Context, file *os.File, o *DownloadFil
 	}
 	do := (*downloadOptions)(o)
 
-	// 1. Calculate the size of the destination file
-	var size int64
-
-	count := do.Range.Count
-	if count == CountToEnd {
-		// Try to get Azure blob's size
-		getBlobPropertiesOptions := do.getBlobPropertiesOptions()
-		props, err := b.GetProperties(ctx, getBlobPropertiesOptions)
-		if err != nil {
-			return 0, err
-		}
-		size = *props.ContentLength - do.Range.Offset
-		do.Range.Count = size
-	} else {
-		size = count
-	}
-
-	// 2. Compare and try to resize local file's size if it doesn't match Azure blob's size.
-	stat, err := file.Stat()
+	downloaded, err := b.downloadBuffer(ctx, file, *do)
 	if err != nil {
 		return 0, err
 	}
-	if stat.Size() != size {
-		if err = file.Truncate(size); err != nil {
-			return 0, err
+
+	if downloaded > 0 {
+		stat, err := file.Stat()
+		if err != nil {
+			return downloaded, err
+		}
+		if stat.Size() != downloaded {
+			if err = file.Truncate(downloaded); err != nil {
+				return downloaded, err
+			}
 		}
 	}
 
-	if size > 0 {
-		return b.downloadBuffer(ctx, file, *do)
-	} else { // if the blob's size is 0, there is no need in downloading it
-		return 0, nil
-	}
+	return downloaded, nil
 }
 
 // parseContentRangeLength parses the range length from a Content-Range header value.
@@ -508,4 +603,12 @@ func parseContentRangeLength(contentRange string) int64 {
 		return 0
 	}
 	return end - start + 1
+}
+
+func parseContentRangeTotal(contentRange string) int64 {
+	var start, end, total int64
+	if _, err := fmt.Sscanf(contentRange, "bytes %d-%d/%d", &start, &end, &total); err != nil {
+		return 0
+	}
+	return total
 }

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -4290,20 +4290,36 @@ func (s *BlobRecordedTestsSuite) TestBlobClientCustomAudience() {
 
 type fakeDownloadBlob struct {
 	contentSize int64
-	numChunks   uint64
+	numGets     uint64
 }
 
 // nolint
 func (f *fakeDownloadBlob) Do(req *http.Request) (*http.Response, error) {
-	// check how many times range based get blob is called
-	if _, ok := req.Header["x-ms-range"]; ok {
-		atomic.AddUint64(&f.numChunks, 1)
+	atomic.AddUint64(&f.numGets, 1)
+
+	if rangeValues, ok := req.Header["x-ms-range"]; ok && len(rangeValues) > 0 {
+		var start, end int64
+		fmt.Sscanf(rangeValues[0], "bytes=%d-%d", &start, &end)
+		if end >= f.contentSize {
+			end = f.contentSize - 1
+		}
+		chunkLen := end - start + 1
+		return &http.Response{
+			Request:    req,
+			Status:     "Partial Content",
+			StatusCode: http.StatusPartialContent,
+			Header: http.Header{
+				"Content-Length": []string{fmt.Sprintf("%d", chunkLen)},
+				"Content-Range":  []string{fmt.Sprintf("bytes %d-%d/%d", start, end, f.contentSize)},
+			},
+			Body: http.NoBody,
+		}, nil
 	}
 	return &http.Response{
 		Request:    req,
-		Status:     "Created",
+		Status:     "OK",
 		StatusCode: http.StatusOK,
-		Header:     http.Header{"Content-Length": []string{fmt.Sprintf("%v", f.contentSize)}},
+		Header:     http.Header{"Content-Length": []string{fmt.Sprintf("%d", f.contentSize)}},
 		Body:       http.NoBody,
 	}, nil
 }
@@ -4314,38 +4330,50 @@ func TestDownloadSmallBlockSize(t *testing.T) {
 	fileSize := int64(100 * 1024 * 1024)
 	blockSize := int64(1024)
 	numChunks := uint64(((fileSize - 1) / blockSize) + 1)
-	fbb := &fakeDownloadBlob{
-		contentSize: fileSize,
-	}
+	fbb := &fakeDownloadBlob{contentSize: fileSize}
 
-	log.SetListener(nil) // no logging
+	log.SetListener(nil)
 
 	blobClient, err := blockblob.NewClientWithNoCredential("https://fake/blob/path", &blockblob.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Transport: fbb,
-		},
+		ClientOptions: policy.ClientOptions{Transport: fbb},
 	})
 	_require.NoError(err)
 	_require.NotNil(blobClient)
 
-	// download to a temp file and verify contents
 	tmp, err := os.CreateTemp("", "")
 	_require.NoError(err)
 	defer func() { _ = tmp.Close() }()
 
 	_, err = blobClient.DownloadFile(context.Background(), tmp, &blob.DownloadFileOptions{BlockSize: blockSize})
 	_require.NoError(err)
+	_require.Equal(numChunks, atomic.LoadUint64(&fbb.numGets))
 
-	_require.Equal(atomic.LoadUint64(&fbb.numChunks), numChunks)
-
-	// reset counter
-	atomic.StoreUint64(&fbb.numChunks, 0)
+	atomic.StoreUint64(&fbb.numGets, 0)
 
 	buff := make([]byte, fileSize)
 	_, err = blobClient.DownloadBuffer(context.Background(), buff, &blob.DownloadBufferOptions{BlockSize: blockSize})
 	_require.NoError(err)
+	_require.Equal(numChunks, atomic.LoadUint64(&fbb.numGets))
+}
 
-	_require.Equal(atomic.LoadUint64(&fbb.numChunks), numChunks)
+func TestDownloadSmallBlobSkipsParallelRequests(t *testing.T) {
+	_require := require.New(t)
+
+	fileSize := int64(512)
+	fbb := &fakeDownloadBlob{contentSize: fileSize}
+
+	log.SetListener(nil)
+
+	blobClient, err := blockblob.NewClientWithNoCredential("https://fake/blob/path", &blockblob.ClientOptions{
+		ClientOptions: policy.ClientOptions{Transport: fbb},
+	})
+	_require.NoError(err)
+
+	buff := make([]byte, fileSize)
+	n, err := blobClient.DownloadBuffer(context.Background(), buff, nil)
+	_require.NoError(err)
+	_require.Equal(fileSize, n)
+	_require.Equal(uint64(1), atomic.LoadUint64(&fbb.numGets))
 }
 
 func (s *BlobRecordedTestsSuite) TestGetSetTagsWithBlobModifiedAccessConditions() {

--- a/sdk/storage/azblob/blob/client_test.go
+++ b/sdk/storage/azblob/blob/client_test.go
@@ -4297,6 +4297,8 @@ type fakeDownloadBlob struct {
 func (f *fakeDownloadBlob) Do(req *http.Request) (*http.Response, error) {
 	atomic.AddUint64(&f.numGets, 1)
 
+	etag := `"test-etag-12345"`
+
 	if rangeValues, ok := req.Header["x-ms-range"]; ok && len(rangeValues) > 0 {
 		var start, end int64
 		fmt.Sscanf(rangeValues[0], "bytes=%d-%d", &start, &end)
@@ -4304,6 +4306,10 @@ func (f *fakeDownloadBlob) Do(req *http.Request) (*http.Response, error) {
 			end = f.contentSize - 1
 		}
 		chunkLen := end - start + 1
+		body := make([]byte, chunkLen)
+		for i := int64(0); i < chunkLen; i++ {
+			body[i] = byte((start + i) % 251)
+		}
 		return &http.Response{
 			Request:    req,
 			Status:     "Partial Content",
@@ -4311,16 +4317,24 @@ func (f *fakeDownloadBlob) Do(req *http.Request) (*http.Response, error) {
 			Header: http.Header{
 				"Content-Length": []string{fmt.Sprintf("%d", chunkLen)},
 				"Content-Range":  []string{fmt.Sprintf("bytes %d-%d/%d", start, end, f.contentSize)},
+				"Etag":           []string{etag},
 			},
-			Body: http.NoBody,
+			Body: io.NopCloser(bytes.NewReader(body)),
 		}, nil
+	}
+	body := make([]byte, f.contentSize)
+	for i := int64(0); i < f.contentSize; i++ {
+		body[i] = byte(i % 251)
 	}
 	return &http.Response{
 		Request:    req,
 		Status:     "OK",
 		StatusCode: http.StatusOK,
-		Header:     http.Header{"Content-Length": []string{fmt.Sprintf("%d", f.contentSize)}},
-		Body:       http.NoBody,
+		Header: http.Header{
+			"Content-Length": []string{fmt.Sprintf("%d", f.contentSize)},
+			"Etag":           []string{etag},
+		},
+		Body: io.NopCloser(bytes.NewReader(body)),
 	}, nil
 }
 
@@ -4374,6 +4388,81 @@ func TestDownloadSmallBlobSkipsParallelRequests(t *testing.T) {
 	_require.NoError(err)
 	_require.Equal(fileSize, n)
 	_require.Equal(uint64(1), atomic.LoadUint64(&fbb.numGets))
+
+	for i := int64(0); i < fileSize; i++ {
+		_require.Equal(byte(i%251), buff[i], "data mismatch at offset %d", i)
+	}
+}
+
+func TestDownloadETagConsistency(t *testing.T) {
+	_require := require.New(t)
+
+	fileSize := int64(10 * 1024 * 1024) // 10MB → 3 chunks at 4MB default
+	blockSize := int64(4 * 1024 * 1024)
+	fbb := &fakeDownloadBlobWithETagCheck{contentSize: fileSize}
+
+	log.SetListener(nil)
+
+	blobClient, err := blockblob.NewClientWithNoCredential("https://fake/blob/path", &blockblob.ClientOptions{
+		ClientOptions: policy.ClientOptions{Transport: fbb},
+	})
+	_require.NoError(err)
+
+	buff := make([]byte, fileSize)
+	_, err = blobClient.DownloadBuffer(context.Background(), buff, &blob.DownloadBufferOptions{BlockSize: blockSize})
+	_require.NoError(err)
+
+	totalGets := atomic.LoadUint64(&fbb.numGets)
+	ifMatchCount := atomic.LoadUint64(&fbb.numIfMatch)
+	_require.Equal(uint64(3), totalGets)
+	_require.Equal(uint64(2), ifMatchCount, "follow-up requests should carry If-Match from initial response")
+}
+
+type fakeDownloadBlobWithETagCheck struct {
+	contentSize int64
+	numGets     uint64
+	numIfMatch  uint64
+}
+
+// nolint
+func (f *fakeDownloadBlobWithETagCheck) Do(req *http.Request) (*http.Response, error) {
+	atomic.AddUint64(&f.numGets, 1)
+
+	if req.Header.Get("If-Match") != "" {
+		atomic.AddUint64(&f.numIfMatch, 1)
+	}
+
+	etag := `"etag-consistency-test"`
+
+	if rangeValues, ok := req.Header["x-ms-range"]; ok && len(rangeValues) > 0 {
+		var start, end int64
+		fmt.Sscanf(rangeValues[0], "bytes=%d-%d", &start, &end)
+		if end >= f.contentSize {
+			end = f.contentSize - 1
+		}
+		chunkLen := end - start + 1
+		return &http.Response{
+			Request:    req,
+			Status:     "Partial Content",
+			StatusCode: http.StatusPartialContent,
+			Header: http.Header{
+				"Content-Length": []string{fmt.Sprintf("%d", chunkLen)},
+				"Content-Range":  []string{fmt.Sprintf("bytes %d-%d/%d", start, end, f.contentSize)},
+				"Etag":           []string{etag},
+			},
+			Body: http.NoBody,
+		}, nil
+	}
+	return &http.Response{
+		Request:    req,
+		Status:     "OK",
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Length": []string{fmt.Sprintf("%d", f.contentSize)},
+			"Etag":           []string{etag},
+		},
+		Body: http.NoBody,
+	}, nil
 }
 
 func (s *BlobRecordedTestsSuite) TestGetSetTagsWithBlobModifiedAccessConditions() {

--- a/sdk/storage/azblob/blob/models.go
+++ b/sdk/storage/azblob/blob/models.go
@@ -155,16 +155,6 @@ type downloadOptions struct {
 	TransactionalValidation TransferValidationType
 }
 
-func (o *downloadOptions) getBlobPropertiesOptions() *GetPropertiesOptions {
-	if o == nil {
-		return nil
-	}
-	return &GetPropertiesOptions{
-		AccessConditions: o.AccessConditions,
-		CPKInfo:          o.CPKInfo,
-	}
-}
-
 func (o *downloadOptions) getDownloadBlobOptions(rnge HTTPRange, rangeGetContentMD5 *bool) *DownloadStreamOptions {
 	if o == nil {
 		return nil

--- a/sdk/storage/azblob/blob/utils_test.go
+++ b/sdk/storage/azblob/blob/utils_test.go
@@ -10,6 +10,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestParseContentRangeTotal(t *testing.T) {
+	require.Equal(t, int64(1000), parseContentRangeTotal("bytes 0-999/1000"))
+	require.Equal(t, int64(5000000), parseContentRangeTotal("bytes 0-4194303/5000000"))
+	require.Equal(t, int64(100), parseContentRangeTotal("bytes 50-99/100"))
+	require.Equal(t, int64(0), parseContentRangeTotal("invalid"))
+	require.Equal(t, int64(0), parseContentRangeTotal(""))
+}
+
+func TestParseContentRangeLength(t *testing.T) {
+	require.Equal(t, int64(1000), parseContentRangeLength("bytes 0-999/1000"))
+	require.Equal(t, int64(4194304), parseContentRangeLength("bytes 0-4194303/5000000"))
+	require.Equal(t, int64(50), parseContentRangeLength("bytes 50-99/100"))
+	require.Equal(t, int64(0), parseContentRangeLength("invalid"))
+}
+
 func TestDeserializeORSPolicies(t *testing.T) {
 
 	headers := map[string]*string{

--- a/sdk/storage/azblob/blockblob/client_test.go
+++ b/sdk/storage/azblob/blockblob/client_test.go
@@ -1913,7 +1913,9 @@ func (s *BlockBlobRecordedTestsSuite) TestPutBlobFromURLCopySourceAuth() {
 
 	// Download data from destination
 	destBuffer := make([]byte, 4*1024)
-	_, err = srcBBClient.DownloadBuffer(context.Background(), destBuffer, nil)
+	_, err = srcBBClient.DownloadBuffer(context.Background(), destBuffer, &blob.DownloadBufferOptions{
+		Range: blob.HTTPRange{Count: int64(contentSize)},
+	})
 	_require.NoError(err)
 	_require.Equal(destBuffer, sourceData)
 


### PR DESCRIPTION
## Summary
- Replace the `GetProperties` (HEAD) call in `DownloadBuffer`/`DownloadFile` with an initial `GetBlob` (GET) request to determine blob size
- For small blobs (<=4MB default block size), the entire content is returned in the initial response - no parallel requests needed, eliminating one full round trip
- For larger blobs, the first chunk is consumed from the initial response and remaining chunks are downloaded in parallel with ETag locking for consistency
- Handle empty blobs (0 bytes) gracefully

## Test plan
- [x] Unit tests added
- [x] Live data integrity: SHA-256 verified for 0B, 1B, 1KB, 16KB, 4MB, 4MB+1, 8MB, 32MB, 64MB, 128MB (both DownloadBuffer and DownloadFile)
- [x] Live range downloads: full blob, first-100-bytes, middle-1KB, last-100-bytes, first-half, second-half
- [x] Live block size variations: 1MB, 2MB, 4MB, 5MB, 10MB, 20MB blocks on 10MB blob
- [x] Live concurrency levels: 1, 2, 4, 8, 16 on 16MB blob