### PR TITLE
[Cosmos] Release: azcosmos 1.6.0-beta.3

### DIFF
--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -2,15 +2,11 @@
 
 <!-- cSpell:ignore documentdb unmarshalling -->
 
-## 1.6.0-beta.3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.6.0-beta.3 (2026-09-01)
 
 ### Other Changes
+
+* Updated dependencies.
 
 ## 1.6.0-beta.2 (2026-08-03)
 

--- a/sdk/data/azcosmos/CHANGELOG.md
+++ b/sdk/data/azcosmos/CHANGELOG.md
@@ -4,11 +4,9 @@
 
 ## 1.6.0-beta.3 (2026-09-01)
 
+### Bugs Fixed
+
 * Fixed `ReadManyItems` requests that target a single logical partition key to include that key in service telemetry, allowing `CDBPartitionKeyRUConsumption` to attribute the request charge to the partition. See [PR 27491](https://github.com/Azure/azure-sdk-for-go/pull/27491).
-
-### Other Changes
-
-* Updated dependencies.
 
 ## 1.6.0-beta.2 (2026-08-03)
 


### PR DESCRIPTION
## azcosmos Release 1.6.0-beta.3

### Version Changes
- azcosmos: 1.6.0-beta.2 → 1.6.0-beta.3

### CHANGELOG
- Fixed `ReadManyItems` requests targeting a single logical partition key to include that key in service telemetry, enabling `CDBPartitionKeyRUConsumption` attribution. See #27491.

### Release date
2026-09-01