### PR TITLE
azcosmos: consume generated Windows/amd64 driver module

### DIFF
--- a/sdk/data/azcosmos/README.md
+++ b/sdk/data/azcosmos/README.md
@@ -16,16 +16,17 @@ Cosmos DB SDKs.
 
 ### Building with the driver
 
-The driver binding is selected automatically when cgo is enabled on glibc `linux/amd64` or
-`darwin/arm64`. No build tag or linker environment variable is required:
+The driver binding is selected automatically when cgo is enabled on glibc `linux/amd64`,
+`darwin/arm64`, or `windows/amd64`. No build tag or linker environment variable is required:
 
 ```sh
 go build ./...
 ```
 
-The native archives are committed as `.syso` files in target-specific internal packages, so Go
-preserves them in module zips and vendored builds and links the matching package automatically. No
-separate driver build or runtime sidecar is required; the resulting executable is self-contained.
+The Linux and macOS archives are committed as `.syso` files in target-specific internal packages.
+Windows links the archive and system libraries from
+`github.com/Azure/azure-cosmos-driver/windows/amd64`. The resulting executable is self-contained;
+no separate driver build or runtime sidecar is required.
 
 `CGO_ENABLED=0` and unsupported platforms select `driver_stub.go`. That diagnostic build keeps the
 API compilable, but operations report that the driver is unavailable.
@@ -34,19 +35,17 @@ Alpine and other musl-based Linux distributions are not supported yet. The bundl
 is built for glibc, and the build reports that limitation explicitly rather than linking Rust code
 compiled for a different libc ABI.
 
