### PR TITLE
Updates to session provider and error handling

### DIFF
--- a/sdk/storage/azblob/internal/base/clients.go
+++ b/sdk/storage/azblob/internal/base/clients.go
@@ -82,6 +82,7 @@ func GetAzClient(serviceURL string, cred azcore.TokenCredential, sharedKey *expo
 	// A session is signed with a session key obtained via a token credential, so asking for one
 	// without a token credential is a configuration error rather than something to silently ignore.
 	if conOptions.Session.Mode == exported.SessionModeEnabled && cred == nil {
+		log.Writef(exported.EventSession, "session authentication cannot be enabled: no token credential was provided; session-based authentication requires a TokenCredential.")
 		return nil, errors.New("session mode is enabled but no token credential was provided; session-based authentication requires a TokenCredential")
 	}
 
@@ -107,6 +108,7 @@ func GetAzClient(serviceURL string, cred azcore.TokenCredential, sharedKey *expo
 						authPolicy = bearerTokenPolicy
 						break
 					}
+					log.Writef(exported.EventSession, "session authentication cannot be enabled: the service URL could not be determined: %v.", err)
 					return nil, fmt.Errorf("session mode is enabled but service URL could not be determined: %w", err)
 				}
 				p, err := NewContainerSessionProvider(cred, svcURL, conOptions)
@@ -116,6 +118,7 @@ func GetAzClient(serviceURL string, cred azcore.TokenCredential, sharedKey *expo
 						authPolicy = bearerTokenPolicy
 						break
 					}
+					log.Writef(exported.EventSession, "session authentication cannot be enabled: the default session provider could not be created: %v.", err)
 					return nil, fmt.Errorf("failed to create default session provider: %w", err)
 				}
 				provider = p
@@ -130,6 +133,7 @@ func GetAzClient(serviceURL string, cred azcore.TokenCredential, sharedKey *expo
 						authPolicy = bearerTokenPolicy
 						break
 					}
+					log.Writef(exported.EventSession, "session authentication cannot be enabled: the account name could not be determined from the URL: %v. Set ClientOptions.Session.AccountName to use sessions.", err)
 					return nil, fmt.Errorf("session mode is enabled but account name could not be determined from URL: %w. Please explicitly pass in options.Session.AccountName", err)
 				}
 				accountName = name
@@ -138,6 +142,7 @@ func GetAzClient(serviceURL string, cred azcore.TokenCredential, sharedKey *expo
 			}
 			authPolicy = exported.NewSessionPolicy(accountName, provider, bearerTokenPolicy)
 		default:
+			log.Writef(exported.EventSession, "session authentication cannot be enabled: unsupported session mode %v.", conOptions.Session.Mode)
 			return nil, fmt.Errorf("unsupported session mode %v", conOptions.Session.Mode)
 		}
 		plOpts.PerRetry = []policy.Policy{authPolicy}

