### PR TITLE
docs: fix typos in development and migration guides

### DIFF
--- a/documentation/development/ARM/new-version-guideline.md
+++ b/documentation/development/ARM/new-version-guideline.md
@@ -101,7 +101,7 @@ if err != nil {
 
 ### Synchronized wrapper
 
-If you do not care about the underlaying detail about the LRO, you can use the following generic utility to create an synchronized wrapper for all LRO.
+If you do not care about the underlying detail about the LRO, you can use the following generic utility to create an synchronized wrapper for all LRO.
 
 > NOTE: The error return of `Wait` includes the error of starting LRO and error of interval polling. Also, the wrapper will hide the `poller` which means you cannot recovery from an LRO accidentally interrupt. 
 

--- a/documentation/development/breaking-changes/sdk-breaking-changes-guide-migration.md
+++ b/documentation/development/breaking-changes/sdk-breaking-changes-guide-migration.md
@@ -637,7 +637,7 @@ Type change for ETag fields from `*string` to `*azcore.ETag`:
 
 **Reason**: During TypeSpec migration, ETag fields are emitted using the strongly-typed `azcore.ETag` instead of a plain `*string`.
 
-**Impact**: Low impact since underlaying type of `azure.Etag` is `string`.
+**Impact**: Low impact since underlying type of `azure.Etag` is `string`.
 
 **Resolution**: Accept these breaking changes.
 

--- a/sdk/monitor/query/MIGRATION.md
+++ b/sdk/monitor/query/MIGRATION.md
@@ -62,7 +62,7 @@ func main() {
 
 ### `azlogs`
 
-The logs code for `azlogs` and `azquery` are very similiar. 
+The logs code for `azlogs` and `azquery` are very similar. 
 
 ```go
 import (


### PR DESCRIPTION
Three typo fixes in hand-written documentation:

- `documentation/development/ARM/new-version-guideline.md:104` — `underlaying` → `underlying`
- `documentation/development/breaking-changes/sdk-breaking-changes-guide-migration.md:640` — `underlaying` → `underlying`
- `sdk/monitor/query/MIGRATION.md:65` — `similiar` → `similar`

### Deliberately not included

Two other occurrences turned up that I left alone:

- `eng/common/TestResources/New-TestResources.ps1.md` (`overriden`) — `eng/common/` is synced from `azure-sdk-tools`, so a fix here would be overwritten; it belongs upstream.
- `sdk/resourcemanager/computeschedule/armcomputeschedule/README.md` (`occured`) — a generated module README, where the text likely originates from the service's swagger description rather than this repo.

Happy to follow up on either if you'd like them handled at the right source.
