### PR TITLE
Reject CR/LF in blob batch subrequest headers

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 
+* Fixed CRLF injection vulnerability in Blob Batch subrequest serialization. Header values containing CR or LF characters are now rejected before serialization, preventing header injection in batch requests.
 * Fixed WASM compilation by using heap-allocated buffers on JS targets.
 
 ### Other Changes

--- a/sdk/storage/azblob/internal/exported/blob_batch.go
+++ b/sdk/storage/azblob/internal/exported/blob_batch.go
@@ -45,7 +45,7 @@ func createBatchID() (string, error) {
 // x-ms-date: Thu, 14 Jun 2018 16:46:54 GMT
 // Authorization: SharedKey account:<redacted>
 // Content-Length: 0
-func buildSubRequest(req *policy.Request) []byte {
+func buildSubRequest(req *policy.Request) ([]byte, error) {
 	var batchSubRequest strings.Builder
 	blobPath := req.Raw().URL.EscapedPath()
 	if len(req.Raw().URL.RawQuery) > 0 {
@@ -59,12 +59,18 @@ func buildSubRequest(req *policy.Request) []byte {
 			continue
 		}
 		if len(v) > 0 {
+			if strings.ContainsAny(k, "\r\n") {
+				return nil, fmt.Errorf("invalid CR/LF in batch subrequest header name %q", k)
+			}
+			if strings.ContainsAny(v[0], "\r\n") {
+				return nil, fmt.Errorf("invalid CR/LF in batch subrequest header value for %q", k)
+			}
 			fmt.Fprintf(&batchSubRequest, "%v: %v%v", k, v[0], httpNewline)
 		}
 	}
 
 	fmt.Fprint(&batchSubRequest, httpNewline)
-	return []byte(batchSubRequest.String())
+	return []byte(batchSubRequest.String()), nil
 }
 
 // CreateBatchRequest creates a new batch request using the sub-requests present in the BlobBatchBuilder.
@@ -118,7 +124,11 @@ func CreateBatchRequest(bb *BlobBatchBuilder) ([]byte, string, error) {
 			return nil, "", err
 		}
 
-		_, err = partWriter.Write(buildSubRequest(req))
+		subReqBytes, err := buildSubRequest(req)
+		if err != nil {
+			return nil, "", err
+		}
+		_, err = partWriter.Write(subReqBytes)
 		if err != nil {
 			return nil, "", err
 		}

--- a/sdk/storage/azblob/internal/exported/blob_batch_test.go
+++ b/sdk/storage/azblob/internal/exported/blob_batch_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package exported
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/stretchr/testify/require"
+)
+
+func newSubRequest(t *testing.T, headers map[string]string) *policy.Request {
+	t.Helper()
+	req, err := runtime.NewRequest(context.Background(), "DELETE", "https://account.blob.core.windows.net/container/blob")
+	require.NoError(t, err)
+	for k, v := range headers {
+		req.Raw().Header.Set(k, v)
+	}
+	return req
+}
+
+func TestBuildSubRequest_Clean(t *testing.T) {
+	req := newSubRequest(t, map[string]string{
+		"x-ms-if-tags": "\"tenant\"='A'",
+	})
+	result, err := buildSubRequest(req)
+	require.NoError(t, err)
+	require.Contains(t, string(result), "X-Ms-If-Tags: \"tenant\"='A'")
+}
+
+func TestBuildSubRequest_CRLFInHeaderValue(t *testing.T) {
+	req := newSubRequest(t, map[string]string{
+		"x-ms-if-tags": "\"tenant\"='A'\r\nx-ms-delete-snapshots: include",
+	})
+	_, err := buildSubRequest(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid CR/LF")
+}
+
+func TestBuildSubRequest_LFInHeaderValue(t *testing.T) {
+	req := newSubRequest(t, map[string]string{
+		"x-ms-if-tags": "\"tenant\"='A'\nx-ms-delete-snapshots: include",
+	})
+	_, err := buildSubRequest(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid CR/LF")
+}
+
+func TestBuildSubRequest_CRInHeaderValue(t *testing.T) {
+	req := newSubRequest(t, map[string]string{
+		"x-ms-if-tags": "value\rwith-cr",
+	})
+	_, err := buildSubRequest(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid CR/LF")
+}
+
+func TestBuildSubRequest_CRLFInHeaderName(t *testing.T) {
+	req := newSubRequest(t, nil)
+	req.Raw().Header["bad\r\nheader"] = []string{"value"}
+	_, err := buildSubRequest(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "header name")
+}
+
+func TestBuildSubRequest_MultipleInjectedHeaders(t *testing.T) {
+	req := newSubRequest(t, map[string]string{
+		"x-ms-if-tags": "\"tenant\"='A'\r\nx-ms-delete-snapshots: include\r\nx-ms-extra: injected",
+	})
+	_, err := buildSubRequest(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid CR/LF")
+}
+
+func TestBuildSubRequest_SkipsXmsVersion(t *testing.T) {
+	req := newSubRequest(t, map[string]string{
+		"x-ms-version": "2023-11-03",
+		"x-ms-if-tags": "\"tenant\"='A'",
+	})
+	result, err := buildSubRequest(req)
+	require.NoError(t, err)
+	require.False(t, strings.Contains(string(result), "x-ms-version"))
+	require.False(t, strings.Contains(string(result), "X-Ms-Version"))
+}


### PR DESCRIPTION
## Summary
- Fixes CRLF header injection vulnerability in Blob Batch subrequest serialization (MSRC 140479)
- `buildSubRequest` now validates header names and values for `\r` and `\n` characters before serialization, returning an error if either is found
- Adds regression tests covering CRLF, LF-only, CR-only injection in values, CRLF in header names, and multiple injected headers.
-The fix rejects any header name or value containing CR/LF before the value reaches the serializer.

## Test plan
- [x] Unit tests for clean headers (no regression)
- [x] Unit tests for CRLF, LF, CR injection in header values
- [x] Unit test for CRLF injection in header names
- [x] Unit test for multiple injected headers
- [x] Unit test confirming x-ms-version is still skipped
- [ ] Live batch delete test with container-SAS confirming rejection