--- a/sdk/storage/azblob/internal/base/clients.go
+++ b/sdk/storage/azblob/internal/base/clients.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/internal/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/generated"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/internal/shared"
@@ -98,10 +99,23 @@ func GetAzClient(serviceURL string, cred azcore.TokenCredential, sharedKey *expo
 			if conOptions.Session.Provider == nil {
 				svcURL, err := shared.GetServiceURL(serviceURL)
 				if err != nil {
+					// In the future, we will make session default enabled. When the caller didn't
+					// explicitly ask for sessions, a setup failure isn't a configuration error,
+					// so warn and authenticate with bearer tokens instead.
+					if conOptions.Session.Mode == exported.SessionModeDefault {
+						log.Writef(exported.EventSession, "session authentication disabled: the service URL could not be determined: %v. Falling back to bearer token authentication.", err)
+						authPolicy = bearerTokenPolicy
+						break
+					}
 					return nil, fmt.Errorf("session mode is enabled but service URL could not be determined: %w", err)
 				}
 				p, err := NewContainerSessionProvider(cred, svcURL, conOptions)
 				if err != nil {
+					if conOptions.Session.Mode == exported.SessionModeDefault {
+						log.Writef(exported.EventSession, "session authentication disabled: the default session provider could not be created: %v. Falling back to bearer token authentication.", err)
+						authPolicy = bearerTokenPolicy
+						break
+					}
 					return nil, fmt.Errorf("failed to create default session provider: %w", err)
 				}
 				provider = p
@@ -111,6 +125,11 @@ func GetAzClient(serviceURL string, cred azcore.TokenCredential, sharedKey *expo
 			if conOptions.Session.AccountName == "" {
 				name, err := shared.GetAccountName(serviceURL)
 				if err != nil {
+					if conOptions.Session.Mode == exported.SessionModeDefault {
+						log.Writef(exported.EventSession, "session authentication disabled: the account name could not be determined from the URL: %v. Falling back to bearer token authentication. Set ClientOptions.Session.AccountName to use sessions.", err)
+						authPolicy = bearerTokenPolicy
+						break
+					}
 					return nil, fmt.Errorf("session mode is enabled but account name could not be determined from URL: %w. Please explicitly pass in options.Session.AccountName", err)
 				}
 				accountName = name

--- a/sdk/storage/azblob/internal/base/session_provider_container.go
+++ b/sdk/storage/azblob/internal/base/session_provider_container.go
@@ -122,6 +122,16 @@ func (p *containerSessionProvider) IsRequestEligible(req *http.Request) bool {
 		return false
 	}
 
+	// Session auth is not supported for requests with restype query parameter
+	if u.Query().Get("restype") != "" {
+		return false
+	}
+
+	// Session auth is not supported for structured message requests
+	if req.Header.Get(shared.HeaderXmsStructuredBody) != "" {
+		return false
+	}
+
 	// A session is scoped to a container, and only blob-level requests are eligible.
 	_, blob, err := shared.GetContainerAndBlobName(u)
 	return err == nil && blob != ""

--- a/sdk/storage/azblob/internal/base/session_provider_container_test.go
+++ b/sdk/storage/azblob/internal/base/session_provider_container_test.go
@@ -112,6 +112,13 @@ func newTestRequest(t *testing.T, method, rawURL string) *http.Request {
 	return req
 }
 
+func newTestRequestWithHeader(t *testing.T, method, rawURL, header, value string) *http.Request {
+	t.Helper()
+	req := newTestRequest(t, method, rawURL)
+	req.Header.Set(header, value)
+	return req
+}
+
 func TestAcquireSession_Success(t *testing.T) {
 	srv, closeFn := mock.NewServer(mock.WithTransformAllRequestsToTestServerUrl())
 	defer closeFn()
@@ -307,6 +314,16 @@ func TestIsRequestEligible(t *testing.T) {
 		{
 			name:     "GetWithCompQueryParameter",
 			req:      newTestRequest(t, http.MethodGet, fakeContainerURL+"/myblob?comp=tags"),
+			expected: false,
+		},
+		{
+			name:     "GetWithRestypeQueryParameter",
+			req:      newTestRequest(t, http.MethodGet, fakeContainerURL+"/myblob?restype=container"),
+			expected: false,
+		},
+		{
+			name:     "GetWithStructuredBodyHeader",
+			req:      newTestRequestWithHeader(t, http.MethodGet, fakeContainerURL+"/myblob", shared.HeaderXmsStructuredBody, shared.SMHeaderValue),
 			expected: false,
 		},
 		{

--- a/sdk/storage/azblob/internal/exported/log_events.go
+++ b/sdk/storage/azblob/internal/exported/log_events.go
@@ -14,4 +14,7 @@ const (
 
 	// EventSubmitBatch is used for logging events related to submit blob batch operation.
 	EventSubmitBatch log.Event = "azblob.SubmitBatch"
+
+	// EventSession is used for logging events related to session-based authentication.
+	EventSession log.Event = "azblob.Session"
 )

--- a/sdk/storage/azblob/internal/shared/shared.go
+++ b/sdk/storage/azblob/internal/shared/shared.go
@@ -39,6 +39,7 @@ const (
 	HeaderXmsRequestID       = "x-ms-request-id"
 	HeaderXmsClientRequestID = "x-ms-client-request-id"
 	HeaderDate               = "Date"
+	HeaderXmsStructuredBody  = "x-ms-structured-body"
 )
 
 const crc64Polynomial uint64 = 0x9A6C9329AC4BC9B5

--- a/sdk/storage/azblob/log.go
+++ b/sdk/storage/azblob/log.go
@@ -13,4 +13,7 @@ const (
 
 	// EventSubmitBatch is used for logging events related to submit blob batch operation.
 	EventSubmitBatch = exported.EventSubmitBatch
+
+	// EventSession is used for logging events related to session-based authentication.
+	EventSession = exported.EventSession
 )


### PR DESCRIPTION
- Session on by default does not break customers
- A couple checks to session provider to disallow restype and structured body
