### PR TITLE
Release azblob v1.8.1

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 
+* Fixed CRLF injection vulnerability in Blob Batch subrequest serialization. Header values containing CR or LF characters are now rejected before serialization, preventing header injection in batch requests.
 * Fixed WASM compilation by using heap-allocated buffers on JS targets.
 
 ### Other Changes

--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -1,19 +1,6 @@
 # Release History
 
-## 1.8.1-beta.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-* Fixed CRLF injection vulnerability in Blob Batch subrequest serialization. Header values containing CR or LF characters are now rejected before serialization, preventing header injection in batch requests.
-* Fixed WASM compilation by using heap-allocated buffers on JS targets.
-
-### Other Changes
-
-## 1.8.1-beta.1 (2026-07-24)
+## 1.8.1 (2026-09-04)
 
 ### Features Added
 * Added support for Structured Message CRC64 content validation on upload and download operations using `TransferValidationTypeComputeStructuredMessageCRC64`.
@@ -22,7 +9,9 @@
 * Blob put operations now return both `ContentMD5` and `ContentCRC64` in the response when a Content-MD5 header is provided (service version 2026-10-06+).
 
 ### Bugs Fixed
+* Fixed CRLF injection vulnerability in Blob Batch subrequest serialization. Header values containing CR or LF characters are now rejected before serialization, preventing header injection in batch requests.
 * Fixed `UploadFile`/`UploadBuffer` responses not including `ContentCRC64` when returned by the service.
+* Fixed WASM compilation by using heap-allocated buffers on JS targets.
 
 ### Other Changes
 * Updated code generator to `@autorest/go@4.0.0-preview.80`.

--- a/sdk/storage/azblob/internal/exported/blob_batch.go
+++ b/sdk/storage/azblob/internal/exported/blob_batch.go
@@ -45,7 +45,7 @@ func createBatchID() (string, error) {
 // x-ms-date: Thu, 14 Jun 2018 16:46:54 GMT
 // Authorization: SharedKey account:<redacted>
 // Content-Length: 0
-func buildSubRequest(req *policy.Request) []byte {
+func buildSubRequest(req *policy.Request) ([]byte, error) {
 	var batchSubRequest strings.Builder
 	blobPath := req.Raw().URL.EscapedPath()
 	if len(req.Raw().URL.RawQuery) > 0 {
@@ -59,12 +59,18 @@ func buildSubRequest(req *policy.Request) []byte {
 			continue
 		}
 		if len(v) > 0 {
+			if strings.ContainsAny(k, "\r\n") {
+				return nil, fmt.Errorf("invalid CR/LF in batch subrequest header name %q", k)
+			}
+			if strings.ContainsAny(v[0], "\r\n") {
+				return nil, fmt.Errorf("invalid CR/LF in batch subrequest header value for %q", k)
+			}
 			fmt.Fprintf(&batchSubRequest, "%v: %v%v", k, v[0], httpNewline)
 		}
 	}
 
 	fmt.Fprint(&batchSubRequest, httpNewline)
-	return []byte(batchSubRequest.String())
+	return []byte(batchSubRequest.String()), nil
 }
 
 // CreateBatchRequest creates a new batch request using the sub-requests present in the BlobBatchBuilder.
@@ -118,7 +124,11 @@ func CreateBatchRequest(bb *BlobBatchBuilder) ([]byte, string, error) {
 			return nil, "", err
 		}
 
-		_, err = partWriter.Write(buildSubRequest(req))
+		subReqBytes, err := buildSubRequest(req)
+		if err != nil {
+			return nil, "", err
+		}
+		_, err = partWriter.Write(subReqBytes)
 		if err != nil {
 			return nil, "", err
 		}

--- a/sdk/storage/azblob/internal/exported/blob_batch_test.go
+++ b/sdk/storage/azblob/internal/exported/blob_batch_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package exported
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/stretchr/testify/require"
+)
+
+func newSubRequest(t *testing.T, headers map[string]string) *policy.Request {
+	t.Helper()
+	req, err := runtime.NewRequest(context.Background(), "DELETE", "https://account.blob.core.windows.net/container/blob")
+	require.NoError(t, err)
+	for k, v := range headers {
+		req.Raw().Header.Set(k, v)
+	}
+	return req
+}
+
+func TestBuildSubRequest_Clean(t *testing.T) {
+	req := newSubRequest(t, map[string]string{
+		"x-ms-if-tags": "\"tenant\"='A'",
+	})
+	result, err := buildSubRequest(req)
+	require.NoError(t, err)
+	require.Contains(t, string(result), "X-Ms-If-Tags: \"tenant\"='A'")
+}
+
+func TestBuildSubRequest_CRLFInHeaderValue(t *testing.T) {
+	req := newSubRequest(t, map[string]string{
+		"x-ms-if-tags": "\"tenant\"='A'\r\nx-ms-delete-snapshots: include",
+	})
+	_, err := buildSubRequest(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid CR/LF")
+}
+
+func TestBuildSubRequest_LFInHeaderValue(t *testing.T) {
+	req := newSubRequest(t, map[string]string{
+		"x-ms-if-tags": "\"tenant\"='A'\nx-ms-delete-snapshots: include",
+	})
+	_, err := buildSubRequest(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid CR/LF")
+}
+
+func TestBuildSubRequest_CRInHeaderValue(t *testing.T) {
+	req := newSubRequest(t, map[string]string{
+		"x-ms-if-tags": "value\rwith-cr",
+	})
+	_, err := buildSubRequest(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid CR/LF")
+}
+
+func TestBuildSubRequest_CRLFInHeaderName(t *testing.T) {
+	req := newSubRequest(t, nil)
+	req.Raw().Header["bad\r\nheader"] = []string{"value"}
+	_, err := buildSubRequest(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "header name")
+}
+
+func TestBuildSubRequest_MultipleInjectedHeaders(t *testing.T) {
+	req := newSubRequest(t, map[string]string{
+		"x-ms-if-tags": "\"tenant\"='A'\r\nx-ms-delete-snapshots: include\r\nx-ms-extra: injected",
+	})
+	_, err := buildSubRequest(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid CR/LF")
+}
+
+func TestBuildSubRequest_SkipsXmsVersion(t *testing.T) {
+	req := newSubRequest(t, map[string]string{
+		"x-ms-version": "2023-11-03",
+		"x-ms-if-tags": "\"tenant\"='A'",
+	})
+	result, err := buildSubRequest(req)
+	require.NoError(t, err)
+	require.False(t, strings.Contains(string(result), "x-ms-version"))
+	require.False(t, strings.Contains(string(result), "X-Ms-Version"))
+}

--- a/sdk/storage/azblob/internal/exported/version.go
+++ b/sdk/storage/azblob/internal/exported/version.go
@@ -5,5 +5,5 @@ package exported
 
 const (
 	ModuleName    = "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
-	ModuleVersion = "v1.8.1-beta.2"
+	ModuleVersion = "v1.8.1"
 )


### PR DESCRIPTION
## Summary
- Patch release for `sdk/storage/azblob` including security fix for CRLF header injection in Blob Batch serialization (MSRC 140479)
- Consolidates all changes from v1.8.1-beta.1 and v1.8.1-beta.2 into stable v1.8.1
- Bumps `ModuleVersion` to `v1.8.1`

## Changes included
- **Security fix:** Reject CR/LF characters in batch subrequest header names and values before serialization
- Structured Message CRC64 content validation support
- Arrow response format for list blobs
- Access tier fields in blob download response
- WASM compilation fix
- Default concurrency now based on CPU core count

## After merge
Tag with `sdk/storage/azblob/v1.8.1`