-**Those committed binaries are temporary and are meant to be deleted.** Checking a build artifact
-into the repository is not the plan of record: the distribution design puts each target's library
-in its own Go module in [azure-cosmos-driver](https://github.com/Azure/azure-cosmos-driver),
-selected by `GOOS`/`GOARCH`. That repository exists and already carries a darwin/arm64 module, but
-not yet one for `linux/amd64`, which is the platform CI runs on — so the copies here stand in until
-it does.
+**The committed Linux and macOS binaries are temporary and are meant to be deleted.** Checking a
+build artifact into this repository is not the plan of record: the distribution design puts each
+target's library in its own Go module in
+[azure-cosmos-driver](https://github.com/Azure/azure-cosmos-driver), selected by `GOOS`/`GOARCH`.
+The Windows module is integrated here, while the committed copies remain until equivalent tagged
+modules can replace them on every supported platform.
 
 The trigger to remove them, and the steps, are recorded in
 [`internal/native/lib/README.md`](internal/native/lib/README.md). Only `linux/amd64` and
-`darwin/arm64` are present, because those are the platforms actually built and tested; another
-platform needs its own build from
-[azure_data_cosmos_driver_native](https://github.com/Azure/azure-sdk-for-rust/tree/main/sdk/cosmos/azure_data_cosmos_driver_native)
-dropped into the matching directory, which is the cost these files impose.
+`darwin/arm64` are present as committed artifacts; `windows/amd64` is supplied by its external
+driver module.
 
 `azurecosmosdriver.h` is the header the driver generates, vendored here and pinned to the version
 in `driver.go`. That version is checked against the linked archive before any struct-sensitive ABI

--- a/sdk/data/azcosmos/azurecosmosdriver.h
+++ b/sdk/data/azcosmos/azurecosmosdriver.h
@@ -48,6 +48,11 @@
 #define COSMOS_VALUE_KIND_BOOL   3
 #define COSMOS_VALUE_KIND_U64    4
 
+// Discriminants for cosmos_operation_options_t.query_plan_mode.
+#define COSMOS_QUERY_PLAN_MODE_UNSET           0
+#define COSMOS_QUERY_PLAN_MODE_LOCAL_PREFERRED 1
+#define COSMOS_QUERY_PLAN_MODE_GATEWAY_ONLY    2
+
 /**
  * Per spec section 3.6.1, every completion has exactly one of these outcomes.
  *
@@ -1388,9 +1393,10 @@ typedef struct cosmos_operation_options_t {
    * When true, the driver transcodes a **text** request body to binary
    * before sending it (an already-binary body is passed through) and
    * advertises `CosmosBinary`, so the caller never encodes binary itself.
-   * An explicit `false` forces binary **off** for this operation regardless
-   * of any account/runtime default; `unset` inherits a lower layer (text by
-   * default).
+   * An explicit `false` (`1`) is the text opt-out: it forces binary **off**
+   * for this operation regardless of any account/runtime default. `unset`
+   * inherits a lower layer, which enables binary encoding by default, so an
+   * all-unset options struct negotiates binary.
    *
    * The response side is uniform across operation types: point reads,
    * writes that echo content, and queries all negotiate a binary response,
@@ -1407,8 +1413,11 @@ typedef struct cosmos_operation_options_t {
    * Tri-state bool (`0` unset / `1` false / `2` true).
    *
    * Only meaningful when [`binary_encoding_enabled`](Self::binary_encoding_enabled)
-   * is true: the wire stays binary in both directions and the driver hands
-   * back text. `unset` / `false` returns the binary response as-is.
+   * resolves to true: the wire stays binary in both directions and the
+   * driver hands back text. `unset` / `false` returns the binary response
+   * as-is. Setting this to `2` is honored even when
+   * [`binary_encoding_enabled`](Self::binary_encoding_enabled) is left
+   * unset, since binary is enabled by default.
    *
    * This applies to every operation type, queries included: the wire keeps
    * the bandwidth saving and the driver transcodes each response body — for
@@ -1417,10 +1426,17 @@ typedef struct cosmos_operation_options_t {
    * Note the returned text is re-serialized by the driver rather than being
    * the service's original bytes: values are preserved, but object keys are
    * emitted in sorted order and numbers use Rust's shortest round-trip
-   * rendering. Hosts needing byte-exact service output should leave binary
-   * encoding disabled.
+   * rendering. Hosts needing byte-exact service output must explicitly
+   * disable binary encoding by setting
+   * [`binary_encoding_enabled`](Self::binary_encoding_enabled) to `1`.
    */
   int8_t binary_encoding_request_text_response;
+  /**
+   * Query-plan mode encoded as a [`CosmosQueryPlanMode`] discriminant.
+   * `0` (`Unset`) inherits. Stored as a raw `i32` so invalid host values can
+   * be rejected before materializing the enum.
+   */
+  int32_t query_plan_mode;
 } cosmos_operation_options_t;
 
 /**
@@ -1435,7 +1451,6 @@ typedef struct cosmos_operation_options_t {
  * - `operation_options`: pointer to a flat
  *   [`cosmos_operation_options_t`](crate::op_request::CosmosOperationOptions),
  *   or NULL to inherit the driver defaults.
- *
  * The account reference stays a separate handle parameter on
  * [`cosmos_driver_options_build`] — it owns `Arc`-shared state and cannot be
  * flattened into bytes.

--- a/sdk/data/azcosmos/cgo_handle_native.go
+++ b/sdk/data/azcosmos/cgo_handle_native.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64))
+//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64) || (windows && amd64))
 
 package azcosmos
 

--- a/sdk/data/azcosmos/cgo_handle_native_test.go
+++ b/sdk/data/azcosmos/cgo_handle_native_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64))
+//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64) || (windows && amd64))
 
 package azcosmos
 

--- a/sdk/data/azcosmos/cgo_native.go
+++ b/sdk/data/azcosmos/cgo_native.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64))
+//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64) || (windows && amd64))
 
 package azcosmos
 
@@ -46,6 +46,7 @@ COSMOS_ASSERT_OFFSET(cosmos_operation_options_t, end_to_end_timeout_ms, 24);
 COSMOS_ASSERT_OFFSET(cosmos_operation_options_t, excluded_regions, 48);
 COSMOS_ASSERT_OFFSET(cosmos_operation_options_t, excluded_regions_len, 56);
 COSMOS_ASSERT_OFFSET(cosmos_operation_options_t, binary_encoding_request_text_response, 81);
+COSMOS_ASSERT_OFFSET(cosmos_operation_options_t, query_plan_mode, 84);
 
 _Static_assert(sizeof(cosmos_driver_options_config_t) == 24, "driver options ABI size changed");
 _Static_assert(_Alignof(cosmos_driver_options_config_t) == 8, "driver options ABI alignment changed");
@@ -92,6 +93,6 @@ import "C"
 // package: repeating them means every file has to be kept in step, and a file that drifts is a
 // link error rather than a compile error.
 //
-// Target-specific internal packages carry the .syso archives and system-linker flags. Keeping each
-// archive behind a conditionally imported package matters because Go treats ios as darwin and
-// android as linux for build tags and .syso filename selection.
+// Target-specific imports carry either a bundled archive or an external driver module, plus the
+// Go-owned callback shim. Keeping each behind a conditional import matters because Go treats ios as
+// darwin and android as linux for build tags and native-object selection.

--- a/sdk/data/azcosmos/completion_native.go
+++ b/sdk/data/azcosmos/completion_native.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64))
+//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64) || (windows && amd64))
 
 package azcosmos
 

--- a/sdk/data/azcosmos/completion_native_test.go
+++ b/sdk/data/azcosmos/completion_native_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64))
+//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64) || (windows && amd64))
 
 package azcosmos
 

--- a/sdk/data/azcosmos/convert_native.go
+++ b/sdk/data/azcosmos/convert_native.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64))
+//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64) || (windows && amd64))
 
 package azcosmos
 
@@ -185,10 +185,12 @@ var (
 
 // nativeOperationOptions is a converted option set, in Go types.
 type nativeOperationOptions struct {
-	readConsistencyStrategy int32
-	contentResponseOnWrite  int32
-	endToEndTimeoutMillis   int64
-	excludedRegions         []string
+	readConsistencyStrategy           int32
+	contentResponseOnWrite            int32
+	endToEndTimeoutMillis             int64
+	excludedRegions                   []string
+	binaryEncodingRequestTextResponse int8
+	queryPlanMode                     int32
 }
 
 // inspectNativeOperationOptions converts an option set and reads the result back.
@@ -196,9 +198,11 @@ func inspectNativeOperationOptions(o OperationOptions) (nativeOperationOptions, 
 	options, release := o.toNative()
 
 	out := nativeOperationOptions{
-		readConsistencyStrategy: int32(options.read_consistency_strategy),
-		contentResponseOnWrite:  int32(options.content_response_on_write),
-		endToEndTimeoutMillis:   int64(options.end_to_end_timeout_ms),
+		readConsistencyStrategy:           int32(options.read_consistency_strategy),
+		contentResponseOnWrite:            int32(options.content_response_on_write),
+		endToEndTimeoutMillis:             int64(options.end_to_end_timeout_ms),
+		binaryEncodingRequestTextResponse: int8(options.binary_encoding_request_text_response),
+		queryPlanMode:                     int32(options.query_plan_mode),
 	}
 	if options.excluded_regions != nil && options.excluded_regions_len > 0 {
 		regions := unsafe.Slice(options.excluded_regions, int(options.excluded_regions_len))
@@ -215,11 +219,15 @@ func inspectNativeOperationOptions(o OperationOptions) (nativeOperationOptions, 
 func defaultNativeOperationOptions() nativeOperationOptions {
 	defaults := C.cosmos_operation_options_default()
 	return nativeOperationOptions{
-		readConsistencyStrategy: int32(defaults.read_consistency_strategy),
-		contentResponseOnWrite:  int32(defaults.content_response_on_write),
-		endToEndTimeoutMillis:   int64(defaults.end_to_end_timeout_ms),
+		readConsistencyStrategy:           int32(defaults.read_consistency_strategy),
+		contentResponseOnWrite:            int32(defaults.content_response_on_write),
+		endToEndTimeoutMillis:             int64(defaults.end_to_end_timeout_ms),
+		binaryEncodingRequestTextResponse: int8(defaults.binary_encoding_request_text_response),
+		queryPlanMode:                     int32(defaults.query_plan_mode),
 	}
 }
+
+var nativeQueryPlanModeUnset = int32(C.COSMOS_QUERY_PLAN_MODE_UNSET)
 
 // nativeReadConsistencyStrategy reports the discriminant a strategy maps to, in Go types.
 func nativeReadConsistencyStrategy(s ReadConsistencyStrategy) (int32, bool) {
@@ -242,6 +250,9 @@ func (o ClientOptions) toNative() (*C.cosmos_driver_options_config_t, func(), er
 	operationOptions, releaseOperationOptions := OperationOptions{
 		EnableContentResponseOnWrite: &contentResponse,
 	}.toNative()
+	// The driver defaults to binary response bodies. The Go API exposes JSON bytes, so keep the
+	// binary wire format while asking the driver to transcode responses back to text.
+	operationOptions.binary_encoding_request_text_response = 2
 	config.operation_options = operationOptions
 
 	var allocations []unsafe.Pointer
@@ -299,9 +310,11 @@ func inspectNativeClientOptions(o ClientOptions) (nativeClientOptions, func(), e
 	}
 	if config.operation_options != nil {
 		out.operationOptions = nativeOperationOptions{
-			readConsistencyStrategy: int32(config.operation_options.read_consistency_strategy),
-			contentResponseOnWrite:  int32(config.operation_options.content_response_on_write),
-			endToEndTimeoutMillis:   int64(config.operation_options.end_to_end_timeout_ms),
+			readConsistencyStrategy:           int32(config.operation_options.read_consistency_strategy),
+			contentResponseOnWrite:            int32(config.operation_options.content_response_on_write),
+			endToEndTimeoutMillis:             int64(config.operation_options.end_to_end_timeout_ms),
+			binaryEncodingRequestTextResponse: int8(config.operation_options.binary_encoding_request_text_response),
+			queryPlanMode:                     int32(config.operation_options.query_plan_mode),
 		}
 	}
 	return out, release, nil

--- a/sdk/data/azcosmos/convert_native_test.go
+++ b/sdk/data/azcosmos/convert_native_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64))
+//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64) || (windows && amd64))
 
 package azcosmos
 
@@ -86,6 +86,8 @@ func TestOperationOptionsToNativeKeepsDefaults(t *testing.T) {
 	t.Cleanup(release)
 
 	require.Equal(t, defaultNativeOperationOptions(), options)
+	require.Equal(t, nativeQueryPlanModeUnset, options.queryPlanMode,
+		"query plan mode is not exposed yet, so it must remain unset")
 }
 
 // The content-response setting is tri-state at the ABI, so false has to be distinguishable from
@@ -179,6 +181,15 @@ func TestOperationRequestUsesTheDriversUnsetSentinels(t *testing.T) {
 // Client options reach the driver through a flat config, so the conversion is what decides whether
 // a setting has any effect at all.
 func TestClientOptionsConvertToTheDriversConfig(t *testing.T) {
+	t.Run("response bodies remain text JSON", func(t *testing.T) {
+		options, release, err := inspectNativeClientOptions(ClientOptions{})
+		require.NoError(t, err)
+		defer release()
+
+		require.Equal(t, int8(2), options.operationOptions.binaryEncodingRequestTextResponse)
+		require.Equal(t, nativeQueryPlanModeUnset, options.operationOptions.queryPlanMode)
+	})
+
 	t.Run("preferred regions are passed in order", func(t *testing.T) {
 		options, release, err := inspectNativeClientOptions(ClientOptions{
 			Routing: PreferredRegions(RegionWestUS, RegionEastUS),

--- a/sdk/data/azcosmos/driver_native.go
+++ b/sdk/data/azcosmos/driver_native.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64))
+//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64) || (windows && amd64))
 
 package azcosmos
 
@@ -23,7 +23,7 @@ import (
 )
 
 // This is the build of the package that binds to azure_data_cosmos_driver_native. It is selected
-// automatically when cgo is enabled on a target for which this module carries a native archive.
+// automatically when cgo is enabled on a target for which a native archive is linked.
 
 // driverAvailable reports whether this build can reach the Cosmos driver.
 const driverAvailable = true

--- a/sdk/data/azcosmos/driver_native_test.go
+++ b/sdk/data/azcosmos/driver_native_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64))
+//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64) || (windows && amd64))
 
 package azcosmos
 

--- a/sdk/data/azcosmos/driver_stub.go
+++ b/sdk/data/azcosmos/driver_stub.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//go:build !cgo || !((darwin && !ios && arm64) || (linux && !android && amd64))
+//go:build !cgo || !((darwin && !ios && arm64) || (linux && !android && amd64) || (windows && amd64))
 
 package azcosmos
 

--- a/sdk/data/azcosmos/emulator_test.go
+++ b/sdk/data/azcosmos/emulator_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64))
+//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64) || (windows && amd64))
 
 package azcosmos
 

--- a/sdk/data/azcosmos/go.mod
+++ b/sdk/data/azcosmos/go.mod
@@ -3,6 +3,7 @@ module github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos/v2
 go 1.25.0
 
 require (
+	github.com/Azure/azure-cosmos-driver/windows/amd64 v0.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/stretchr/testify v1.11.1

--- a/sdk/data/azcosmos/go.sum
+++ b/sdk/data/azcosmos/go.sum
@@ -1,3 +1,5 @@
+github.com/Azure/azure-cosmos-driver/windows/amd64 v0.1.0 h1:BBFXzlLetpTbF8NkmwqwBp5kepP5EB2UgV6sp12jQGs=
+github.com/Azure/azure-cosmos-driver/windows/amd64 v0.1.0/go.mod h1:DTNc/bxTjyBIf1GjPXjr8hrpEOCP+uljtMoEDrTBfIk=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0 h1:aokoqcHvaGjiM3VpjKDfMMnF/8epJ+Q1HLJ7CudztqE=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0/go.mod h1:/WYEx9pcM9Y+Dd/APJaNlSvVSvzl54rrMdZT5+Oi2LM=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0 h1:CU4+EJeJi3TKYWEcYuSdWsjzw0nVsK/H0MSQOiPcymU=

--- a/sdk/data/azcosmos/internal/native/lib/README.md
+++ b/sdk/data/azcosmos/internal/native/lib/README.md
@@ -17,15 +17,15 @@ first place.
 
 The distribution design puts each target's library in its own Go module in the
 [azure-cosmos-driver](https://github.com/Azure/azure-cosmos-driver) repository, selected by
-`GOOS`/`GOARCH` build constraints. That repository exists and already carries a `darwin/arm64`
-module, but not yet one for `linux/amd64`, which is the platform CI runs on.
+`GOOS`/`GOARCH` build constraints. Windows already consumes that target module; the copies here
+remain for Linux and macOS until equivalent module versions are available.
 
 ## When to delete this directory
 
 **As soon as `azure-cosmos-driver` carries a module for every platform this module builds on.**
 At that point:
 
-1. Add the driver modules to `go.mod`.
+1. Add the remaining driver modules to `go.mod`.
 2. Update `link_darwin_arm64.go` and `link_linux_amd64.go` to import the corresponding external
    target packages alongside the existing internal packages. Each external package must carry its
    archive and the system linker flags currently in `internal/native/{darwinarm64,linuxamd64}/link.go`.
@@ -103,11 +103,11 @@ and build recipe as well as the checksum. Independent artifact attestation is tr
 
 ## While they are still here
 
-Only `linux/amd64` and `darwin/arm64` are present, because those are the platforms actually built
-and tested. Another platform needs its own target-constrained `internal/native/<goos><goarch>`
-package containing the `.syso` archive and its `link.go` settings, plus a matching conditionally
-built root package import. An unsuffixed `.syso` must not be placed in the module root, where every
-target could select and link it.
+Only `linux/amd64` and `darwin/arm64` are present here. Windows uses the external target module and
+retains only the Go-owned callback shim under `internal/native/windowsamd64`. Any further platform
+must likewise keep its archive and linker settings behind a target-constrained package import. An
+unsuffixed `.syso` must not be placed in the module root, where every target could select and link
+it.
 
 The `.syso` suffix is required rather than merely convenient. Go preserves platform-specific
 `.syso` files in module zips and `go mod vendor`, then links the matching file automatically.

--- a/sdk/data/azcosmos/internal/native/windowsamd64/link.go
+++ b/sdk/data/azcosmos/internal/native/windowsamd64/link.go
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build cgo && windows && amd64
+
+// Package windowsamd64 compiles the Go token-provider callback shim for Windows on amd64.
+package windowsamd64
+
+/*
+#include "../../../azurecosmosdriver.h"
+*/
+import "C"

--- a/sdk/data/azcosmos/internal/native/windowsamd64/token_provider.c
+++ b/sdk/data/azcosmos/internal/native/windowsamd64/token_provider.c
@@ -1,0 +1,15 @@
+#include "../../../azurecosmosdriver.h"
+
+extern int32_t goCosmosTokenProviderGet(
+    intptr_t user_data,
+    const cosmos_token_request_t *request);
+extern void goCosmosTokenProviderFree(intptr_t user_data);
+
+cosmos_token_provider_t cosmos_go_token_provider(void)
+{
+    cosmos_token_provider_t provider = {
+        .get_token = goCosmosTokenProviderGet,
+        .user_data_free = goCosmosTokenProviderFree,
+    };
+    return provider;
+}

--- a/sdk/data/azcosmos/link_windows_amd64.go
+++ b/sdk/data/azcosmos/link_windows_amd64.go
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build cgo && windows && amd64
+
+package azcosmos
+
+import (
+	_ "github.com/Azure/azure-cosmos-driver/windows/amd64"
+	_ "github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos/v2/internal/native/windowsamd64"
+)

--- a/sdk/data/azcosmos/link_windows_amd64_test.go
+++ b/sdk/data/azcosmos/link_windows_amd64_test.go
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build cgo && windows && amd64
+
+package azcosmos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWindowsAMD64SelectsNativeDriver(t *testing.T) {
+	require.True(t, driverAvailable)
+	require.NoError(t, verifyDriverVersion())
+}

--- a/sdk/data/azcosmos/operation_native.go
+++ b/sdk/data/azcosmos/operation_native.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64))
+//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64) || (windows && amd64))
 
 package azcosmos
 

