### PR TITLE
[Storage] Add structured message CRC64 for azfile Create with data

### DIFF
--- a/sdk/storage/azfile/CHANGELOG.md
+++ b/sdk/storage/azfile/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 * Exported `ShareNFSSettings` and `ShareNFSSettingsEncryptionInTransit` types.
 * Added structured message (XSM/1.0) CRC64 content validation for `azfile` uploads and downloads via the new `TransferValidationTypeComputeStructuredMessageCRC64` transfer validation option.
+* Added `TransactionalValidation` support on `CreateOptions` for structured message CRC64 content validation when creating a file with initial data.
 
 ### Breaking Changes
 

--- a/sdk/storage/azfile/file/client.go
+++ b/sdk/storage/azfile/file/client.go
@@ -154,6 +154,10 @@ func (f *Client) Create(ctx context.Context, fileContentLength int64, options *C
 	opts := options.format(f.getClientOptions().FileRequestIntent, f.getClientOptions().AllowTrailingDot)
 
 	if options != nil && options.OptionalBody != nil && options.TransactionalValidation != nil {
+		if _, ok := options.TransactionalValidation.(TransferValidationTypeMD5); !ok &&
+			exported.GetStructuredBodyType(options.TransactionalValidation) == "" {
+			return CreateResponse{}, errors.New("unsupported TransactionalValidation type for Create; only MD5 and structured message CRC64 are supported")
+		}
 		body, err := options.TransactionalValidation.Apply(options.OptionalBody, opts)
 		if err != nil {
 			return CreateResponse{}, err

--- a/sdk/storage/azfile/file/client.go
+++ b/sdk/storage/azfile/file/client.go
@@ -152,6 +152,17 @@ func (f *Client) URL() string {
 // For more information, see https://learn.microsoft.com/en-us/rest/api/storageservices/create-file.
 func (f *Client) Create(ctx context.Context, fileContentLength int64, options *CreateOptions) (CreateResponse, error) {
 	opts := options.format(f.getClientOptions().FileRequestIntent, f.getClientOptions().AllowTrailingDot)
+
+	if options != nil && options.OptionalBody != nil && options.TransactionalValidation != nil {
+		if _, ok := options.TransactionalValidation.(TransferValidationTypeMD5); !ok {
+			body, err := options.TransactionalValidation.Apply(options.OptionalBody, opts)
+			if err != nil {
+				return CreateResponse{}, err
+			}
+			opts.Optionalbody = body
+		}
+	}
+
 	return f.generated().Create(ctx, fileContentLength, opts)
 }
 

--- a/sdk/storage/azfile/file/client.go
+++ b/sdk/storage/azfile/file/client.go
@@ -154,6 +154,8 @@ func (f *Client) Create(ctx context.Context, fileContentLength int64, options *C
 	opts := options.format(f.getClientOptions().FileRequestIntent, f.getClientOptions().AllowTrailingDot)
 
 	if options != nil && options.OptionalBody != nil && options.TransactionalValidation != nil {
+		// Defensive: CRC64 types (precomputed/computed) aren't publicly exported from this
+		// package so callers can't reach this, but reject them to avoid a silent no-op via SetCRC64.
 		if _, ok := options.TransactionalValidation.(TransferValidationTypeMD5); !ok &&
 			exported.GetStructuredBodyType(options.TransactionalValidation) == "" {
 			return CreateResponse{}, errors.New("unsupported TransactionalValidation type for Create; only MD5 and structured message CRC64 are supported")

--- a/sdk/storage/azfile/file/client.go
+++ b/sdk/storage/azfile/file/client.go
@@ -154,13 +154,11 @@ func (f *Client) Create(ctx context.Context, fileContentLength int64, options *C
 	opts := options.format(f.getClientOptions().FileRequestIntent, f.getClientOptions().AllowTrailingDot)
 
 	if options != nil && options.OptionalBody != nil && options.TransactionalValidation != nil {
-		if _, ok := options.TransactionalValidation.(TransferValidationTypeMD5); !ok {
-			body, err := options.TransactionalValidation.Apply(options.OptionalBody, opts)
-			if err != nil {
-				return CreateResponse{}, err
-			}
-			opts.Optionalbody = body
+		body, err := options.TransactionalValidation.Apply(options.OptionalBody, opts)
+		if err != nil {
+			return CreateResponse{}, err
 		}
+		opts.Optionalbody = body
 	}
 
 	return f.generated().Create(ctx, fileContentLength, opts)

--- a/sdk/storage/azfile/file/client_test.go
+++ b/sdk/storage/azfile/file/client_test.go
@@ -5261,6 +5261,46 @@ func TestFileUploadRangeStructuredMessageBody(t *testing.T) {
 	_require.Equal(strconv.Itoa(contentSize), sclHeader[0])
 }
 
+func TestFileCreateStructuredMessageBody(t *testing.T) {
+	_require := require.New(t)
+
+	log.SetListener(nil)
+
+	const contentSize = 2048
+	const segmentSize = 512
+	content := make([]byte, contentSize)
+	_, err := rand.Read(content)
+	_require.NoError(err)
+
+	encoder := shared.NewSMEncoder(streaming.NopCloser(bytes.NewReader(content)), int64(contentSize), segmentSize)
+	expectedBody, err := io.ReadAll(encoder)
+	_require.NoError(err)
+	_require.Greater(len(expectedBody), contentSize)
+
+	transport := &captureBodyTransport{}
+	fileClient, err := file.NewClientWithNoCredential("https://fake/share/file", &file.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Transport: transport,
+		},
+	})
+	_require.NoError(err)
+
+	_, err = fileClient.Create(context.Background(), int64(contentSize), &file.CreateOptions{
+		OptionalBody:            streaming.NopCloser(bytes.NewReader(content)),
+		TransactionalValidation: file.TransferValidationTypeComputeStructuredMessageCRC64(segmentSize),
+	})
+	_require.NoError(err)
+
+	_require.Equal(expectedBody, transport.capturedBody)
+
+	sbHeader := foldedHeaderValues(transport.capturedHeaders, "x-ms-structured-body")
+	_require.Len(sbHeader, 1)
+	_require.Equal(shared.SMHeaderValue, sbHeader[0])
+	sclHeader := foldedHeaderValues(transport.capturedHeaders, "x-ms-structured-content-length")
+	_require.Len(sclHeader, 1)
+	_require.Equal(strconv.Itoa(contentSize), sclHeader[0])
+}
+
 // TODO: Add tests for retry header options
 
 func (f *FileRecordedTestsSuite) TestCreateHardLinkNFS() {

--- a/sdk/storage/azfile/file/client_test.go
+++ b/sdk/storage/azfile/file/client_test.go
@@ -6059,3 +6059,154 @@ func (f *FileUnrecordedTestsSuite) TestUploadRangeCustomSegmentSizeWithStructure
 	_require.NoError(err)
 	_require.EqualValues(contentD, downloadedData)
 }
+
+// ===== Create with Data + Structured Message CRC64 Tests =====
+
+func (f *FileUnrecordedTestsSuite) TestFileCreateDataWithStructuredMessageCRC64() {
+	_require := require.New(f.T())
+	testName := f.T().Name()
+
+	svcClient, err := testcommon.GetServiceClient(f.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	shareClient := testcommon.CreateNewShare(context.Background(), _require, testcommon.GenerateShareName(testName), svcClient)
+	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
+
+	fileName := testcommon.GenerateFileName(testName)
+	fileClient := shareClient.NewRootDirectoryClient().NewFileClient(fileName)
+
+	body, data := testcommon.GenerateData(1024)
+
+	_, err = fileClient.Create(context.Background(), int64(len(data)), &file.CreateOptions{
+		OptionalBody:            body,
+		TransactionalValidation: file.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	downloadResp, err := fileClient.DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+	downloaded, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.EqualValues(data, downloaded)
+}
+
+func (f *FileUnrecordedTestsSuite) TestFileCreateDataWithSMCRC64ThenDownloadWithSM() {
+	_require := require.New(f.T())
+	testName := f.T().Name()
+
+	svcClient, err := testcommon.GetServiceClient(f.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	shareClient := testcommon.CreateNewShare(context.Background(), _require, testcommon.GenerateShareName(testName), svcClient)
+	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
+
+	fileName := testcommon.GenerateFileName(testName)
+	fileClient := shareClient.NewRootDirectoryClient().NewFileClient(fileName)
+
+	body, data := testcommon.GenerateData(4 * 1024)
+
+	_, err = fileClient.Create(context.Background(), int64(len(data)), &file.CreateOptions{
+		OptionalBody:            body,
+		TransactionalValidation: file.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	downloadResp, err := fileClient.DownloadStream(context.Background(), &file.DownloadStreamOptions{
+		TransactionalValidation: file.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+	downloaded, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.EqualValues(data, downloaded)
+}
+
+func (f *FileUnrecordedTestsSuite) TestFileCreateDataSingleByteWithSMCRC64() {
+	_require := require.New(f.T())
+	testName := f.T().Name()
+
+	svcClient, err := testcommon.GetServiceClient(f.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	shareClient := testcommon.CreateNewShare(context.Background(), _require, testcommon.GenerateShareName(testName), svcClient)
+	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
+
+	fileName := testcommon.GenerateFileName(testName)
+	fileClient := shareClient.NewRootDirectoryClient().NewFileClient(fileName)
+
+	content := []byte{0x42}
+	_, err = fileClient.Create(context.Background(), 1, &file.CreateOptions{
+		OptionalBody:            streaming.NopCloser(bytes.NewReader(content)),
+		TransactionalValidation: file.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	downloadResp, err := fileClient.DownloadStream(context.Background(), &file.DownloadStreamOptions{
+		TransactionalValidation: file.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+	downloaded, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.EqualValues(content, downloaded)
+}
+
+func (f *FileUnrecordedTestsSuite) TestFileCreateDataExactly4MiBWithSMCRC64() {
+	_require := require.New(f.T())
+	testName := f.T().Name()
+
+	svcClient, err := testcommon.GetServiceClient(f.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	shareClient := testcommon.CreateNewShare(context.Background(), _require, testcommon.GenerateShareName(testName), svcClient)
+	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
+
+	fileName := testcommon.GenerateFileName(testName)
+	fileClient := shareClient.NewRootDirectoryClient().NewFileClient(fileName)
+
+	dataSize := 4 * 1024 * 1024
+	data := make([]byte, dataSize)
+	_, err = rand.Read(data)
+	_require.NoError(err)
+
+	body := readSeekNopCloser{bytes.NewReader(data)}
+
+	_, err = fileClient.Create(context.Background(), int64(dataSize), &file.CreateOptions{
+		OptionalBody:            body,
+		TransactionalValidation: file.TransferValidationTypeComputeStructuredMessageCRC64(0),
+	})
+	_require.NoError(err)
+
+	downloadResp, err := fileClient.DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+	downloaded, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.Equal(dataSize, len(downloaded))
+	_require.EqualValues(data, downloaded)
+}
+
+func (f *FileUnrecordedTestsSuite) TestFileCreateDataMultiSegmentWithSMCRC64() {
+	_require := require.New(f.T())
+	testName := f.T().Name()
+
+	svcClient, err := testcommon.GetServiceClient(f.T(), testcommon.TestAccountDefault, nil)
+	_require.NoError(err)
+
+	shareClient := testcommon.CreateNewShare(context.Background(), _require, testcommon.GenerateShareName(testName), svcClient)
+	defer testcommon.DeleteShare(context.Background(), _require, shareClient)
+
+	fileName := testcommon.GenerateFileName(testName)
+	fileClient := shareClient.NewRootDirectoryClient().NewFileClient(fileName)
+
+	body, data := testcommon.GenerateData(2048)
+
+	_, err = fileClient.Create(context.Background(), int64(len(data)), &file.CreateOptions{
+		OptionalBody:            body,
+		TransactionalValidation: file.TransferValidationTypeComputeStructuredMessageCRC64(512),
+	})
+	_require.NoError(err)
+
+	downloadResp, err := fileClient.DownloadStream(context.Background(), nil)
+	_require.NoError(err)
+	downloaded, err := io.ReadAll(downloadResp.Body)
+	_require.NoError(err)
+	_require.EqualValues(data, downloaded)
+}

--- a/sdk/storage/azfile/file/client_test.go
+++ b/sdk/storage/azfile/file/client_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/file"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/fileerror"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/exported"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/generated"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/shared"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azfile/internal/testcommon"
@@ -5299,6 +5300,37 @@ func TestFileCreateStructuredMessageBody(t *testing.T) {
 	sclHeader := foldedHeaderValues(transport.capturedHeaders, "x-ms-structured-content-length")
 	_require.Len(sclHeader, 1)
 	_require.Equal(strconv.Itoa(contentSize), sclHeader[0])
+}
+
+func TestFileCreateRejectsUnsupportedValidationType(t *testing.T) {
+	_require := require.New(t)
+
+	transport := &captureBodyTransport{}
+	fileClient, err := file.NewClientWithNoCredential("https://fake/share/file", &file.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Transport: transport,
+		},
+	})
+	_require.NoError(err)
+
+	body := streaming.NopCloser(bytes.NewReader([]byte("data")))
+
+	// Precomputed CRC64
+	_, err = fileClient.Create(context.Background(), 4, &file.CreateOptions{
+		OptionalBody:            body,
+		TransactionalValidation: exported.TransferValidationTypeCRC64(123),
+	})
+	_require.Error(err)
+	_require.Contains(err.Error(), "unsupported TransactionalValidation type")
+
+	// Computed CRC64
+	body = streaming.NopCloser(bytes.NewReader([]byte("data")))
+	_, err = fileClient.Create(context.Background(), 4, &file.CreateOptions{
+		OptionalBody:            body,
+		TransactionalValidation: exported.TransferValidationTypeComputeCRC64(),
+	})
+	_require.Error(err)
+	_require.Contains(err.Error(), "unsupported TransactionalValidation type")
 }
 
 // TODO: Add tests for retry header options

--- a/sdk/storage/azfile/file/models.go
+++ b/sdk/storage/azfile/file/models.go
@@ -96,6 +96,9 @@ type CreateOptions struct {
 	OptionalBody          io.ReadSeekCloser
 	ContentLength         *int64
 	ContentMD5            []byte
+	// TransactionalValidation specifies the transfer validation type to use.
+	// The default is nil (no transfer validation).
+	TransactionalValidation TransferValidationType
 }
 
 func (o *CreateOptions) format(fileRequestIntent *generated.ShareTokenIntent, allowTrailingDot *bool) *generated.FileClientCreateOptions {

--- a/sdk/storage/azfile/internal/generated/models.go
+++ b/sdk/storage/azfile/internal/generated/models.go
@@ -31,6 +31,19 @@ func (f *FileClientUploadRangeOptions) SetStructuredBody(bodyType string, conten
 	f.StructuredContentLength = &contentLength
 }
 
+func (f *FileClientCreateOptions) SetMD5(v []byte) {
+	f.ContentMD5 = v
+}
+
+func (f *FileClientCreateOptions) SetCRC64([]byte) {
+	// no-op: Azure Files does not support transactional CRC64 headers on Create
+}
+
+func (f *FileClientCreateOptions) SetStructuredBody(bodyType string, contentLength int64) {
+	f.StructuredBodyType = &bodyType
+	f.StructuredContentLength = &contentLength
+}
+
 type SourceContentSetter interface {
 	SetSourceContentCRC64(v []byte)
 	// add SetSourceContentMD5() when Azure File service starts supporting it.


### PR DESCRIPTION
## Summary
- Adds `TransactionalValidation` support on the `Create` API so callers can use structured message CRC64 when creating a file with initial data
- Implements `TransactionalContentSetter` on `FileClientCreateOptions` in the generated layer
- Applies SM encoding in `Create()` following the same pattern as `UploadRange()`
- Adds integration tests (basic, single-byte, 4 MiB, multi-segment, SM upload+download roundtrip)

## Test plan
- [x] All 5 new SM Create tests pass against live account
- [x] Existing Create-with-data tests pass (no regression)
- [x] Existing UploadRange SM tests pass (no regression)
- [x] `go build ./...` clean