### PR TITLE
azcosmos: include partition key in read many telemetry

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bugs Fixed
 
-* Fixed `ReadManyItems` requests that target a single logical partition key to include that key in service telemetry, allowing `CDBPartitionKeyRUConsumption` to attribute the request charge to the partition. See [issue 27476](https://github.com/Azure/azure-sdk-for-go/issues/27476).
+* Fixed `ReadManyItems` requests that target a single logical partition key to include that key in service telemetry, allowing `CDBPartitionKeyRUConsumption` to attribute the request charge to the partition. See [PR 27491](https://github.com/Azure/azure-sdk-for-go/pull/27491).
 
 ### Other Changes
 

--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+* Fixed `ReadManyItems` requests that target a single logical partition key to include that key in service telemetry, allowing `CDBPartitionKeyRUConsumption` to attribute the request charge to the partition. See [issue 27476](https://github.com/Azure/azure-sdk-for-go/issues/27476).
+
 ### Other Changes
 
 ## 1.6.0-beta.2 (2026-08-03)

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -501,7 +501,6 @@ func (c *ContainerClient) ReadManyItems(
 	}
 
 	h := headerOptionsOverride{
-		partitionKey:     sharedPartitionKey(itemIdentities),
 		priorityLevel:    readManyOptions.PriorityLevel,
 		throughputBucket: readManyOptions.ThroughputBucket,
 	}

--- a/sdk/data/azcosmos/cosmos_container.go
+++ b/sdk/data/azcosmos/cosmos_container.go
@@ -501,6 +501,7 @@ func (c *ContainerClient) ReadManyItems(
 	}
 
 	h := headerOptionsOverride{
+		partitionKey:     sharedPartitionKey(itemIdentities),
 		priorityLevel:    readManyOptions.PriorityLevel,
 		throughputBucket: readManyOptions.ThroughputBucket,
 	}

--- a/sdk/data/azcosmos/cosmos_container_read_many.go
+++ b/sdk/data/azcosmos/cosmos_container_read_many.go
@@ -19,6 +19,25 @@ import (
 const maxItemsPerQuery = 1000
 const maxPKRangeGoneRetries = 3
 
+func sharedPartitionKey(items []ItemIdentity) *PartitionKey {
+	if len(items) == 0 {
+		return nil
+	}
+
+	partitionKey := &items[0].PartitionKey
+	serializedPartitionKey, err := partitionKey.toJsonString()
+	if err != nil {
+		return nil
+	}
+	for i := 1; i < len(items); i++ {
+		serialized, err := items[i].PartitionKey.toJsonString()
+		if err != nil || serialized != serializedPartitionKey {
+			return nil
+		}
+	}
+	return partitionKey
+}
+
 // determineConcurrency returns either the provided positive max or NumCPU (>=1).
 func determineConcurrency(max *int32) int {
 	if max != nil && *max > 0 {

--- a/sdk/data/azcosmos/cosmos_container_read_many.go
+++ b/sdk/data/azcosmos/cosmos_container_read_many.go
@@ -38,6 +38,14 @@ func sharedPartitionKey(items []ItemIdentity) *PartitionKey {
 	return partitionKey
 }
 
+func completeSharedPartitionKey(items []ItemIdentity, pkDef PartitionKeyDefinition) *PartitionKey {
+	partitionKey := sharedPartitionKey(items)
+	if partitionKey == nil || len(partitionKey.values) != len(pkDef.Paths) {
+		return nil
+	}
+	return partitionKey
+}
+
 // determineConcurrency returns either the provided positive max or NumCPU (>=1).
 func determineConcurrency(max *int32) int {
 	if max != nil && *max > 0 {
@@ -380,6 +388,8 @@ func (c *ContainerClient) executeReadManyWithQueries(
 			}
 			pkDef = containerResp.ContainerProperties.PartitionKeyDefinition
 		}
+
+		operationContext.headerOptionsOverride.partitionKey = completeSharedPartitionKey(items, pkDef)
 
 		pkRangeResp, err := c.getPartitionKeyRanges(ctx, nil)
 		if err != nil {

--- a/sdk/data/azcosmos/cosmos_container_read_many_test.go
+++ b/sdk/data/azcosmos/cosmos_container_read_many_test.go
@@ -5,7 +5,9 @@ package azcosmos
 
 import (
 	"context"
+	"encoding/json"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"strings"
@@ -225,6 +227,135 @@ func TestBuildQueryChunksForRanges_Chunking(t *testing.T) {
 	require.Len(t, chunks, 2)
 	require.Equal(t, "0", chunks[0].rangeID)
 	require.Equal(t, "0", chunks[1].rangeID)
+}
+
+func TestReadManyItems_PartitionKeyHeader(t *testing.T) {
+	hierarchicalPK := NewPartitionKeyString("tenant").AppendString("user")
+	testCases := []struct {
+		name             string
+		partitionKeyDef  PartitionKeyDefinition
+		items            []ItemIdentity
+		expectedPKHeader string
+	}{
+		{
+			name: "same logical partition key",
+			partitionKeyDef: PartitionKeyDefinition{
+				Paths:   []string{"/pk"},
+				Kind:    PartitionKeyKindHash,
+				Version: 2,
+			},
+			items: []ItemIdentity{
+				{ID: "1", PartitionKey: NewPartitionKeyString("pk1")},
+				{ID: "2", PartitionKey: NewPartitionKeyString("pk1")},
+			},
+			expectedPKHeader: `["pk1"]`,
+		},
+		{
+			name: "different logical partition keys",
+			partitionKeyDef: PartitionKeyDefinition{
+				Paths:   []string{"/pk"},
+				Kind:    PartitionKeyKindHash,
+				Version: 2,
+			},
+			items: []ItemIdentity{
+				{ID: "1", PartitionKey: NewPartitionKeyString("pk1")},
+				{ID: "2", PartitionKey: NewPartitionKeyString("pk2")},
+			},
+		},
+		{
+			name: "different signed zero partition keys",
+			partitionKeyDef: PartitionKeyDefinition{
+				Paths:   []string{"/pk"},
+				Kind:    PartitionKeyKindHash,
+				Version: 2,
+			},
+			items: []ItemIdentity{
+				{ID: "1", PartitionKey: NewPartitionKeyNumber(0)},
+				{ID: "2", PartitionKey: NewPartitionKeyNumber(math.Copysign(0, -1))},
+			},
+		},
+		{
+			name: "same hierarchical partition key",
+			partitionKeyDef: PartitionKeyDefinition{
+				Paths:   []string{"/tenant", "/user"},
+				Kind:    PartitionKeyKindMultiHash,
+				Version: 2,
+			},
+			items: []ItemIdentity{
+				{ID: "1", PartitionKey: hierarchicalPK},
+				{ID: "2", PartitionKey: hierarchicalPK},
+			},
+			expectedPKHeader: `["tenant","user"]`,
+		},
+		{
+			name: "different hierarchical partition key component",
+			partitionKeyDef: PartitionKeyDefinition{
+				Paths:   []string{"/tenant", "/user"},
+				Kind:    PartitionKeyKindMultiHash,
+				Version: 2,
+			},
+			items: []ItemIdentity{
+				{ID: "1", PartitionKey: hierarchicalPK},
+				{ID: "2", PartitionKey: NewPartitionKeyString("tenant").AppendString("other")},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			containerBody, err := json.Marshal(ContainerProperties{
+				ID:                     "containerId",
+				PartitionKeyDefinition: tc.partitionKeyDef,
+			})
+			require.NoError(t, err)
+
+			rangeBody, err := json.Marshal(partitionKeyRangeResponse{
+				PartitionKeyRanges: []partitionKeyRange{
+					{ID: "0", MinInclusive: "", MaxExclusive: "FF"},
+				},
+				Count: 1,
+			})
+			require.NoError(t, err)
+
+			srv, closeSrv := mock.NewTLSServer()
+			defer closeSrv()
+			srv.AppendResponse(mock.WithBody(containerBody), mock.WithStatusCode(http.StatusOK))
+			srv.AppendResponse(mock.WithBody(rangeBody), mock.WithStatusCode(http.StatusOK))
+			srv.AppendResponse(
+				mock.WithBody([]byte(`{"Documents":[]}`)),
+				mock.WithHeader(cosmosHeaderRequestCharge, "1.0"),
+				mock.WithStatusCode(http.StatusOK),
+			)
+
+			verifier := pipelineVerifier{}
+			internalClient, err := azcore.NewClient(
+				"azcosmostest",
+				"v1.0.0",
+				azruntime.PipelineOptions{PerCall: []policy.Policy{&headerPolicies{}, &verifier}},
+				&policy.ClientOptions{Transport: srv},
+			)
+			require.NoError(t, err)
+
+			defaultEndpoint, err := url.Parse(srv.URL())
+			require.NoError(t, err)
+			client := &Client{
+				endpoint:    srv.URL(),
+				endpointUrl: defaultEndpoint,
+				internal:    internalClient,
+				gem:         &globalEndpointManager{preferredLocations: []string{}},
+			}
+			database, err := newDatabase("databaseId", client)
+			require.NoError(t, err)
+			container, err := newContainer("containerId", database)
+			require.NoError(t, err)
+
+			_, err = container.ReadManyItems(context.Background(), tc.items, nil)
+			require.NoError(t, err)
+			require.Len(t, verifier.requests, 3)
+			require.Equal(t, tc.expectedPKHeader, verifier.requests[2].headers.Get(cosmosHeaderPartitionKey))
+			require.Equal(t, "0", verifier.requests[2].headers.Get(cosmosHeaderPartitionKeyRangeId))
+		})
+	}
 }
 
 // cancelOnNthQueryPolicy is a pipeline policy that cancels a context after the

--- a/sdk/data/azcosmos/cosmos_container_read_many_test.go
+++ b/sdk/data/azcosmos/cosmos_container_read_many_test.go
@@ -299,6 +299,18 @@ func TestReadManyItems_PartitionKeyHeader(t *testing.T) {
 				{ID: "2", PartitionKey: NewPartitionKeyString("tenant").AppendString("other")},
 			},
 		},
+		{
+			name: "same partial hierarchical partition key",
+			partitionKeyDef: PartitionKeyDefinition{
+				Paths:   []string{"/tenant", "/user"},
+				Kind:    PartitionKeyKindMultiHash,
+				Version: 2,
+			},
+			items: []ItemIdentity{
+				{ID: "1", PartitionKey: NewPartitionKeyString("tenant")},
+				{ID: "2", PartitionKey: NewPartitionKeyString("tenant")},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/sdk/data/azcosmos/cosmos_container_read_many_test.go
+++ b/sdk/data/azcosmos/cosmos_container_read_many_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+// cSpell:ignore azcosmostest
 
 package azcosmos
 
@@ -321,11 +322,12 @@ func TestReadManyItems_PartitionKeyHeader(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			rangeBody, err := json.Marshal(partitionKeyRangeResponse{
-				PartitionKeyRanges: []partitionKeyRange{
-					{ID: "0", MinInclusive: "", MaxExclusive: "FF"},
-				},
-				Count: 1,
+			rangeBody, err := json.Marshal(struct {
+				PartitionKeyRanges []partitionKeyRange `json:"PartitionKeyRanges"`
+				Count              int                 `json:"_count"`
+			}{
+				PartitionKeyRanges: []partitionKeyRange{{ID: "0", MinInclusive: "", MaxExclusive: "FF"}},
+				Count:              1,
 			})
 			require.NoError(t, err)
 

--- a/sdk/data/azcosmos/cosmos_query_builder.go
+++ b/sdk/data/azcosmos/cosmos_query_builder.go
@@ -44,17 +44,7 @@ func (qb queryBuilder) isSingleLogicalPartitionQuery(items []ItemIdentity) bool 
 	if len(items) <= 1 {
 		return false
 	}
-	first, err := items[0].PartitionKey.toJsonString()
-	if err != nil {
-		return false
-	}
-	for i := 1; i < len(items); i++ {
-		s, err := items[i].PartitionKey.toJsonString()
-		if err != nil || s != first {
-			return false
-		}
-	}
-	return true
+	return sharedPartitionKey(items) != nil
 }
 
 // buildIDInQuery builds: SELECT * FROM c WHERE c.id IN (@param_id0, @param_id1, …)

--- a/sdk/data/azcosmos/cosmos_query_builder.go
+++ b/sdk/data/azcosmos/cosmos_query_builder.go
@@ -38,15 +38,6 @@ func (qb queryBuilder) isIDPartitionKeyQuery(items []ItemIdentity, pkDef Partiti
 	return true
 }
 
-// isSingleLogicalPartitionQuery returns true when all items share the same
-// logical partition key value. The check compares JSON-serialised PK strings.
-func (qb queryBuilder) isSingleLogicalPartitionQuery(items []ItemIdentity) bool {
-	if len(items) <= 1 {
-		return false
-	}
-	return sharedPartitionKey(items) != nil
-}
-
 // buildIDInQuery builds: SELECT * FROM c WHERE c.id IN (@param_id0, @param_id1, …)
 func (qb queryBuilder) buildIDInQuery(items []ItemIdentity) (string, []QueryParameter) {
 	params := make([]QueryParameter, 0, len(items))
@@ -63,7 +54,7 @@ func (qb queryBuilder) buildIDInQuery(items []ItemIdentity) (string, []QueryPara
 // buildPKAndIDInQuery builds:
 //
 //	SELECT * FROM c WHERE <pkExpr> = @pk AND c.id IN (@id0, @id1, …)
-func (qb queryBuilder) buildPKAndIDInQuery(items []ItemIdentity, pkDef PartitionKeyDefinition) (string, []QueryParameter) {
+func (qb queryBuilder) buildPKAndIDInQuery(items []ItemIdentity, partitionKey PartitionKey, pkDef PartitionKeyDefinition) (string, []QueryParameter) {
 	params := make([]QueryParameter, 0, len(items)+len(pkDef.Paths))
 
 	// Build PK equality conditions (one per path for hierarchical PKs)
@@ -73,8 +64,8 @@ func (qb queryBuilder) buildPKAndIDInQuery(items []ItemIdentity, pkDef Partition
 		paramName := fmt.Sprintf("@pk%d", pathIdx)
 
 		var pkVal interface{}
-		if pathIdx < len(items[0].PartitionKey.values) {
-			pkVal = items[0].PartitionKey.values[pathIdx]
+		if pathIdx < len(partitionKey.values) {
+			pkVal = partitionKey.values[pathIdx]
 		}
 
 		if pkVal == nil {
@@ -143,8 +134,10 @@ func (qb queryBuilder) buildParameterizedQueryForItems(items []ItemIdentity, pkD
 	if qb.isIDPartitionKeyQuery(items, pkDef) {
 		return qb.buildIDInQuery(items)
 	}
-	if qb.isSingleLogicalPartitionQuery(items) {
-		return qb.buildPKAndIDInQuery(items, pkDef)
+	if len(items) > 1 {
+		if partitionKey := sharedPartitionKey(items); partitionKey != nil {
+			return qb.buildPKAndIDInQuery(items, *partitionKey, pkDef)
+		}
 	}
 	return qb.buildOrOfConjunctionsQuery(items, pkDef)
 }

--- a/sdk/data/azcosmos/cosmos_query_builder_test.go
+++ b/sdk/data/azcosmos/cosmos_query_builder_test.go
@@ -59,8 +59,6 @@ func TestQueryBuilder_SingleLogicalPartition(t *testing.T) {
 		{ID: "5", PartitionKey: NewPartitionKeyString("samePK")},
 	}
 
-	require.True(t, qb.isSingleLogicalPartitionQuery(items))
-
 	query, params := qb.buildParameterizedQueryForItems(items, pkDef)
 	require.Equal(t, "SELECT * FROM c WHERE c.myPk = @pk0 AND c.id IN (@param_id0, @param_id1, @param_id2, @param_id3, @param_id4)", query)
 	require.Len(t, params, 6)
@@ -82,7 +80,6 @@ func TestQueryBuilder_MultipleLogicalPartitions(t *testing.T) {
 	}
 
 	require.False(t, qb.isIDPartitionKeyQuery(items, pkDef))
-	require.False(t, qb.isSingleLogicalPartitionQuery(items))
 
 	query, params := qb.buildParameterizedQueryForItems(items, pkDef)
 	require.Equal(t, "SELECT * FROM c WHERE (c.id = @param_id0 AND c.pk = @param_pk00) OR (c.id = @param_id1 AND c.pk = @param_pk10) OR (c.id = @param_id2 AND c.pk = @param_pk20)", query)
@@ -151,7 +148,6 @@ func TestQueryBuilder_EmptyItems(t *testing.T) {
 	pkDef := PartitionKeyDefinition{Paths: []string{"/pk"}}
 
 	require.False(t, qb.isIDPartitionKeyQuery(nil, pkDef))
-	require.False(t, qb.isSingleLogicalPartitionQuery(nil))
 }
 
 func TestQueryBuilder_SingleItem(t *testing.T) {
@@ -160,10 +156,7 @@ func TestQueryBuilder_SingleItem(t *testing.T) {
 		{ID: "1", PartitionKey: NewPartitionKeyString("pk1")},
 	}
 
-	// Single item → isSingleLogicalPartitionQuery returns false
-	require.False(t, qb.isSingleLogicalPartitionQuery(items))
-
-	// buildParameterizedQueryForItems still works (OR-of-conjunctions with 1 item)
+	// A single item uses the general OR-of-conjunctions shape.
 	pkDef := PartitionKeyDefinition{Paths: []string{"/pk"}}
 	query, params := qb.buildParameterizedQueryForItems(items, pkDef)
 	require.Equal(t, "SELECT * FROM c WHERE (c.id = @param_id0 AND c.pk = @param_pk00)", query)


### PR DESCRIPTION
Fixes #27476.

## Summary
- include the logical partition key header for `ReadManyItems` requests when all items share the same partition key
- preserve cross-partition behavior for mixed logical keys
- reuse canonical partition-key comparison for query shaping and header selection
- add coverage for scalar, hierarchical, mixed, and signed-zero partition keys