--- a/sdk/data/azcosmos/operation_native_test.go
+++ b/sdk/data/azcosmos/operation_native_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64))
+//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64) || (windows && amd64))
 
 package azcosmos
 

--- a/sdk/data/azcosmos/reactor_native.go
+++ b/sdk/data/azcosmos/reactor_native.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64))
+//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64) || (windows && amd64))
 
 package azcosmos
 

--- a/sdk/data/azcosmos/reactor_native_test.go
+++ b/sdk/data/azcosmos/reactor_native_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64))
+//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64) || (windows && amd64))
 
 package azcosmos
 

--- a/sdk/data/azcosmos/token_credential_native.go
+++ b/sdk/data/azcosmos/token_credential_native.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64))
+//go:build cgo && ((darwin && !ios && arm64) || (linux && !android && amd64) || (windows && amd64))
 
 package azcosmos
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Azure SDK for Go.

Please verify the following before submitting your PR, thank you!
-->

- [x] The purpose of this PR is explained in this or a referenced issue.
- [ ] The PR does not update generated files.
   - This intentionally syncs the vendored `azurecosmosdriver.h` byte-for-byte with the pipeline-generated driver module.
- [x] Tests are included and/or updated for code changes.
- [ ] Updates to module CHANGELOG.md are included.
   - This is a blocked draft integration follow-up; release notes should wait for the driver module tag.
