### PR TITLE
Release azblob v1.8.1

### DIFF
--- a/sdk/storage/azblob/CHANGELOG.md
+++ b/sdk/storage/azblob/CHANGELOG.md
@@ -1,18 +1,6 @@
 # Release History
 
-## 1.8.1-beta.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-* Fixed WASM compilation by using heap-allocated buffers on JS targets.
-
-### Other Changes
-
-## 1.8.1-beta.1 (2026-07-24)
+## 1.8.1 (2026-09-04)
 
 ### Features Added
 * Added support for Structured Message CRC64 content validation on upload and download operations using `TransferValidationTypeComputeStructuredMessageCRC64`.
@@ -21,7 +9,9 @@
 * Blob put operations now return both `ContentMD5` and `ContentCRC64` in the response when a Content-MD5 header is provided (service version 2026-10-06+).
 
 ### Bugs Fixed
+* Fixed CRLF injection vulnerability in Blob Batch subrequest serialization. Header values containing CR or LF characters are now rejected before serialization, preventing header injection in batch requests.
 * Fixed `UploadFile`/`UploadBuffer` responses not including `ContentCRC64` when returned by the service.
+* Fixed WASM compilation by using heap-allocated buffers on JS targets.
 
 ### Other Changes
 * Updated code generator to `@autorest/go@4.0.0-preview.80`.

--- a/sdk/storage/azblob/internal/exported/version.go
+++ b/sdk/storage/azblob/internal/exported/version.go
@@ -5,5 +5,5 @@ package exported
 
 const (
 	ModuleName    = "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
-	ModuleVersion = "v1.8.1-beta.2"
+	ModuleVersion = "v1.8.1"
 )


### PR DESCRIPTION
## Summary
- Patch release for `sdk/storage/azblob` including security fix for CRLF header injection in Blob Batch serialization (MSRC 140479)
- Consolidates all changes from v1.8.1-beta.1 and v1.8.1-beta.2 into stable v1.8.1
- Bumps `ModuleVersion` to `v1.8.1`

## Changes included
- **Security fix:** Reject CR/LF characters in batch subrequest header names and values before serialization
- Structured Message CRC64 content validation support
- Arrow response format for list blobs
- Access tier fields in blob download response
- WASM compilation fix
- Default concurrency now based on CPU core count

## After merge
Tag with `sdk/storage/azblob/v1.8.1`