### PR TITLE
fix(azservicebus): recover connection-scoped not-allowed errors

### DIFF
--- a/sdk/messaging/azservicebus/internal/amqpLinks.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks.go
@@ -451,7 +451,11 @@ func (links *AMQPLinksImpl) closeIfNeeded(ctx context.Context, err error, lastID
 	case RecoveryKindConn:
 		links.Writef(exported.EventConn, "Closing connection AND links for error %s", err.Error())
 		_ = links.closeWithoutLocking(ctx, false)
-		_ = links.ns.Close(false)
+		if lastID != nil {
+			_ = links.ns.CloseIfNeeded(lastID.Conn)
+		} else {
+			_ = links.ns.Close(false)
+		}
 		return rk
 	case RecoveryKindNone:
 		return rk

--- a/sdk/messaging/azservicebus/internal/amqpLinks.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks.go
@@ -337,7 +337,7 @@ func (links *AMQPLinksImpl) Retry(ctx context.Context, eventName azlog.Event, op
 		return links.getRecoveryKindFunc(err) == RecoveryKindFatal
 	}
 
-	return utils.Retry(ctx, eventName, links.Prefix()+"("+operation+")", func(ctx context.Context, args *utils.RetryFnArgs) error {
+	err := utils.Retry(ctx, eventName, links.Prefix()+"("+operation+")", func(ctx context.Context, args *utils.RetryFnArgs) error {
 		if err := links.RecoverIfNeeded(ctx, lastID, args.LastErr); err != nil {
 			return err
 		}
@@ -380,6 +380,15 @@ func (links *AMQPLinksImpl) Retry(ctx context.Context, eventName azlog.Event, op
 
 		return nil
 	}, isFatalErrorFunc, o)
+
+	if err != nil {
+		switch links.getRecoveryKindFunc(err) {
+		case RecoveryKindLink, RecoveryKindConn:
+			links.CloseIfNeeded(context.Background(), err)
+		}
+	}
+
+	return err
 }
 
 // EntityPath is the full entity path for the queue/topic/subscription.

--- a/sdk/messaging/azservicebus/internal/amqpLinks.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks.go
@@ -384,7 +384,7 @@ func (links *AMQPLinksImpl) Retry(ctx context.Context, eventName azlog.Event, op
 	if err != nil {
 		switch links.getRecoveryKindFunc(err) {
 		case RecoveryKindLink, RecoveryKindConn:
-			links.CloseIfNeeded(context.Background(), err)
+			links.closeIfNeeded(context.Background(), err, &lastID)
 		}
 	}
 
@@ -422,8 +422,16 @@ func (l *AMQPLinksImpl) Close(ctx context.Context, permanent bool) error {
 // if you're trying to exit out of a function quickly but still need to react
 // to a returned error.
 func (links *AMQPLinksImpl) CloseIfNeeded(ctx context.Context, err error) RecoveryKind {
+	return links.closeIfNeeded(ctx, err, nil)
+}
+
+func (links *AMQPLinksImpl) closeIfNeeded(ctx context.Context, err error, lastID *LinkID) RecoveryKind {
 	links.mu.Lock()
 	defer links.mu.Unlock()
+
+	if lastID != nil && links.id != *lastID {
+		return RecoveryKindNone
+	}
 
 	if IsCancelError(err) {
 		links.Writef(exported.EventConn, "No close needed for cancellation")

--- a/sdk/messaging/azservicebus/internal/amqpLinks_test.go
+++ b/sdk/messaging/azservicebus/internal/amqpLinks_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/amqpwrap"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/exported"
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/mock/emulation"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/test"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/utils"
 	"github.com/Azure/go-amqp"
@@ -634,6 +635,42 @@ func TestAMQPLinksRetry(t *testing.T) {
 	var connErr *amqp.ConnError
 	require.ErrorAs(t, err, &connErr)
 	require.EqualValues(t, 3, createLinksCalled)
+}
+
+func TestAMQPLinksRetrySkipsStaleNamespaceCleanup(t *testing.T) {
+	createLinkFn := func(ctx context.Context, session amqpwrap.AMQPSession) (amqpwrap.AMQPSenderCloser, amqpwrap.AMQPReceiverCloser, error) {
+		return newLinksForAMQPLinksTest("entity path", session)
+	}
+
+	md, links, ns, cleanup := newAMQPLinksForTest(t, emulation.MockDataOptions{}, createLinkFn)
+	defer cleanup()
+
+	links2 := NewAMQPLinks(NewAMQPLinksArgs{
+		NS:                  ns,
+		EntityPath:          "entity path",
+		CreateLinkFunc:      createLinkFn,
+		GetRecoveryKindFunc: GetRecoveryKind,
+	}).(*AMQPLinksImpl)
+	defer test.RequireLinksClose(t, links2)
+
+	lwid2, err := links2.Get(context.Background())
+	require.NoError(t, err)
+	require.EqualValues(t, 1, lwid2.ID.Conn)
+
+	err = links.Retry(context.Background(), exported.EventConn, "Test", func(ctx context.Context, lwid *LinksWithID, args *utils.RetryFnArgs) error {
+		require.NoError(t, links2.RecoverIfNeeded(ctx, lwid2.ID, &amqp.ConnError{}))
+		return &amqp.ConnError{}
+	}, exported.RetryOptions{MaxRetries: -1})
+
+	var connErr *amqp.ConnError
+	require.ErrorAs(t, err, &connErr)
+
+	ns.clientMu.RLock()
+	client, connID := ns.client, ns.connID
+	ns.clientMu.RUnlock()
+	require.NotNil(t, client)
+	require.EqualValues(t, 2, connID)
+	require.Len(t, md.Events.GetOpenConns(), 1)
 }
 
 func TestAMQPLinksMultipleWithSameConnection(t *testing.T) {

--- a/sdk/messaging/azservicebus/internal/amqp_test_utils.go
+++ b/sdk/messaging/azservicebus/internal/amqp_test_utils.go
@@ -287,6 +287,14 @@ func (ns *FakeNS) Close(permanently bool) error {
 	return nil
 }
 
+func (ns *FakeNS) CloseIfNeeded(clientRevision uint64) error {
+	if clientRevision == ns.recovered+100 {
+		ns.CloseCalled++
+	}
+
+	return nil
+}
+
 func (ns *FakeNS) Check() error {
 	return nil
 }

--- a/sdk/messaging/azservicebus/internal/amqplinks_unit_test.go
+++ b/sdk/messaging/azservicebus/internal/amqplinks_unit_test.go
@@ -98,6 +98,45 @@ func TestAMQPLinksRetriesUnit(t *testing.T) {
 	}
 }
 
+func TestAMQPLinksRetrySkipsStaleCleanup(t *testing.T) {
+	ns := &FakeNS{}
+	var receivers []*FakeAMQPReceiver
+
+	links := NewAMQPLinks(NewAMQPLinksArgs{
+		NS:         ns,
+		EntityPath: "entityPath",
+		CreateLinkFunc: func(ctx context.Context, session amqpwrap.AMQPSession) (amqpwrap.AMQPSenderCloser, amqpwrap.AMQPReceiverCloser, error) {
+			receiver := &FakeAMQPReceiver{}
+			receivers = append(receivers, receiver)
+			return &FakeAMQPSender{}, receiver, nil
+		},
+		GetRecoveryKindFunc: GetRecoveryKind,
+	}).(*AMQPLinksImpl)
+
+	defer func() {
+		require.NoError(t, links.Close(context.Background(), true))
+	}()
+
+	var recoveryErr error
+	err := links.Retry(context.Background(), log.Event("NotUsed"), "OverallOperation", func(ctx context.Context, lwid *LinksWithID, args *utils.RetryFnArgs) error {
+		recoveryDone := make(chan struct{})
+		go func() {
+			recoveryErr = links.RecoverIfNeeded(ctx, lwid.ID, &amqp.ConnError{})
+			close(recoveryDone)
+		}()
+		<-recoveryDone
+
+		return &amqp.ConnError{}
+	}, exported.RetryOptions{MaxRetries: -1})
+
+	var connErr *amqp.ConnError
+	require.ErrorAs(t, err, &connErr)
+	require.NoError(t, recoveryErr)
+	require.Len(t, receivers, 2)
+	require.Equal(t, 1, receivers[0].Closed)
+	require.Equal(t, 0, receivers[1].Closed)
+}
+
 func TestAMQPLinks_Logging(t *testing.T) {
 	t.Run("link", func(t *testing.T) {
 		receiver := &FakeAMQPReceiver{}

--- a/sdk/messaging/azservicebus/internal/errors.go
+++ b/sdk/messaging/azservicebus/internal/errors.go
@@ -223,6 +223,11 @@ func GetRecoveryKind(err error) RecoveryKind {
 		return RecoveryKindFatal
 	}
 
+	var connErr *amqp.ConnError
+	if errors.As(err, &connErr) && connErr.RemoteErr != nil && connErr.RemoteErr.Condition == amqp.ErrCondNotAllowed {
+		return RecoveryKindConn
+	}
+
 	// check the AMQP condition first since it's usually more specific than just knowing it came
 	// from a link, or a connection.
 	if amqpError := (*amqp.Error)(nil); errors.As(err, &amqpError) {
@@ -239,7 +244,6 @@ func GetRecoveryKind(err error) RecoveryKind {
 		return RecoveryKindLink
 	}
 
-	var connErr *amqp.ConnError
 	var sessionErr *amqp.SessionError
 
 	if errors.As(err, &connErr) ||

--- a/sdk/messaging/azservicebus/internal/errors_test.go
+++ b/sdk/messaging/azservicebus/internal/errors_test.go
@@ -153,6 +153,14 @@ func Test_IsNonRetriable(t *testing.T) {
 	}
 }
 
+func TestGetRecoveryKind_NotAllowedWrapperScope(t *testing.T) {
+	remoteErr := &amqp.Error{Condition: amqp.ErrCondNotAllowed}
+
+	require.Equal(t, RecoveryKindFatal, GetRecoveryKind(&amqp.Error{Condition: amqp.ErrCondNotAllowed}))
+	require.Equal(t, RecoveryKindFatal, GetRecoveryKind(&amqp.LinkError{RemoteErr: remoteErr}))
+	require.Equal(t, RecoveryKindConn, GetRecoveryKind(&amqp.ConnError{RemoteErr: remoteErr}))
+}
+
 func Test_ServiceBusError_NoRecoveryNeeded(t *testing.T) {
 	var tempErrors = []error{
 		&amqp.Error{Condition: amqp.ErrCond("com.microsoft:server-busy")},

--- a/sdk/messaging/azservicebus/internal/mock/mock_namespace.go
+++ b/sdk/messaging/azservicebus/internal/mock/mock_namespace.go
@@ -67,6 +67,20 @@ func (mr *MockNamespaceForAMQPLinksMockRecorder) Close(permanently interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockNamespaceForAMQPLinks)(nil).Close), permanently)
 }
 
+// CloseIfNeeded mocks base method.
+func (m *MockNamespaceForAMQPLinks) CloseIfNeeded(clientRevision uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloseIfNeeded", clientRevision)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CloseIfNeeded indicates an expected call of CloseIfNeeded.
+func (mr *MockNamespaceForAMQPLinksMockRecorder) CloseIfNeeded(clientRevision interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseIfNeeded", reflect.TypeOf((*MockNamespaceForAMQPLinks)(nil).CloseIfNeeded), clientRevision)
+}
+
 // GetEntityAudience mocks base method.
 func (m *MockNamespaceForAMQPLinks) GetEntityAudience(entityPath string) string {
 	m.ctrl.T.Helper()

--- a/sdk/messaging/azservicebus/internal/namespace.go
+++ b/sdk/messaging/azservicebus/internal/namespace.go
@@ -86,6 +86,9 @@ type NamespaceForAMQPLinks interface {
 	// connection - the previous connection is always closed.
 	Recover(ctx context.Context, clientRevision uint64) (bool, error)
 
+	// CloseIfNeeded closes the current AMQP connection if it has the given revision.
+	CloseIfNeeded(clientRevision uint64) error
+
 	Close(permanently bool) error
 }
 
@@ -267,6 +270,24 @@ func (ns *Namespace) NewRPCLink(ctx context.Context, managementPath string) (amq
 func (ns *Namespace) Close(permanently bool) error {
 	ns.clientMu.Lock()
 	defer ns.clientMu.Unlock()
+
+	return ns.closeWithoutLocking(permanently)
+}
+
+// CloseIfNeeded closes the current cached client if it has the given revision.
+func (ns *Namespace) CloseIfNeeded(clientRevision uint64) error {
+	ns.clientMu.Lock()
+	defer ns.clientMu.Unlock()
+
+	if ns.connID != clientRevision {
+		log.Writef(exported.EventConn, "Skipping connection close, already recovered: %d vs %d", ns.connID, clientRevision)
+		return nil
+	}
+
+	return ns.closeWithoutLocking(false)
+}
+
+func (ns *Namespace) closeWithoutLocking(permanently bool) error {
 
 	if permanently {
 		ns.closedPermanently = true

--- a/sdk/messaging/azservicebus/internal/utils/retrier.go
+++ b/sdk/messaging/azservicebus/internal/utils/retrier.go
@@ -125,7 +125,7 @@ func calcDelay(o exported.RetryOptions, try int32) time.Duration { // try is >=1
 	}
 
 	delay := factor * o.RetryDelay
-	if o.RetryDelay > 0 && delay/o.RetryDelay != factor {
+	if delay < factor {
 		// overflow has happened so set to max value
 		delay = time.Duration(math.MaxInt64)
 	}

--- a/sdk/messaging/azservicebus/internal/utils/retrier.go
+++ b/sdk/messaging/azservicebus/internal/utils/retrier.go
@@ -125,7 +125,7 @@ func calcDelay(o exported.RetryOptions, try int32) time.Duration { // try is >=1
 	}
 
 	delay := factor * o.RetryDelay
-	if delay < factor {
+	if o.RetryDelay > 0 && delay/o.RetryDelay != factor {
 		// overflow has happened so set to max value
 		delay = time.Duration(math.MaxInt64)
 	}

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -62,6 +62,7 @@ type Receiver struct {
 	mu                       sync.Mutex
 	receiveMode              ReceiveMode
 	receiving                bool
+	getRecoveryKindFunc      func(err error) internal.RecoveryKind
 	retryOptions             RetryOptions
 	settler                  *messageSettler
 	defaultReleaserTimeout   time.Duration // defaults to 1min, settable for unit tests.
@@ -144,6 +145,7 @@ func newReceiver(args newReceiverArgs, options *ReceiverOptions) (*Receiver, err
 		cleanupOnClose:           args.cleanupOnClose,
 		lastPeekedSequenceNumber: 0,
 		maxAllowedCredits:        defaultLinkRxBuffer,
+		getRecoveryKindFunc:      args.getRecoveryKindFunc,
 		retryOptions:             args.retryOptions,
 		defaultReleaserTimeout:   time.Minute,
 	}
@@ -404,33 +406,6 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 		return msgs, nil
 	}
 
-	var linksWithID *internal.LinksWithID
-
-	err := r.amqpLinks.Retry(ctx, EventReceiver, "receiveMessages.getlinks", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
-		linksWithID = lwid
-		return nil
-	}, r.retryOptions)
-
-	if err != nil {
-		return nil, err
-	}
-
-	// request just the right amount of credits, taking into account the credits
-	// that are already active on the link from prior ReceiveMessages() calls that
-	// might have exited before all credits were used up.
-	currentReceiverCredits := int64(linksWithID.Receiver.Credits())
-	creditsToIssue := int64(maxMessages) - currentReceiverCredits
-
-	if creditsToIssue > 0 {
-		r.amqpLinks.Writef(EventReceiver, "Issuing %d credits, have %d", creditsToIssue, currentReceiverCredits)
-
-		if err := linksWithID.Receiver.IssueCredit(uint32(creditsToIssue)); err != nil {
-			return nil, err
-		}
-	} else {
-		r.amqpLinks.Writef(EventReceiver, "Have %d credits, no new credits needed", currentReceiverCredits)
-	}
-
 	timeAfterFirstMessage := 20 * time.Millisecond
 
 	if options != nil && options.TimeAfterFirstMessage > 0 {
@@ -439,13 +414,62 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 		timeAfterFirstMessage = time.Second
 	}
 
-	result := r.fetchMessages(ctx, linksWithID.Receiver, maxMessages, timeAfterFirstMessage)
+	var linksWithID *internal.LinksWithID
+	var result fetchMessagesResult
 
-	r.amqpLinks.Writef(EventReceiver, "Received %d/%d messages", len(result.Messages), maxMessages)
+	err := r.amqpLinks.Retry(ctx, EventReceiver, "receiveMessages", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
+		linksWithID = lwid
 
-	// this'll only close anything if the error indicates that the link/connection is bad.
-	// it's safe to call with cancellation errors.
-	rk := r.amqpLinks.CloseIfNeeded(context.Background(), result.Error)
+		// request just the right amount of credits, taking into account the credits
+		// that are already active on the link from prior ReceiveMessages() calls that
+		// might have exited before all credits were used up.
+		currentReceiverCredits := int64(lwid.Receiver.Credits())
+		creditsToIssue := int64(maxMessages) - currentReceiverCredits
+
+		if creditsToIssue > 0 {
+			r.amqpLinks.Writef(EventReceiver, "Issuing %d credits, have %d", creditsToIssue, currentReceiverCredits)
+
+			if err := lwid.Receiver.IssueCredit(uint32(creditsToIssue)); err != nil {
+				result = fetchMessagesResult{Error: err}
+				if !r.shouldRetryReceiveError(err) {
+					return nil
+				}
+
+				return err
+			}
+		} else {
+			r.amqpLinks.Writef(EventReceiver, "Have %d credits, no new credits needed", currentReceiverCredits)
+		}
+
+		result = r.fetchMessages(ctx, lwid.Receiver, maxMessages, timeAfterFirstMessage)
+		r.amqpLinks.Writef(EventReceiver, "Received %d/%d messages", len(result.Messages), maxMessages)
+
+		if len(result.Messages) > 0 || !r.shouldRetryReceiveError(result.Error) {
+			return nil
+		}
+
+		return result.Error
+	}, r.retryOptions)
+
+	if err != nil {
+		result = fetchMessagesResult{Error: err}
+	}
+
+	var rk internal.RecoveryKind
+	if err != nil {
+		rk = r.getRecoveryKind(err)
+		if rk == internal.RecoveryKindFatal {
+			rk = r.amqpLinks.CloseIfNeeded(context.Background(), err)
+		}
+	} else {
+		// this'll only close anything if the error indicates that the link/connection is bad.
+		// it's safe to call with cancellation errors.
+		rk = r.amqpLinks.CloseIfNeeded(context.Background(), result.Error)
+	}
+	if err != nil {
+		r.amqpLinks.Writef(EventReceiver, "Failure when receiving messages: %s", result.Error)
+		return nil, err
+	}
 
 	if rk == internal.RecoveryKindNone {
 		// The link is still alive - we'll start the releaser which will releasing any messages
@@ -483,6 +507,29 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 	}
 
 	return receivedMessages, nil
+}
+
+func (r *Receiver) getRecoveryKind(err error) internal.RecoveryKind {
+	if r.getRecoveryKindFunc != nil {
+		return r.getRecoveryKindFunc(err)
+	}
+
+	return internal.GetRecoveryKind(err)
+}
+
+func (r *Receiver) shouldRetryReceiveError(err error) bool {
+	rk := r.getRecoveryKind(err)
+	if rk != internal.RecoveryKindLink && rk != internal.RecoveryKindConn {
+		return false
+	}
+
+	if rk == internal.RecoveryKindLink {
+		var linkErr *amqp.LinkError
+		return !errors.As(err, &linkErr) || linkErr.RemoteErr != nil
+	}
+
+	var connErr *amqp.ConnError
+	return !errors.As(err, &connErr) || connErr.RemoteErr != nil
 }
 
 // receiveFromCache gets any messages that were retrieved after the Receiver was closed

--- a/sdk/messaging/azservicebus/receiver.go
+++ b/sdk/messaging/azservicebus/receiver.go
@@ -416,6 +416,7 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 
 	var linksWithID *internal.LinksWithID
 	var result fetchMessagesResult
+	var creditErr error
 
 	err := r.amqpLinks.Retry(ctx, EventReceiver, "receiveMessages", func(ctx context.Context, lwid *internal.LinksWithID, args *utils.RetryFnArgs) error {
 		linksWithID = lwid
@@ -430,12 +431,8 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 			r.amqpLinks.Writef(EventReceiver, "Issuing %d credits, have %d", creditsToIssue, currentReceiverCredits)
 
 			if err := lwid.Receiver.IssueCredit(uint32(creditsToIssue)); err != nil {
-				result = fetchMessagesResult{Error: err}
-				if !r.shouldRetryReceiveError(err) {
-					return nil
-				}
-
-				return err
+				creditErr = err
+				return nil
 			}
 		} else {
 			r.amqpLinks.Writef(EventReceiver, "Have %d credits, no new credits needed", currentReceiverCredits)
@@ -450,6 +447,10 @@ func (r *Receiver) receiveMessagesImpl(ctx context.Context, maxMessages int, opt
 
 		return result.Error
 	}, r.retryOptions)
+
+	if creditErr != nil {
+		return nil, creditErr
+	}
 
 	if err != nil {
 		result = fetchMessagesResult{Error: err}

--- a/sdk/messaging/azservicebus/receiver_simulated_test.go
+++ b/sdk/messaging/azservicebus/receiver_simulated_test.go
@@ -5,6 +5,7 @@ package azservicebus
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"testing"
 	"time"
@@ -141,6 +142,100 @@ func TestReceiver_Simulated_Recovery(t *testing.T) {
 	require.NoError(t, err)
 
 	emulation.RequireNoLeaks(t, md.Events)
+}
+
+func TestReceiver_ReceiveMessages_RecoversFromConnectionScopedNotAllowed(t *testing.T) {
+	var receiveAttempts int
+	var md *emulation.MockData
+	md, client, cleanup := newClientWithMockedConn(t, &emulation.MockDataOptions{
+		PreReceiverMock: func(mr *emulation.MockReceiver, ctx context.Context) error {
+			if mr.Source == "queue" {
+				mr.EXPECT().Receive(gomock.Any(), gomock.Nil()).DoAndReturn(func(ctx context.Context, o *amqp.ReceiveOptions) (*amqp.Message, error) {
+					receiveAttempts++
+					if receiveAttempts == 1 {
+						return nil, fmt.Errorf("wrapped: %w", &amqp.ConnError{RemoteErr: &amqp.Error{Condition: amqp.ErrCondNotAllowed}})
+					}
+
+					return mr.InternalReceive(ctx, o)
+				}).AnyTimes()
+			}
+
+			return nil
+		},
+	}, &ClientOptions{
+		RetryOptions: exported.RetryOptions{
+			MaxRetries:    1,
+			RetryDelay:    -1,
+			MaxRetryDelay: -1,
+		},
+	})
+	defer cleanup()
+
+	sender, err := client.NewSender("queue", nil)
+	require.NoError(t, err)
+	err = sender.SendMessage(context.Background(), &Message{Body: []byte("hello")}, nil)
+	require.NoError(t, err)
+	test.RequireClose(t, sender)
+
+	receiver, err := client.NewReceiverForQueue("queue", &ReceiverOptions{ReceiveMode: ReceiveModeReceiveAndDelete})
+	require.NoError(t, err)
+	receiverLinks := receiver.amqpLinks
+
+	messages, err := receiver.ReceiveMessages(context.Background(), 1, nil)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	require.Equal(t, 2, receiveAttempts)
+	require.Equal(t, 2, countEmulationEvents(md.Events.All(), emulation.EventTypeConnOpen))
+	require.Equal(t, 3, len(md.Events.GetOpenLinks()))
+	require.Same(t, receiverLinks, receiver.amqpLinks)
+}
+
+func TestReceiver_ReceiveMessages_RecoveryExhaustionLeavesReceiverUsable(t *testing.T) {
+	failReceives := true
+	var receiveAttempts int
+	_, client, cleanup := newClientWithMockedConn(t, &emulation.MockDataOptions{
+		PreReceiverMock: func(mr *emulation.MockReceiver, ctx context.Context) error {
+			if mr.Source == "queue" {
+				mr.EXPECT().Receive(gomock.Any(), gomock.Nil()).DoAndReturn(func(ctx context.Context, o *amqp.ReceiveOptions) (*amqp.Message, error) {
+					receiveAttempts++
+					if failReceives {
+						return nil, fmt.Errorf("wrapped: %w", &amqp.ConnError{RemoteErr: &amqp.Error{Condition: amqp.ErrCondNotAllowed}})
+					}
+
+					return mr.InternalReceive(ctx, o)
+				}).AnyTimes()
+			}
+
+			return nil
+		},
+	}, &ClientOptions{
+		RetryOptions: exported.RetryOptions{
+			MaxRetries:    1,
+			RetryDelay:    -1,
+			MaxRetryDelay: -1,
+		},
+	})
+	defer cleanup()
+
+	sender, err := client.NewSender("queue", nil)
+	require.NoError(t, err)
+	err = sender.SendMessage(context.Background(), &Message{Body: []byte("hello")}, nil)
+	require.NoError(t, err)
+	test.RequireClose(t, sender)
+
+	receiver, err := client.NewReceiverForQueue("queue", &ReceiverOptions{ReceiveMode: ReceiveModeReceiveAndDelete})
+	require.NoError(t, err)
+
+	messages, err := receiver.ReceiveMessages(context.Background(), 1, nil)
+	require.Error(t, err)
+	require.Empty(t, messages)
+	require.Equal(t, 2, receiveAttempts)
+
+	failReceives = false
+	messages, err = receiver.ReceiveMessages(context.Background(), 1, nil)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	require.Equal(t, 3, receiveAttempts)
 }
 
 func TestReceiver_ReceiveMessages_SomeMessagesAndCancelled(t *testing.T) {

--- a/sdk/messaging/azservicebus/receiver_simulated_test.go
+++ b/sdk/messaging/azservicebus/receiver_simulated_test.go
@@ -417,6 +417,53 @@ func TestReceiver_ReceiveMessages_SomeMessagesAndError(t *testing.T) {
 	require.Equal(t, 0, len(md.Events.GetOpenLinks()), "Receive links are still open")
 }
 
+func TestReceiver_ReceiveMessages_SomeMessagesAndConnectionScopedNotAllowed(t *testing.T) {
+	var receiveAttempts int
+	var md *emulation.MockData
+	md, client, cleanup := newClientWithMockedConn(t, &emulation.MockDataOptions{
+		PreReceiverMock: func(mr *emulation.MockReceiver, ctx context.Context) error {
+			if mr.Source == "queue" {
+				mr.EXPECT().Receive(gomock.Any(), gomock.Nil()).DoAndReturn(func(ctx context.Context, o *amqp.ReceiveOptions) (*amqp.Message, error) {
+					receiveAttempts++
+					switch receiveAttempts {
+					case 1:
+						return mr.InternalReceive(ctx, o)
+					case 2:
+						return nil, fmt.Errorf("wrapped: %w", &amqp.ConnError{RemoteErr: &amqp.Error{Condition: amqp.ErrCondNotAllowed}})
+					default:
+						return nil, internal.NewErrNonRetriable("unexpected extra receive")
+					}
+				}).AnyTimes()
+			}
+
+			return nil
+		},
+	}, &ClientOptions{
+		RetryOptions: exported.RetryOptions{
+			MaxRetries:    1,
+			RetryDelay:    time.Millisecond,
+			MaxRetryDelay: time.Millisecond,
+		},
+	})
+	defer cleanup()
+
+	sender, err := client.NewSender("queue", nil)
+	require.NoError(t, err)
+	err = sender.SendMessage(context.Background(), &Message{Body: []byte("hello")}, nil)
+	require.NoError(t, err)
+	test.RequireClose(t, sender)
+
+	receiver, err := client.NewReceiverForQueue("queue", &ReceiverOptions{ReceiveMode: ReceiveModeReceiveAndDelete})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	messages, err := receiver.ReceiveMessages(ctx, 2, nil)
+	require.Equal(t, []int{2, 1}, []int{receiveAttempts, countEmulationEvents(md.Events.All(), emulation.EventTypeConnOpen)}, "receive attempts and connection opens")
+	require.NoError(t, err)
+	require.Equal(t, []string{"hello"}, getSortedBodies(messages))
+}
+
 func TestReceiver_UserFacingErrors(t *testing.T) {
 	var receiveErr error
 

--- a/sdk/messaging/azservicebus/receiver_simulated_test.go
+++ b/sdk/messaging/azservicebus/receiver_simulated_test.go
@@ -165,8 +165,8 @@ func TestReceiver_ReceiveMessages_RecoversFromConnectionScopedNotAllowed(t *test
 	}, &ClientOptions{
 		RetryOptions: exported.RetryOptions{
 			MaxRetries:    1,
-			RetryDelay:    -1,
-			MaxRetryDelay: -1,
+			RetryDelay:    time.Millisecond,
+			MaxRetryDelay: time.Millisecond,
 		},
 	})
 	defer cleanup()
@@ -211,8 +211,8 @@ func TestReceiver_ReceiveMessages_RecoveryExhaustionLeavesReceiverUsable(t *test
 	}, &ClientOptions{
 		RetryOptions: exported.RetryOptions{
 			MaxRetries:    1,
-			RetryDelay:    -1,
-			MaxRetryDelay: -1,
+			RetryDelay:    time.Millisecond,
+			MaxRetryDelay: time.Millisecond,
 		},
 	})
 	defer cleanup()
@@ -805,6 +805,7 @@ func TestSessionReceiverUserFacingErrors_Methods(t *testing.T) {
 				}).AnyTimes()
 
 				mr.EXPECT().LinkSourceFilterValue("com.microsoft:session-filter").Return("session ID").AnyTimes()
+				mr.EXPECT().Properties().Return(map[string]any(nil)).AnyTimes()
 			}
 
 			return nil

--- a/sdk/messaging/azservicebus/receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/receiver_unit_test.go
@@ -5,6 +5,7 @@ package azservicebus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -39,6 +40,23 @@ func TestReceiver_ReceiveMessages_AMQPLinksFailure(t *testing.T) {
 	require.Equal(t, internal.RecoveryKindFatal, internal.GetRecoveryKind(err))
 	require.Equal(t, "failed to create links", err.Error())
 	require.Empty(t, messages)
+}
+
+func TestReceiver_ReceiveMessages_IssueCreditError(t *testing.T) {
+	issueCreditErr := errors.New("issue credit failed")
+	amqpReceiver := &internal.FakeAMQPReceiver{IssueCreditErr: issueCreditErr}
+	receiver := &Receiver{
+		amqpLinks:         &internal.FakeAMQPLinks{Receiver: amqpReceiver},
+		cancelReleaser:    &atomic.Value{},
+		maxAllowedCredits: defaultLinkRxBuffer,
+	}
+	receiver.cancelReleaser.Store(emptyCancelFn)
+
+	messages, err := receiver.receiveMessagesImpl(context.Background(), 1, nil)
+
+	require.ErrorIs(t, err, issueCreditErr)
+	require.Empty(t, messages)
+	require.Zero(t, amqpReceiver.ReceiveCalled)
 }
 
 var receiveModesForTests = []struct {

--- a/sdk/messaging/azservicebus/receiver_unit_test.go
+++ b/sdk/messaging/azservicebus/receiver_unit_test.go
@@ -5,7 +5,6 @@ package azservicebus
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -43,7 +42,7 @@ func TestReceiver_ReceiveMessages_AMQPLinksFailure(t *testing.T) {
 }
 
 func TestReceiver_ReceiveMessages_IssueCreditError(t *testing.T) {
-	issueCreditErr := errors.New("issue credit failed")
+	issueCreditErr := &amqp.ConnError{}
 	amqpReceiver := &internal.FakeAMQPReceiver{IssueCreditErr: issueCreditErr}
 	receiver := &Receiver{
 		amqpLinks:         &internal.FakeAMQPLinks{Receiver: amqpReceiver},

--- a/sdk/messaging/azservicebus/sender_unit_test.go
+++ b/sdk/messaging/azservicebus/sender_unit_test.go
@@ -5,14 +5,106 @@ package azservicebus
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/internal/mock/emulation"
 	"github.com/Azure/go-amqp"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSender_SendMessage_RecoversFromConnectionScopedNotAllowed(t *testing.T) {
+	var sendAttempts int
+	var md *emulation.MockData
+	md, client, cleanup := newClientWithMockedConn(t, &emulation.MockDataOptions{
+		PreSenderMock: func(ms *emulation.MockSender, ctx context.Context) error {
+			if ms.Target == "queue" {
+				ms.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Nil()).DoAndReturn(func(ctx context.Context, msg *amqp.Message, o *amqp.SendOptions) error {
+					sendAttempts++
+					if sendAttempts == 1 {
+						return fmt.Errorf("wrapped: %w", &amqp.ConnError{RemoteErr: &amqp.Error{Condition: amqp.ErrCondNotAllowed}})
+					}
+
+					return md.AllQueues()[ms.Target].Send(ctx, msg, ms.LinkEvent(), ms.Status)
+				}).AnyTimes()
+			}
+
+			return nil
+		},
+	}, &ClientOptions{
+		RetryOptions: exported.RetryOptions{
+			MaxRetries:    1,
+			RetryDelay:    -1,
+			MaxRetryDelay: -1,
+		},
+	})
+	defer cleanup()
+
+	sender, err := client.NewSender("queue", nil)
+	require.NoError(t, err)
+	senderLinks := sender.links
+
+	err = sender.SendMessage(context.Background(), &Message{Body: []byte("hello")}, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, sendAttempts)
+	require.Equal(t, 2, countEmulationEvents(md.Events.All(), emulation.EventTypeConnOpen))
+	require.Equal(t, 3, len(md.Events.GetOpenLinks()))
+	require.Same(t, senderLinks, sender.links)
+}
+
+func TestSender_SendMessage_RecoveryExhaustionLeavesSenderUsable(t *testing.T) {
+	failSends := true
+	var sendAttempts int
+	var md *emulation.MockData
+	md, client, cleanup := newClientWithMockedConn(t, &emulation.MockDataOptions{
+		PreSenderMock: func(ms *emulation.MockSender, ctx context.Context) error {
+			if ms.Target == "queue" {
+				ms.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Nil()).DoAndReturn(func(ctx context.Context, msg *amqp.Message, o *amqp.SendOptions) error {
+					sendAttempts++
+					if failSends {
+						return fmt.Errorf("wrapped: %w", &amqp.ConnError{RemoteErr: &amqp.Error{Condition: amqp.ErrCondNotAllowed}})
+					}
+
+					return md.AllQueues()[ms.Target].Send(ctx, msg, ms.LinkEvent(), ms.Status)
+				}).AnyTimes()
+			}
+
+			return nil
+		},
+	}, &ClientOptions{
+		RetryOptions: exported.RetryOptions{
+			MaxRetries:    1,
+			RetryDelay:    -1,
+			MaxRetryDelay: -1,
+		},
+	})
+	defer cleanup()
+
+	sender, err := client.NewSender("queue", nil)
+	require.NoError(t, err)
+
+	err = sender.SendMessage(context.Background(), &Message{Body: []byte("first")}, nil)
+	require.Error(t, err)
+	require.Equal(t, 2, sendAttempts)
+
+	failSends = false
+	err = sender.SendMessage(context.Background(), &Message{Body: []byte("second")}, nil)
+	require.NoError(t, err)
+	require.Equal(t, 3, sendAttempts)
+}
+
+func countEmulationEvents(events []emulation.Event, eventType emulation.EventType) int {
+	count := 0
+	for _, event := range events {
+		if event.Type == eventType {
+			count++
+		}
+	}
+	return count
+}
 
 func TestSender_UserFacingError(t *testing.T) {
 	_, client, cleanup := newClientWithMockedConn(t, &emulation.MockDataOptions{

--- a/sdk/messaging/azservicebus/sender_unit_test.go
+++ b/sdk/messaging/azservicebus/sender_unit_test.go
@@ -37,8 +37,8 @@ func TestSender_SendMessage_RecoversFromConnectionScopedNotAllowed(t *testing.T)
 	}, &ClientOptions{
 		RetryOptions: exported.RetryOptions{
 			MaxRetries:    1,
-			RetryDelay:    -1,
-			MaxRetryDelay: -1,
+			RetryDelay:    time.Millisecond,
+			MaxRetryDelay: time.Millisecond,
 		},
 	})
 	defer cleanup()
@@ -77,8 +77,8 @@ func TestSender_SendMessage_RecoveryExhaustionLeavesSenderUsable(t *testing.T) {
 	}, &ClientOptions{
 		RetryOptions: exported.RetryOptions{
 			MaxRetries:    1,
-			RetryDelay:    -1,
-			MaxRetryDelay: -1,
+			RetryDelay:    time.Millisecond,
+			MaxRetryDelay: time.Millisecond,
 		},
 	})
 	defer cleanup()


### PR DESCRIPTION
## Summary

Service Bus sender and receiver operations did not recover when an AMQP connection closed with connection-scoped `amqp:not-allowed`. Fixes #27016

## Motivation

Connection-scoped AMQP errors require rebuilding the connection and links before retrying. Without recovery, the same Client and Sender or Receiver remain unusable, while retry exhaustion can leave stale recoverable state. The change is internal and has no public API or dependency change.

## Changes

- Classifies only `amqp:not-allowed` wrapped in `*amqp.ConnError` as connection recoverable.
- Rebuilds sender or receiver connections and links and retries according to context and RetryOptions.
- Restricts receiver recovery to zero-message receives and preserves partial receive and IssueCredit error behavior.
- Clears exhausted recoverable state for later operations.
- Adds regression coverage for classifier, sender, receiver, retry exhaustion, and credit errors.

## Test plan

- `go build ./...`
- `go test -count=1 ./...`
- Focused classifier, sender, receiver, exhaustion, and credit tests
- `go vet ./...`
- `gofmt -d` on changed Go files
- `go test -race -count=1 ./...`
- `go test ./...`