- [x] MIT license headers are included in each file.

[Azure/autorest.go]: https://github.com/Azure/autorest.go

## Summary

Draft follow-up stacked on https://github.com/Azure/azure-sdk-for-go/pull/27482. It adds Windows/amd64 consumption of the generated external driver module for https://github.com/Azure/azure-sdk-for-go/issues/27307.

- Extends the native build constraints and excludes the diagnostic stub for `cgo && windows && amd64`.
- Blank-imports `github.com/Azure/azure-cosmos-driver/windows/amd64@v0.1.0` for the archive and Windows linker settings.
- Keeps the Go-specific token-provider callback shim in this SDK rather than the generated driver module.
- Syncs `azurecosmosdriver.h` to driver PR https://github.com/Azure/azure-cosmos-driver/pull/14 and pins the new `query_plan_mode` ABI offset while preserving its unset/default value.
- Requests driver-side text transcoding at the client baseline because the Go API exposes JSON bytes while Rust driver 0.8.0 now defaults wire responses to Cosmos binary JSON. Per-operation options continue to inherit that baseline.

## Versions and source

- Native module: `github.com/Azure/azure-cosmos-driver/windows/amd64@v0.1.0`
- Native interface: `0.1.0`
- Rust driver: `0.8.0`
- Generated module source head: `464c63b66e12a4d6fa2ec107c489e67dff4d8cdc`
- Rust source: `d8dc2a4ce3adc8fcab8815f1032fda978dd15adb`
- Canonical header SHA-256: `3814d16b18639a42b2daba6ef001046d4b2b621e20f22deb94d045ada1320aa6`

## Local Windows proof

Using Go 1.25.9, MinGW GCC 15.2.0, `CGO_ENABLED=1`, `GOWORK=off`, an isolated module/build cache, and the retained file proxy:

- `go build -mod=readonly ./...` passed.
- `go test -mod=readonly -count=1 ./...` passed.
- `go test -mod=readonly -race -count=1 ./...` passed.
- A real master-key Create/Read completed against the installed Windows Azure Cosmos DB Emulator with Cargo and Rust absent from the consumer `PATH`: Create charged 6.29 RU; Read charged 1 RU, returned the same ETag, and returned JSON value `42` through the external module.

## Blocked

This draft is blocked on https://github.com/Azure/azure-cosmos-driver/pull/14 merging and publishing the path-prefixed tag `windows/amd64/v0.1.0`. There is no `replace` directive or `go.work` workaround. Current public CI is expected to fail module resolution until that tag exists; this does not claim acceptance through a published Go proxy.

The retained local file proxy was produced by the rehearsal work in https://github.com/Azure/azure-cosmos-driver/pull/10 and is not committed here.